### PR TITLE
Change preparation error mapping

### DIFF
--- a/air/src/execution_step/errors.rs
+++ b/air/src/execution_step/errors.rs
@@ -127,11 +127,14 @@ macro_rules! trace_to_exec_err {
 
 impl ExecutionError {
     pub(crate) fn to_error_code(&self) -> u32 {
+        const EXECUTION_ERRORS_START_ID: u32 = 1000;
+
         let mut errors = ExecutionErrorDiscriminants::iter();
         let actual_error_type = ExecutionErrorDiscriminants::from(self);
 
         // unwrap is safe here because errors are guaranteed to contain all errors variants
-        errors.position(|et| et == actual_error_type).unwrap() as _
+        let enum_variant_position = errors.position(|et| et == actual_error_type).unwrap() as u32;
+        EXECUTION_ERRORS_START_ID + enum_variant_position
     }
 }
 

--- a/air/src/preparation_step/errors.rs
+++ b/air/src/preparation_step/errors.rs
@@ -42,10 +42,13 @@ pub enum PreparationError {
 
 impl PreparationError {
     pub(crate) fn to_error_code(&self) -> u32 {
+        const PREPARATION_ERRORS_START_ID: u32 = 1;
+
         let mut errors = PreparationErrorDiscriminants::iter();
         let actual_error_type = PreparationErrorDiscriminants::from(self);
 
         // unwrap is safe here because errors are guaranteed to contain all errors variants
-        errors.position(|et| et == actual_error_type).unwrap() as _
+        let enum_variant_position = errors.position(|et| et == actual_error_type).unwrap() as u32;
+        PREPARATION_ERRORS_START_ID + enum_variant_position
     }
 }

--- a/air/src/runner/outcome.rs
+++ b/air/src/runner/outcome.rs
@@ -31,9 +31,6 @@ use std::collections::HashMap;
 use std::hash::Hash;
 use std::rc::Rc;
 
-const PREPARATION_ERRORS_START_ID: i32 = 1;
-const EXECUTION_ERRORS_START_ID: i32 = 1000;
-
 /// Create InterpreterOutcome from supplied execution context and trace handler,
 /// set ret_code to INTERPRETER_SUCCESS.
 pub(crate) fn from_success_result(exec_ctx: ExecutionCtx<'_>, trace_handler: TraceHandler) -> InterpreterOutcome {
@@ -60,7 +57,6 @@ pub(crate) fn from_success_result(exec_ctx: ExecutionCtx<'_>, trace_handler: Tra
 /// set ret_code based on the error.
 pub(crate) fn from_preparation_error(data: impl Into<Vec<u8>>, err: PreparationError) -> InterpreterOutcome {
     let ret_code = err.to_error_code() as i32;
-    let ret_code = PREPARATION_ERRORS_START_ID + ret_code;
     let data = data.into();
     let call_requests = serde_json::to_vec(&CallRequests::new()).expect("default serializer shouldn't fail");
 
@@ -77,7 +73,6 @@ pub(crate) fn from_preparation_error(data: impl Into<Vec<u8>>, err: PreparationE
 /// set ret_code based on the error.
 pub(crate) fn from_trace_error(data: impl Into<Vec<u8>>, err: Rc<ExecutionError>) -> InterpreterOutcome {
     let ret_code = err.to_error_code() as i32;
-    let ret_code = EXECUTION_ERRORS_START_ID + ret_code;
     let data = data.into();
     let call_requests = serde_json::to_vec(&CallRequests::new()).expect("default serializer shouldn't fail");
 
@@ -98,7 +93,6 @@ pub(crate) fn from_execution_error(
     err: Rc<ExecutionError>,
 ) -> InterpreterOutcome {
     let ret_code = err.to_error_code() as i32;
-    let ret_code = EXECUTION_ERRORS_START_ID + ret_code;
 
     let streams = extract_stream_generations(exec_ctx.streams);
     let data = InterpreterData::from_execution_result(

--- a/air/src/runner/outcome.rs
+++ b/air/src/runner/outcome.rs
@@ -31,6 +31,7 @@ use std::collections::HashMap;
 use std::hash::Hash;
 use std::rc::Rc;
 
+const PREPARATION_ERRORS_START_ID: i32 = 1;
 const EXECUTION_ERRORS_START_ID: i32 = 1000;
 
 /// Create InterpreterOutcome from supplied execution context and trace handler,
@@ -59,6 +60,7 @@ pub(crate) fn from_success_result(exec_ctx: ExecutionCtx<'_>, trace_handler: Tra
 /// set ret_code based on the error.
 pub(crate) fn from_preparation_error(data: impl Into<Vec<u8>>, err: PreparationError) -> InterpreterOutcome {
     let ret_code = err.to_error_code() as i32;
+    let ret_code = PREPARATION_ERRORS_START_ID + ret_code;
     let data = data.into();
     let call_requests = serde_json::to_vec(&CallRequests::new()).expect("default serializer shouldn't fail");
 

--- a/air/tests/test_module/integration/air_basic.rs
+++ b/air/tests/test_module/integration/air_basic.rs
@@ -148,3 +148,14 @@ fn create_service() {
     assert_eq!(actual_trace, expected_trace);
     assert_eq!(result.next_peer_pks, vec![String::from("remote_peer_id")]);
 }
+
+#[test]
+fn invalid_air() {
+    let vm_peer_id = "some_peer_id";
+    let mut vm = create_avm(unit_call_service(), vm_peer_id);
+
+    let script = r#"(seq )"#;
+
+    let result = call_vm!(vm, "", script, "", "");
+    assert_eq!(result.ret_code, 1);
+}


### PR DESCRIPTION
The interpreter returns 0 if supplied air is invalid due to the automatic error to int mapping by `strum`. This PR changes this scheme and force the interpreter to return not 0 in case of any error.