### PR TITLE
Remove serde version lock on 1.0.118 and serde_json lock on 1.0.61

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "air-parser"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -1781,9 +1781,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.61"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
+checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
 dependencies = [
  "indexmap",
  "itoa",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "air"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "air-interpreter-data",
  "air-interpreter-interface",
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "air-interpreter"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "air",
  "log",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "air-interpreter-data"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "once_cell",
  "semver 1.0.4",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "air-interpreter-interface"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "fluence-it-types",
  "marine-rs-sdk",
@@ -97,7 +97,7 @@ dependencies = [
 
 [[package]]
 name = "air-test-utils"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "air",
  "avm-server",
@@ -116,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28ae2b3dec75a406790005a200b1bd89785afc02517a00ca99ecfe093ee9e6cf"
+checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
 
 [[package]]
 name = "array_tool"
@@ -166,13 +166,13 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "avm-server"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "air-interpreter-interface",
  "fluence-faas",
  "log",
  "maplit",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "serde",
  "serde_json",
  "thiserror",
@@ -275,9 +275,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
+checksum = "d26a6ce4b6a484fa3edb70f7efa6fc430fd2b87285fe8b84304fd0936faa0dc0"
 
 [[package]]
 name = "cfg-if"
@@ -535,9 +535,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e98e2ad1a782e33928b96fc3948e7c355e5af34ba4de7670fe8bac2a3b2006d"
+checksum = "ccc0a48a9b826acdf4028595adc9db92caea352f7af011a3034acd172a52a0aa"
 dependencies = [
  "quote",
  "syn",
@@ -702,13 +702,14 @@ dependencies = [
 
 [[package]]
 name = "fluence-it-types"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5006d09553345421af5dd2334cc945fc34dc2a73d7c1ed842a39a3803699619d"
+checksum = "047f670b4807cab8872550a607b1515daff08b3e3bb7576ce8f45971fd811a4e"
 dependencies = [
  "it-to-bytes",
  "nom",
  "serde",
+ "variant_count",
  "wast",
 ]
 
@@ -1028,9 +1029,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.100"
+version = "0.2.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1fa8cddc8fbbee11227ef194b5317ed014b8acbf15139bd716a18ad3fe99ec5"
+checksum = "a2a5ac8f984bfcf3a823267e5fde638acc3325f6496633a5da6bb6eb2171e103"
 
 [[package]]
 name = "lock_api"
@@ -1043,9 +1044,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb"
+checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
 dependencies = [
  "scopeguard",
 ]
@@ -1067,9 +1068,9 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "marine-it-generator"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e62f29b16bbdb0763a04f8561c954624ee9cd9f558af4e67b95eb00880da11ec"
+checksum = "e7b40920a86fb49456f0e94862d56a8e0bfc22489e518d894628da0f3ade03d8"
 dependencies = [
  "cargo_toml",
  "it-lilo",
@@ -1085,9 +1086,9 @@ dependencies = [
 
 [[package]]
 name = "marine-it-interfaces"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f18c137e51fd52ab7a3652233fc4eaa68e25a6a53d609bf9dd0f2e3bf67adee1"
+checksum = "42e229143e72ba20e754de4766ff0d02e0cf176001f7471593f82b16c72dc26d"
 dependencies = [
  "multimap",
  "wasmer-interface-types-fl",
@@ -1095,9 +1096,9 @@ dependencies = [
 
 [[package]]
 name = "marine-it-parser"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a6606e472587b2e7b759b16d037a4ea951facc2a6650f668f22403978c2442"
+checksum = "4154fc98fcfeba65a45d774cff6eeb8bddc8aa66e897f46a74dc95e8823771ea"
 dependencies = [
  "anyhow",
  "itertools 0.10.1",
@@ -1153,9 +1154,9 @@ dependencies = [
 
 [[package]]
 name = "marine-module-interface"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a5936273bebb523ed169863282dbc19fc66bb983c7031c5b8b0556584f2401"
+checksum = "035fb5d160a50cbcbe244a343081550f689ceba945d95281bbe207d98bf25586"
 dependencies = [
  "anyhow",
  "itertools 0.10.1",
@@ -1380,13 +1381,13 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
- "lock_api 0.4.4",
- "parking_lot_core 0.8.3",
+ "lock_api 0.4.5",
+ "parking_lot_core 0.8.5",
 ]
 
 [[package]]
@@ -1405,9 +1406,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
+checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
 dependencies = [
  "cfg-if 1.0.0",
  "instant",
@@ -1487,7 +1488,7 @@ dependencies = [
 
 [[package]]
 name = "polyplets"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "marine-rs-sdk",
  "serde",
@@ -1519,9 +1520,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
+checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
 dependencies = [
  "unicode-xid",
 ]
@@ -1792,9 +1793,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "729a25c17d72b06c68cb47955d44fda88ad2d3e7d77e025663fdd69b93dd71a1"
+checksum = "533494a8f9b724d33625ab53c6c4800f7cc445895924a8ef649222dcb76e938b"
 
 [[package]]
 name = "smallvec"
@@ -1846,9 +1847,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.75"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f58f7e8eaa0009c5fec437aabf511bd9933e4b2d7407bd05273c01a8906ea7"
+checksum = "c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1892,18 +1893,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.26"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
+checksum = "602eca064b2d83369e2b2f34b09c70b605402801927c65c11071ac911d299b88"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.26"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
+checksum = "bad553cc2c78e8de258400763a647e80e6d1b31ee237275d756f6836d204494c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1951,9 +1952,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
+checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
 
 [[package]]
 name = "typetag"
@@ -2010,6 +2011,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
  "getrandom 0.2.3",
+]
+
+[[package]]
+name = "variant_count"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae2faf80ac463422992abf4de234731279c058aaf33171ca70277c98406b124"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2181,9 +2192,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-interface-types-fl"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df960871d756f87237e7630daa0e8453dd48f9e44e0f214e795362a6daa04967"
+checksum = "14ba3b5a07989987994b96bf5cc7ac2947005f9ff6123d71b7064232f07d28fa"
 dependencies = [
  "fluence-it-types",
  "it-lilo",

--- a/air-interpreter/Cargo.toml
+++ b/air-interpreter/Cargo.toml
@@ -23,8 +23,8 @@ marine-rs-sdk = { version = "0.6.11", features = ["logger"] }
 wasm-bindgen = "=0.2.65"
 
 log = "0.4.11"
-serde = { version = "=1.0.118", features = [ "derive", "rc" ] }
-serde_json = "=1.0.61"
+serde = { version = "1.0.118", features = [ "derive", "rc" ] }
+serde_json = "1.0.61"
 
 [features]
 marine = ["air/marine"]

--- a/air-interpreter/Cargo.toml
+++ b/air-interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "air-interpreter"
-version = "0.14.0"
+version = "0.14.1"
 authors = ["Fluence Labs"]
 edition = "2018"
 publish = false

--- a/air/Cargo.toml
+++ b/air/Cargo.toml
@@ -17,8 +17,8 @@ air-interpreter-data = { path = "../crates/interpreter-data" }
 air-interpreter-interface = { path = "../crates/interpreter-interface" }
 marine-rs-sdk = { version = "0.6.11", features = ["logger"] }
 
-serde = { version = "=1.0.118", features = [ "derive", "rc" ] }
-serde_json = "=1.0.61"
+serde = { version = "1.0.118", features = [ "derive", "rc" ] }
+serde_json = "1.0.61"
 
 jsonpath_lib-fl = "=0.3.7"
 

--- a/air/Cargo.toml
+++ b/air/Cargo.toml
@@ -41,7 +41,7 @@ once_cell = "1.4.1"
 env_logger = "0.7.1"
 maplit = "1.0.2"
 pretty_assertions = "0.6.1"
-serde_json = "=1.0.61"
+serde_json = "1.0.61"
 
 [[bench]]
 name = "call_benchmark"

--- a/air/Cargo.toml
+++ b/air/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "air"
-version = "0.14.0"
+version = "0.14.1"
 authors = ["Fluence Labs"]
 edition = "2018"
 publish = false

--- a/avm/server/Cargo.toml
+++ b/avm/server/Cargo.toml
@@ -16,8 +16,8 @@ air-interpreter-interface = { version = "0.6.0", path = "../../crates/interprete
 
 thiserror = "1.0.24"
 maplit = "1.0.2"
-serde_json = "=1.0.61"
-serde = "=1.0.118"
+serde_json = "1.0.61"
+serde = "1.0.118"
 log = "0.4.14"
 parking_lot = "0.11.1"
 

--- a/avm/server/Cargo.toml
+++ b/avm/server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "avm-server"
 description = "Fluence AIR VM"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Fluence Labs"]
 edition = "2018"
 license = "Apache-2.0"

--- a/crates/air-parser/Cargo.toml
+++ b/crates/air-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "air-parser"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Fluence Labs"]
 edition = "2018"
 license = "Apache-2.0"

--- a/crates/air-parser/Cargo.toml
+++ b/crates/air-parser/Cargo.toml
@@ -17,8 +17,8 @@ codespan-reporting = "0.11.1"
 multimap = "0.8.3"
 
 # TODO: hide serde behind a feature
-serde = { version = "=1.0.118", features = ["rc", "derive"] }
-serde_json = "=1.0.61"
+serde = { version = "1.0.118", features = ["rc", "derive"] }
+serde_json = "1.0.61"
 
 itertools = "0.10.0"
 

--- a/crates/interpreter-data/Cargo.toml
+++ b/crates/interpreter-data/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "air-interpreter-data"
 description = "Data format of the AIR interpreter"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Fluence Labs"]
 edition = "2018"
 license = "Apache-2.0"

--- a/crates/interpreter-data/Cargo.toml
+++ b/crates/interpreter-data/Cargo.toml
@@ -14,7 +14,7 @@ name = "air_interpreter_data"
 path = "src/lib.rs"
 
 [dependencies]
-serde = {version = "=1.0.118", features = ["derive", "rc"]}
-serde_json = "=1.0.61"
+serde = {version = "1.0.118", features = ["derive", "rc"]}
+serde_json = "1.0.61"
 semver = { version = "1.0.3", features = ["serde"] }
 once_cell = "1.8.0"

--- a/crates/interpreter-interface/Cargo.toml
+++ b/crates/interpreter-interface/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "air-interpreter-interface"
 description = "Interface of the AIR interpreter"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Fluence Labs"]
 edition = "2018"
 license = "Apache-2.0"

--- a/crates/interpreter-interface/Cargo.toml
+++ b/crates/interpreter-interface/Cargo.toml
@@ -18,4 +18,4 @@ path = "src/lib.rs"
 marine-rs-sdk = "0.6.11"
 fluence-it-types = "0.3.0"
 
-serde = "=1.0.118"
+serde = "1.0.118"

--- a/crates/polyplets/Cargo.toml
+++ b/crates/polyplets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polyplets"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Fluence Labs"]
 edition = "2018"
 license = "Apache-2.0"

--- a/crates/polyplets/Cargo.toml
+++ b/crates/polyplets/Cargo.toml
@@ -16,5 +16,5 @@ path = "src/lib.rs"
 
 [dependencies]
 marine-rs-sdk = { version = "0.6.11", features = ["logger"] }
-serde = { version = "=1.0.118", features = ["rc", "derive"] }
+serde = { version = "1.0.118", features = ["rc", "derive"] }
 

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -15,4 +15,4 @@ marine-rs-sdk = "0.6.11"
 avm-server = { path = "../../avm/server", features = ["raw-avm-api"] }
 air = { path = "../../air" }
 
-serde_json = "=1.0.61"
+serde_json = "1.0.61"

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "air-test-utils"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Fluence Labs"]
 edition = "2018"
 license = "Apache-2.0"


### PR DESCRIPTION
`serde` version was strictly locked at `1.0.118` due to a breaking change in `1.0.119`. Now marine compiles with `serde 1.0.130` and it is possible to remove the strict requirement. This will avoid conflicts with crates that require `serde` newer than `1.0.118`. Same for `serde_json`.