### PR TITLE
Refactor join behaviour and par subtree completeness

### DIFF
--- a/air/src/execution_step/air/call.rs
+++ b/air/src/execution_step/air/call.rs
@@ -28,7 +28,7 @@ use super::LastErrorDescriptor;
 use super::TraceHandler;
 use crate::execution_step::Joinable;
 use crate::execution_step::RSecurityTetraplet;
-use crate::joinable_call;
+use crate::joinable;
 use crate::log_instruction;
 
 use air_parser::ast::Call;
@@ -40,13 +40,13 @@ impl<'i> super::ExecutableInstruction<'i> for Call<'i> {
         log_instruction!(call, exec_ctx, trace_ctx);
         exec_ctx.tracker.meet_call();
 
-        let resolved_call = joinable_call!(ResolvedCall::new(self, exec_ctx), exec_ctx).map_err(|e| {
+        let resolved_call = joinable!(ResolvedCall::new(self, exec_ctx), exec_ctx).map_err(|e| {
             set_last_error(self, exec_ctx, e.clone(), None);
             e
         })?;
 
         let tetraplet = resolved_call.as_tetraplet();
-        joinable_call!(resolved_call.execute(exec_ctx, trace_ctx), exec_ctx).map_err(|e| {
+        joinable!(resolved_call.execute(exec_ctx, trace_ctx), exec_ctx).map_err(|e| {
             set_last_error(self, exec_ctx, e.clone(), Some(tetraplet));
             e
         })

--- a/air/src/execution_step/air/fold_scalar.rs
+++ b/air/src/execution_step/air/fold_scalar.rs
@@ -19,6 +19,8 @@ use super::ExecutableInstruction;
 use super::ExecutionCtx;
 use super::ExecutionResult;
 use super::TraceHandler;
+use crate::execution_step::Joinable;
+use crate::joinable;
 use crate::log_instruction;
 
 use air_parser::ast::FoldScalar;
@@ -31,7 +33,8 @@ impl<'i> ExecutableInstruction<'i> for FoldScalar<'i> {
 
         exec_ctx.scalars.meet_fold_start();
 
-        let fold_result = match construct_scalar_iterable_value(&self.iterable, exec_ctx)? {
+        let scalar_iterable = joinable!(construct_scalar_iterable_value(&self.iterable, exec_ctx), exec_ctx)?;
+        let fold_result = match scalar_iterable {
             FoldIterableScalar::Empty => Ok(()),
             FoldIterableScalar::Scalar(iterable) => fold(
                 iterable,

--- a/air/src/execution_step/air/fold_stream.rs
+++ b/air/src/execution_step/air/fold_stream.rs
@@ -20,6 +20,8 @@ use super::ExecutableInstruction;
 use super::ExecutionCtx;
 use super::ExecutionResult;
 use super::TraceHandler;
+use crate::execution_step::Joinable;
+use crate::joinable;
 use crate::log_instruction;
 use crate::trace_to_exec_err;
 
@@ -29,7 +31,8 @@ impl<'i> ExecutableInstruction<'i> for FoldStream<'i> {
     fn execute(&self, exec_ctx: &mut ExecutionCtx<'i>, trace_ctx: &mut TraceHandler) -> ExecutionResult<()> {
         log_instruction!(fold, exec_ctx, trace_ctx);
 
-        let iterables = match construct_stream_iterable_value(&self.iterable, exec_ctx)? {
+        let stream_iterable = joinable!(construct_stream_iterable_value(&self.iterable, exec_ctx), exec_ctx)?;
+        let iterables = match stream_iterable {
             FoldIterableStream::Empty => return Ok(()),
             FoldIterableStream::Stream(iterables) => iterables,
         };

--- a/air/src/execution_step/air/mod.rs
+++ b/air/src/execution_step/air/mod.rs
@@ -181,24 +181,11 @@ macro_rules! log_instruction {
 
 /// This macro converts joinable errors to Ok and sets subtree complete to false.
 #[macro_export]
-macro_rules! joinable_call {
-    ($cmd:expr, $exec_ctx:expr) => {
-        match $cmd {
-            Err(e) if e.is_joinable() => {
-                $exec_ctx.subtree_complete = false;
-                return Ok(());
-            }
-            v => v,
-        }
-    };
-}
-
-/// This macro converts joinable errors to Ok.
-#[macro_export]
 macro_rules! joinable {
     ($cmd:expr, $exec_ctx:expr) => {
         match $cmd {
             Err(e) if e.is_joinable() => {
+                $exec_ctx.subtree_complete = false;
                 return Ok(());
             }
             v => v,

--- a/air/src/execution_step/air/par.rs
+++ b/air/src/execution_step/air/par.rs
@@ -68,9 +68,11 @@ fn execute_subtree<'i>(
             SubtreeResult::Succeeded
         }
         Err(e) if !e.is_catchable() => {
+            exec_ctx.subtree_complete = false;
             return Err(e);
         }
         Err(e) => {
+            exec_ctx.subtree_complete = false;
             trace_to_exec_err!(trace_ctx.meet_par_subtree_end(subtree_type))?;
             SubtreeResult::Failed(e)
         }

--- a/air/src/execution_step/air/par.rs
+++ b/air/src/execution_step/air/par.rs
@@ -67,14 +67,14 @@ fn execute_subtree<'i>(
             trace_to_exec_err!(trace_ctx.meet_par_subtree_end(subtree_type))?;
             SubtreeResult::Succeeded
         }
-        Err(e) if !e.is_catchable() => {
-            exec_ctx.subtree_complete = false;
-            return Err(e);
-        }
-        Err(e) => {
+        Err(e) if e.is_catchable() => {
             exec_ctx.subtree_complete = false;
             trace_to_exec_err!(trace_ctx.meet_par_subtree_end(subtree_type))?;
             SubtreeResult::Failed(e)
+        }
+        Err(e) => {
+            exec_ctx.subtree_complete = false;
+            return Err(e);
         }
     };
 

--- a/air/tests/test_module/integration/issue_180.rs
+++ b/air/tests/test_module/integration/issue_180.rs
@@ -31,8 +31,8 @@ fn issue_180() {
             (call "{peer_2_id}" ("" "") [] join_var)
             (seq
                 (par
-                    (call "{peer_1_id}" ("" "") [join_var]) ;; will trigger VariableNotFound exception
-                    (fold join_var iterator ;; will trigger VariableNotFound exception
+                    (call "{peer_1_id}" ("" "") [join_var]) ;; sets subtree_complete to false
+                    (fold join_var iterator ;; (on < 0.17.3) triggers ValueNotFound exception and doesn't touch subtree_complete flag
                         (null)
                     )
                 )

--- a/air/tests/test_module/integration/issue_180.rs
+++ b/air/tests/test_module/integration/issue_180.rs
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 Fluence Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use air_test_utils::prelude::*;
+
+use fstrings::f;
+use fstrings::format_args_f;
+
+#[test]
+// test for github.com/fluencelabs/aquavm/issues/180
+fn issue_180() {
+    let peer_1_id = "peer_1_id";
+    let peer_2_id = "peer_2_id";
+    let mut peer_1 = create_avm(unit_call_service(), peer_1_id);
+
+    let script = f!(r#"
+        (par
+            (call "{peer_2_id}" ("" "") [] join_var)
+            (seq
+                (par
+                    (call "{peer_1_id}" ("" "") [join_var]) ;; will trigger VariableNotFound exception
+                    (fold join_var iterator ;; will trigger VariableNotFound exception
+                        (null)
+                    )
+                )
+                (call "{peer_1_id}" ("" "") []) ;; this should be called only when join_var is set
+            )
+        )
+        "#);
+
+    let peer_1_result = checked_call_vm!(peer_1, "", &script, "", "");
+    let trace = trace_from_result(&peer_1_result);
+    assert_eq!(trace.len(), 3);
+}

--- a/air/tests/test_module/integration/mod.rs
+++ b/air/tests/test_module/integration/mod.rs
@@ -22,6 +22,7 @@ mod data_merge;
 mod empty_array;
 mod flattening;
 mod issue_137;
+mod issue_180;
 mod join;
 mod join_behaviour;
 mod json_path;


### PR DESCRIPTION
Before this PR:
 - `call` sets `subtree_complete` to false in join behaviour
 - `match`/`mismatch`/`fold` don't touch `subtree_complete` in join behaviour
 - `par`'s subtree could be completed (`subtree_complete` = true) even if it's finished with a error (#180 was caused with this behaviour)

After this PR:
 - `call`/`match`/`mismatch`/`fold` set `subtree_complete` to false in join behaviour
 - `par` sets subtree complete to false if there's an error

Resolves #180.