### PR TITLE
Delete double description field from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,6 @@ exclude = [
 opt-level = 3
 # since the interpreter in actively development stage, these settings are true at least for a while
 debug = true
-debug-assertions = true
 overflow-checks = true
+debug-assertions = false
 panic = "unwind"

--- a/air/Cargo.toml
+++ b/air/Cargo.toml
@@ -1,10 +1,9 @@
 [package]
 name = "air"
 version = "0.15.0"
-description = "Implementation of the AIR interpreter"
+description = "Interpreter of AIR scripts intended to coordinate request flow in the Fluence network"
 authors = ["Fluence Labs"]
 edition = "2018"
-description = "Interpreter of AIR scripts intended to coordinate request flow in the Fluence network"
 repository = "https://github.com/fluencelabs/aquavm"
 publish = false
 keywords = ["fluence", "air", "webassembly", "programming-language"]


### PR DESCRIPTION
In #144 the second descrption for the `air` crate was accidentally added.