### PR TITLE
Add API for returning interpreter memory size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.52"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84450d0b4a8bd1ba4144ce8ce718fbc5d071358b1e5384bace6536b3d1f2d5b3"
+checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
 
 [[package]]
 name = "arrayref"
@@ -214,7 +214,7 @@ version = "0.1.0"
 
 [[package]]
 name = "avm-server"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "air-interpreter-interface",
  "avm-data-store",
@@ -294,9 +294,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.8.0"
+version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
+checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 
 [[package]]
 name = "byteorder"
@@ -523,9 +523,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -544,9 +544,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+checksum = "97242a70df9b89a65d0b6df3c4bf5b9ce03c5b7309019777fbde37e7537f8762"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -557,9 +557,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
 dependencies = [
  "cfg-if 1.0.0",
  "lazy_static",
@@ -577,7 +577,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array 0.14.5",
  "subtle",
 ]
 
@@ -675,7 +675,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -729,9 +729,9 @@ dependencies = [
 
 [[package]]
 name = "erased-serde"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44a5d80251b806a14cd3e4e1a582e912d5cbf6904ab19fdefbd7a56adca088e1"
+checksum = "56047058e1ab118075ca22f9ecd737bcc961aa3566a3019cb71388afa280bd8a"
 dependencies = [
  "serde",
 ]
@@ -759,9 +759,9 @@ dependencies = [
 
 [[package]]
 name = "eyre"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "221239d1d5ea86bf5d6f91c9d6bc3646ffe471b08ff9b0f91c44f115ac969d2b"
+checksum = "bc225d8f637923fe585089fcf03e705c222131232d2c1fb622e84ecf725d0eb8"
 dependencies = [
  "indenter",
  "once_cell",
@@ -798,7 +798,7 @@ dependencies = [
  "cmd_lib",
  "itertools 0.9.0",
  "log",
- "marine-module-interface 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "marine-module-interface",
  "marine-rs-sdk",
  "marine-rs-sdk-main",
  "marine-runtime 0.7.2",
@@ -818,13 +818,14 @@ dependencies = [
 [[package]]
 name = "fluence-faas"
 version = "0.11.0"
-source = "git+https://github.com/fluencelabs/marine?branch=feature/module-memory-footprint#4598e00a4e8b3a90b74fa4322e41f8154d2f5256"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "991bfad8dddf1c6be445e6fc298cf4a77caa815f02740a78897d1d9eafbf9fc7"
 dependencies = [
  "bytesize",
  "cmd_lib",
  "itertools 0.9.0",
  "log",
- "marine-module-interface 0.1.6 (git+https://github.com/fluencelabs/marine?branch=feature/module-memory-footprint)",
+ "marine-module-interface",
  "marine-rs-sdk",
  "marine-rs-sdk-main",
  "marine-runtime 0.9.0",
@@ -904,9 +905,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.4"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
 dependencies = [
  "typenum",
  "version_check",
@@ -925,9 +926,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -1020,9 +1021,9 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -1040,9 +1041,9 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2f6fdbc5fd6457ae78e0313ba2eb5cb509655bbcfe8c577096cdbae8ff621c"
+checksum = "ce6b5d8c669bfbad811d95ddd7a1c6cf9cfdbf2777e59928b6f3fa8ff54f72a0"
 dependencies = [
  "ctor",
  "ghost",
@@ -1107,9 +1108,9 @@ dependencies = [
 
 [[package]]
 name = "lalrpop"
-version = "0.19.6"
+version = "0.19.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15174f1c529af5bf1283c3bc0058266b483a67156f79589fab2a25e23cf8988"
+checksum = "852b75a095da6b69da8c5557731c3afd06525d4f655a4fc1c799e2ec8bc4dce4"
 dependencies = [
  "ascii-canvas",
  "atty",
@@ -1130,9 +1131,9 @@ dependencies = [
 
 [[package]]
 name = "lalrpop-util"
-version = "0.19.6"
+version = "0.19.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e58cce361efcc90ba8a0a5f982c741ff86b603495bb15a998412e957dcd278"
+checksum = "d6d265705249fe209280676d8f68887859fa42e1d34f342fc05bd47726a5e188"
 dependencies = [
  "regex",
 ]
@@ -1164,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.112"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+checksum = "b0005d08a8f7b65fb8073cb697aa0b12b631ed251ce73d862ce50eeb52ce3b50"
 
 [[package]]
 name = "lock_api"
@@ -1209,24 +1210,7 @@ checksum = "890b228b9151e9dff213501986f564445a2f9ca5a706088b5d900f5ecf67f7e7"
 dependencies = [
  "cargo_toml",
  "it-lilo",
- "marine-it-parser 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "marine-macro-impl",
- "once_cell",
- "serde",
- "serde_json",
- "thiserror",
- "walrus",
- "wasmer-interface-types-fl",
-]
-
-[[package]]
-name = "marine-it-generator"
-version = "0.5.6"
-source = "git+https://github.com/fluencelabs/marine?branch=feature/module-memory-footprint#4598e00a4e8b3a90b74fa4322e41f8154d2f5256"
-dependencies = [
- "cargo_toml",
- "it-lilo",
- "marine-it-parser 0.6.8 (git+https://github.com/fluencelabs/marine?branch=feature/module-memory-footprint)",
+ "marine-it-parser",
  "marine-macro-impl",
  "once_cell",
  "serde",
@@ -1247,15 +1231,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "marine-it-interfaces"
-version = "0.4.1"
-source = "git+https://github.com/fluencelabs/marine?branch=feature/module-memory-footprint#4598e00a4e8b3a90b74fa4322e41f8154d2f5256"
-dependencies = [
- "multimap",
- "wasmer-interface-types-fl",
-]
-
-[[package]]
 name = "marine-it-parser"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1263,26 +1238,8 @@ checksum = "edd97bd85072fc540763769be153a7c8ee83391e668b37ef96d6c48decec2cd5"
 dependencies = [
  "anyhow",
  "itertools 0.10.3",
- "marine-it-interfaces 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "marine-module-interface 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "nom",
- "semver 0.11.0",
- "serde",
- "thiserror",
- "walrus",
- "wasmer-interface-types-fl",
- "wasmer-runtime-core-fl",
-]
-
-[[package]]
-name = "marine-it-parser"
-version = "0.6.8"
-source = "git+https://github.com/fluencelabs/marine?branch=feature/module-memory-footprint#4598e00a4e8b3a90b74fa4322e41f8154d2f5256"
-dependencies = [
- "anyhow",
- "itertools 0.10.3",
- "marine-it-interfaces 0.4.1 (git+https://github.com/fluencelabs/marine?branch=feature/module-memory-footprint)",
- "marine-module-interface 0.1.6 (git+https://github.com/fluencelabs/marine?branch=feature/module-memory-footprint)",
+ "marine-it-interfaces",
+ "marine-module-interface",
  "nom",
  "semver 0.11.0",
  "serde",
@@ -1333,21 +1290,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "marine-module-info-parser"
-version = "0.2.2"
-source = "git+https://github.com/fluencelabs/marine?branch=feature/module-memory-footprint#4598e00a4e8b3a90b74fa4322e41f8154d2f5256"
-dependencies = [
- "anyhow",
- "chrono",
- "marine-rs-sdk-main",
- "semver 0.11.0",
- "serde",
- "thiserror",
- "walrus",
- "wasmer-runtime-core-fl",
-]
-
-[[package]]
 name = "marine-module-interface"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1355,24 +1297,7 @@ checksum = "06bc36ef268bf7436916f1fa9b0c84104692a717ea5eef3c90b9f25c3407f6b7"
 dependencies = [
  "anyhow",
  "itertools 0.10.3",
- "marine-it-interfaces 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "nom",
- "semver 0.11.0",
- "serde",
- "thiserror",
- "walrus",
- "wasmer-interface-types-fl",
- "wasmer-runtime-core-fl",
-]
-
-[[package]]
-name = "marine-module-interface"
-version = "0.1.6"
-source = "git+https://github.com/fluencelabs/marine?branch=feature/module-memory-footprint#4598e00a4e8b3a90b74fa4322e41f8154d2f5256"
-dependencies = [
- "anyhow",
- "itertools 0.10.3",
- "marine-it-interfaces 0.4.1 (git+https://github.com/fluencelabs/marine?branch=feature/module-memory-footprint)",
+ "marine-it-interfaces",
  "nom",
  "semver 0.11.0",
  "serde",
@@ -1415,11 +1340,11 @@ dependencies = [
  "boolinator",
  "it-lilo",
  "log",
- "marine-it-generator 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "marine-it-interfaces 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "marine-it-parser 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "marine-module-info-parser 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "marine-module-interface 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "marine-it-generator",
+ "marine-it-interfaces",
+ "marine-it-parser",
+ "marine-module-info-parser",
+ "marine-module-interface",
  "marine-utils 0.2.0",
  "multimap",
  "once_cell",
@@ -1438,18 +1363,19 @@ dependencies = [
 [[package]]
 name = "marine-runtime"
 version = "0.9.0"
-source = "git+https://github.com/fluencelabs/marine?branch=feature/module-memory-footprint#4598e00a4e8b3a90b74fa4322e41f8154d2f5256"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9eea4841ab8dfa29c46b1d628af1b4225a5b57add2656db457839a501a77278"
 dependencies = [
  "anyhow",
  "boolinator",
  "bytesize",
  "it-lilo",
  "log",
- "marine-it-generator 0.5.6 (git+https://github.com/fluencelabs/marine?branch=feature/module-memory-footprint)",
- "marine-it-interfaces 0.4.1 (git+https://github.com/fluencelabs/marine?branch=feature/module-memory-footprint)",
- "marine-it-parser 0.6.8 (git+https://github.com/fluencelabs/marine?branch=feature/module-memory-footprint)",
- "marine-module-info-parser 0.2.2 (git+https://github.com/fluencelabs/marine?branch=feature/module-memory-footprint)",
- "marine-module-interface 0.1.6 (git+https://github.com/fluencelabs/marine?branch=feature/module-memory-footprint)",
+ "marine-it-generator",
+ "marine-it-interfaces",
+ "marine-it-parser",
+ "marine-module-info-parser",
+ "marine-module-interface",
  "marine-utils 0.4.0",
  "multimap",
  "once_cell",
@@ -1484,7 +1410,8 @@ checksum = "8dc5838acba84ce4d802d672afd0814fae0ae7098021ae5b06d975e70d09f812"
 [[package]]
 name = "marine-utils"
 version = "0.4.0"
-source = "git+https://github.com/fluencelabs/marine?branch=feature/module-memory-footprint#4598e00a4e8b3a90b74fa4322e41f8154d2f5256"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cff7a23a7f3925a712c34dfb9cd87994012d7743f016fd1533e12ab5a8335ca"
 
 [[package]]
 name = "memchr"
@@ -1820,9 +1747,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
+checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2",
 ]
@@ -1884,7 +1811,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
- "getrandom 0.2.3",
+ "getrandom 0.2.4",
  "redox_syscall 0.2.10",
 ]
 
@@ -2006,9 +1933,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.132"
+version = "1.0.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9875c23cf305cd1fd7eb77234cbb705f21ea6a72c637a5c6db5fe4b8e7f008"
+checksum = "2cf9235533494ea2ddcdb794665461814781c53f19d87b76e571a1c35acbad2b"
 dependencies = [
  "serde_derive",
 ]
@@ -2044,9 +1971,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.132"
+version = "1.0.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc0db5cb2556c0e558887d9bbdcf6ac4471e83ff66cf696e5419024d1606276"
+checksum = "8dcde03d87d4c973c04be249e7d8f0b35db1c848c487bd43032808e59dd8328d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2055,9 +1982,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.73"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcbd0344bc6533bc7ec56df11d42fb70f1b912351c0825ccb7211b59d8af7cf5"
+checksum = "d23c1ba4cf0efd44be32017709280b32d1cea5c3f1275c3b6d9e8bc54f758085"
 dependencies = [
  "itoa 1.0.1",
  "ryu",
@@ -2089,15 +2016,15 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "0.3.7"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533494a8f9b724d33625ab53c6c4800f7cc445895924a8ef649222dcb76e938b"
+checksum = "a86232ab60fa71287d7f2ddae4a7073f6b7aac33631c3015abb556f08c6d0a3e"
 
 [[package]]
 name = "smallvec"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
+checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "static_assertions"
@@ -2150,9 +2077,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.84"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecb2e6da8ee5eb9a61068762a32fa9619cc591ceb055b3687f4cd4051ec2e06b"
+checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2313,7 +2240,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom 0.2.3",
+ "getrandom 0.2.4",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,12 +214,12 @@ version = "0.1.0"
 
 [[package]]
 name = "avm-server"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "air-interpreter-interface",
  "avm-data-store",
  "eyre",
- "fluence-faas 0.10.1",
+ "fluence-faas 0.11.0",
  "log",
  "maplit",
  "parking_lot 0.11.2",
@@ -798,7 +798,7 @@ dependencies = [
  "cmd_lib",
  "itertools 0.9.0",
  "log",
- "marine-module-interface",
+ "marine-module-interface 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "marine-rs-sdk",
  "marine-rs-sdk-main",
  "marine-runtime 0.7.2",
@@ -817,18 +817,17 @@ dependencies = [
 
 [[package]]
 name = "fluence-faas"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "999490a4665246d0f6904743b3b5c8b4abe6723529d9c9b72c58a3f3e5df65d6"
+version = "0.11.0"
+source = "git+https://github.com/fluencelabs/marine?branch=feature/module-memory-footprint#4598e00a4e8b3a90b74fa4322e41f8154d2f5256"
 dependencies = [
  "bytesize",
  "cmd_lib",
  "itertools 0.9.0",
  "log",
- "marine-module-interface",
+ "marine-module-interface 0.1.6 (git+https://github.com/fluencelabs/marine?branch=feature/module-memory-footprint)",
  "marine-rs-sdk",
  "marine-rs-sdk-main",
- "marine-runtime 0.8.1",
+ "marine-runtime 0.9.0",
  "marine-utils 0.4.0",
  "safe-transmute",
  "serde",
@@ -1210,7 +1209,24 @@ checksum = "890b228b9151e9dff213501986f564445a2f9ca5a706088b5d900f5ecf67f7e7"
 dependencies = [
  "cargo_toml",
  "it-lilo",
- "marine-it-parser",
+ "marine-it-parser 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "marine-macro-impl",
+ "once_cell",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "walrus",
+ "wasmer-interface-types-fl",
+]
+
+[[package]]
+name = "marine-it-generator"
+version = "0.5.6"
+source = "git+https://github.com/fluencelabs/marine?branch=feature/module-memory-footprint#4598e00a4e8b3a90b74fa4322e41f8154d2f5256"
+dependencies = [
+ "cargo_toml",
+ "it-lilo",
+ "marine-it-parser 0.6.8 (git+https://github.com/fluencelabs/marine?branch=feature/module-memory-footprint)",
  "marine-macro-impl",
  "once_cell",
  "serde",
@@ -1231,6 +1247,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "marine-it-interfaces"
+version = "0.4.1"
+source = "git+https://github.com/fluencelabs/marine?branch=feature/module-memory-footprint#4598e00a4e8b3a90b74fa4322e41f8154d2f5256"
+dependencies = [
+ "multimap",
+ "wasmer-interface-types-fl",
+]
+
+[[package]]
 name = "marine-it-parser"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1238,8 +1263,26 @@ checksum = "edd97bd85072fc540763769be153a7c8ee83391e668b37ef96d6c48decec2cd5"
 dependencies = [
  "anyhow",
  "itertools 0.10.3",
- "marine-it-interfaces",
- "marine-module-interface",
+ "marine-it-interfaces 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "marine-module-interface 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom",
+ "semver 0.11.0",
+ "serde",
+ "thiserror",
+ "walrus",
+ "wasmer-interface-types-fl",
+ "wasmer-runtime-core-fl",
+]
+
+[[package]]
+name = "marine-it-parser"
+version = "0.6.8"
+source = "git+https://github.com/fluencelabs/marine?branch=feature/module-memory-footprint#4598e00a4e8b3a90b74fa4322e41f8154d2f5256"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.3",
+ "marine-it-interfaces 0.4.1 (git+https://github.com/fluencelabs/marine?branch=feature/module-memory-footprint)",
+ "marine-module-interface 0.1.6 (git+https://github.com/fluencelabs/marine?branch=feature/module-memory-footprint)",
  "nom",
  "semver 0.11.0",
  "serde",
@@ -1290,6 +1333,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "marine-module-info-parser"
+version = "0.2.2"
+source = "git+https://github.com/fluencelabs/marine?branch=feature/module-memory-footprint#4598e00a4e8b3a90b74fa4322e41f8154d2f5256"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "marine-rs-sdk-main",
+ "semver 0.11.0",
+ "serde",
+ "thiserror",
+ "walrus",
+ "wasmer-runtime-core-fl",
+]
+
+[[package]]
 name = "marine-module-interface"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1297,7 +1355,24 @@ checksum = "06bc36ef268bf7436916f1fa9b0c84104692a717ea5eef3c90b9f25c3407f6b7"
 dependencies = [
  "anyhow",
  "itertools 0.10.3",
- "marine-it-interfaces",
+ "marine-it-interfaces 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom",
+ "semver 0.11.0",
+ "serde",
+ "thiserror",
+ "walrus",
+ "wasmer-interface-types-fl",
+ "wasmer-runtime-core-fl",
+]
+
+[[package]]
+name = "marine-module-interface"
+version = "0.1.6"
+source = "git+https://github.com/fluencelabs/marine?branch=feature/module-memory-footprint#4598e00a4e8b3a90b74fa4322e41f8154d2f5256"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.3",
+ "marine-it-interfaces 0.4.1 (git+https://github.com/fluencelabs/marine?branch=feature/module-memory-footprint)",
  "nom",
  "semver 0.11.0",
  "serde",
@@ -1340,11 +1415,11 @@ dependencies = [
  "boolinator",
  "it-lilo",
  "log",
- "marine-it-generator",
- "marine-it-interfaces",
- "marine-it-parser",
- "marine-module-info-parser",
- "marine-module-interface",
+ "marine-it-generator 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "marine-it-interfaces 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "marine-it-parser 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "marine-module-info-parser 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "marine-module-interface 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "marine-utils 0.2.0",
  "multimap",
  "once_cell",
@@ -1362,19 +1437,19 @@ dependencies = [
 
 [[package]]
 name = "marine-runtime"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06f9bc60de3416381b56783f9060f1fcb75fc9dc99c3debdb6c5fc1dd306f52"
+version = "0.9.0"
+source = "git+https://github.com/fluencelabs/marine?branch=feature/module-memory-footprint#4598e00a4e8b3a90b74fa4322e41f8154d2f5256"
 dependencies = [
  "anyhow",
  "boolinator",
+ "bytesize",
  "it-lilo",
  "log",
- "marine-it-generator",
- "marine-it-interfaces",
- "marine-it-parser",
- "marine-module-info-parser",
- "marine-module-interface",
+ "marine-it-generator 0.5.6 (git+https://github.com/fluencelabs/marine?branch=feature/module-memory-footprint)",
+ "marine-it-interfaces 0.4.1 (git+https://github.com/fluencelabs/marine?branch=feature/module-memory-footprint)",
+ "marine-it-parser 0.6.8 (git+https://github.com/fluencelabs/marine?branch=feature/module-memory-footprint)",
+ "marine-module-info-parser 0.2.2 (git+https://github.com/fluencelabs/marine?branch=feature/module-memory-footprint)",
+ "marine-module-interface 0.1.6 (git+https://github.com/fluencelabs/marine?branch=feature/module-memory-footprint)",
  "marine-utils 0.4.0",
  "multimap",
  "once_cell",
@@ -1409,8 +1484,7 @@ checksum = "8dc5838acba84ce4d802d672afd0814fae0ae7098021ae5b06d975e70d09f812"
 [[package]]
 name = "marine-utils"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cff7a23a7f3925a712c34dfb9cd87994012d7743f016fd1533e12ab5a8335ca"
+source = "git+https://github.com/fluencelabs/marine?branch=feature/module-memory-footprint#4598e00a4e8b3a90b74fa4322e41f8154d2f5256"
 
 [[package]]
 name = "memchr"

--- a/avm/server/Cargo.toml
+++ b/avm/server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "avm-server"
 description = "Fluence AIR VM"
-version = "0.15.0"
+version = "0.14.0"
 authors = ["Fluence Labs"]
 edition = "2018"
 license = "Apache-2.0"

--- a/avm/server/Cargo.toml
+++ b/avm/server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "avm-server"
 description = "Fluence AIR VM"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Fluence Labs"]
 edition = "2018"
 license = "Apache-2.0"
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 [dependencies]
 air-interpreter-interface = { version = "0.8.0", path = "../../crates/air-lib/interpreter-interface" }
 avm-data-store = { version = "0.1.0", path = "../../crates/data-store" }
-fluence-faas = { git = "https://github.com/fluencelabs/marine", branch = "feature/module-memory-footprint" }
+fluence-faas = "0.11.0"
 polyplets = { version = "0.2.0", path = "../../crates/air-lib/polyplets" }
 
 eyre = "0.6.5"

--- a/avm/server/Cargo.toml
+++ b/avm/server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "avm-server"
 description = "Fluence AIR VM"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["Fluence Labs"]
 edition = "2018"
 license = "Apache-2.0"
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 [dependencies]
 air-interpreter-interface = { version = "0.8.0", path = "../../crates/air-lib/interpreter-interface" }
 avm-data-store = { version = "0.1.0", path = "../../crates/data-store" }
-fluence-faas = "0.10.0"
+fluence-faas = { git = "https://github.com/fluencelabs/marine", branch = "feature/module-memory-footprint" }
 polyplets = { version = "0.2.0", path = "../../crates/air-lib/polyplets" }
 
 eyre = "0.6.5"

--- a/avm/server/src/avm.rs
+++ b/avm/server/src/avm.rs
@@ -99,7 +99,7 @@ impl<E> AVM<E> {
         Ok(())
     }
 
-    /// Return size of interpreter heap.
+    /// Return size of interpreter heap in bytes.
     pub fn heap_size(&self) -> usize {
         self.runner.heap_size()
     }

--- a/avm/server/src/avm.rs
+++ b/avm/server/src/avm.rs
@@ -99,7 +99,7 @@ impl<E> AVM<E> {
         Ok(())
     }
 
-    /// Return size of interpreter heap
+    /// Return size of interpreter heap.
     pub fn heap_size(&self) -> usize {
         self.runner.heap_size()
     }

--- a/avm/server/src/avm.rs
+++ b/avm/server/src/avm.rs
@@ -98,4 +98,9 @@ impl<E> AVM<E> {
         self.data_store.cleanup_data(particle_id)?;
         Ok(())
     }
+
+    /// Return size of interpreter heap
+    pub fn heap_size(&self) -> usize {
+        self.runner.heap_size()
+    }
 }

--- a/avm/server/src/avm.rs
+++ b/avm/server/src/avm.rs
@@ -100,7 +100,7 @@ impl<E> AVM<E> {
     }
 
     /// Return size of interpreter heap in bytes.
-    pub fn heap_size(&self) -> usize {
-        self.runner.heap_size()
+    pub fn memory_size(&self) -> usize {
+        self.runner.memory_size()
     }
 }

--- a/avm/server/src/runner.rs
+++ b/avm/server/src/runner.rs
@@ -87,12 +87,12 @@ impl AVMRunner {
         Ok(outcome)
     }
 
-    pub fn heap_size(&self) -> usize {
-        let statistic = self.faas.heap_statistic();
+    pub fn memory_size(&self) -> usize {
+        let stats = self.faas.module_memory_stats();
 
         // only the interpreters must be loaded in FaaS
-        debug_assert!(statistic.len() == 1);
-        statistic[0].memory_size
+        debug_assert!(stats.len() == 1);
+        stats[0].memory_size
     }
 }
 

--- a/avm/server/src/runner.rs
+++ b/avm/server/src/runner.rs
@@ -86,6 +86,14 @@ impl AVMRunner {
 
         Ok(outcome)
     }
+
+    pub fn heap_size(&self) -> usize {
+        let statistic = self.faas.heap_statistic();
+
+        // only the interpreters must be loaded in FaaS
+        debug_assert!(statistic.len() == 1);
+        statistic[0].memory_size
+    }
 }
 
 fn prepare_args(

--- a/crates/air-lib/air-parser/src/parser/air.rs
+++ b/crates/air-lib/air-parser/src/parser/air.rs
@@ -1,4 +1,4 @@
-// auto-generated: "lalrpop 0.19.6"
+// auto-generated: "lalrpop 0.19.7"
 // sha3: c2929fd6be582606809ced9bf24341f11131eef708d60644d19fb79f070
 use crate::ast::*;
 use crate::parser::ParserError;
@@ -19,7 +19,7 @@ extern crate alloc;
 
 #[cfg_attr(rustfmt, rustfmt_skip)]
 mod __parse__AIR {
-    #![allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, unused_imports, unused_parens)]
+    #![allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, unused_imports, unused_parens, clippy::all)]
 
     use crate::ast::*;
     use crate::parser::ParserError;
@@ -5683,16 +5683,19 @@ fn __action95<
     )
 }
 
-pub trait __ToTriple<'err, 'input, 'v, > {
+pub trait __ToTriple<'err, 'input, 'v, >
+{
     fn to_triple(value: Self) -> Result<(usize,Token<'input>,usize), __lalrpop_util::ParseError<usize, Token<'input>, ParserError>>;
 }
 
-impl<'err, 'input, 'v, > __ToTriple<'err, 'input, 'v, > for (usize, Token<'input>, usize) {
+impl<'err, 'input, 'v, > __ToTriple<'err, 'input, 'v, > for (usize, Token<'input>, usize)
+{
     fn to_triple(value: Self) -> Result<(usize,Token<'input>,usize), __lalrpop_util::ParseError<usize, Token<'input>, ParserError>> {
         Ok(value)
     }
 }
-impl<'err, 'input, 'v, > __ToTriple<'err, 'input, 'v, > for Result<(usize, Token<'input>, usize), ParserError> {
+impl<'err, 'input, 'v, > __ToTriple<'err, 'input, 'v, > for Result<(usize, Token<'input>, usize), ParserError>
+{
     fn to_triple(value: Self) -> Result<(usize,Token<'input>,usize), __lalrpop_util::ParseError<usize, Token<'input>, ParserError>> {
         match value {
             Ok(v) => Ok(v),

--- a/crates/air-lib/lambda/parser/src/parser/va_lambda.rs
+++ b/crates/air-lib/lambda/parser/src/parser/va_lambda.rs
@@ -1,4 +1,4 @@
-// auto-generated: "lalrpop 0.19.6"
+// auto-generated: "lalrpop 0.19.7"
 // sha3: 517c7e1bd341e1434f9ffcbf3c72151e4b928e7befd38c6ee2e3e734565b
 use crate::ValueAccessor;
 use crate::parser::lexer::LexerError;
@@ -13,7 +13,7 @@ extern crate alloc;
 
 #[cfg_attr(rustfmt, rustfmt_skip)]
 mod __parse__Lambda {
-    #![allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, unused_imports, unused_parens)]
+    #![allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, unused_imports, unused_parens, clippy::all)]
 
     use crate::ValueAccessor;
     use crate::parser::lexer::LexerError;
@@ -1841,16 +1841,19 @@ fn __action29<
     )
 }
 
-pub trait __ToTriple<'err, 'input, > {
+pub trait __ToTriple<'err, 'input, >
+{
     fn to_triple(value: Self) -> Result<(usize,Token<'input>,usize), __lalrpop_util::ParseError<usize, Token<'input>, LexerError>>;
 }
 
-impl<'err, 'input, > __ToTriple<'err, 'input, > for (usize, Token<'input>, usize) {
+impl<'err, 'input, > __ToTriple<'err, 'input, > for (usize, Token<'input>, usize)
+{
     fn to_triple(value: Self) -> Result<(usize,Token<'input>,usize), __lalrpop_util::ParseError<usize, Token<'input>, LexerError>> {
         Ok(value)
     }
 }
-impl<'err, 'input, > __ToTriple<'err, 'input, > for Result<(usize, Token<'input>, usize), LexerError> {
+impl<'err, 'input, > __ToTriple<'err, 'input, > for Result<(usize, Token<'input>, usize), LexerError>
+{
     fn to_triple(value: Self) -> Result<(usize,Token<'input>,usize), __lalrpop_util::ParseError<usize, Token<'input>, LexerError>> {
         match value {
             Ok(v) => Ok(v),


### PR DESCRIPTION
Adds a new API for getting memory size of a loaded interpreter:

```rust
pub fn memory_size(&self) -> usize { ... }
```