### PR TITLE
Remove RefCell from streams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "air"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "air-execution-info-collector",
  "air-interpreter-data",
@@ -51,7 +51,7 @@ version = "0.1.0"
 
 [[package]]
 name = "air-interpreter"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "air",
  "air-log-targets",

--- a/air/src/execution_step/air/ap/utils.rs
+++ b/air/src/execution_step/air/ap/utils.rs
@@ -81,7 +81,7 @@ fn variable_to_generations(variable: &ast::Variable<'_>, exec_ctx: &ExecutionCtx
             // unwrap here is safe because this function will be called only
             // when this stream's been created
             let stream = exec_ctx.streams.get(stream.name, stream.position).unwrap();
-            let generation = match stream.borrow().generations_count() {
+            let generation = match stream.generations_count() {
                 0 => 0,
                 n => n - 1,
             };

--- a/air/src/execution_step/air/call/call_result_setter.rs
+++ b/air/src/execution_step/air/call/call_result_setter.rs
@@ -42,7 +42,7 @@ pub(crate) fn set_local_result<'i>(
             // TODO: refactor this generation handling
             let generation = match exec_ctx.streams.get(stream.name, stream.position) {
                 Some(stream) => {
-                    let generation = match stream.borrow().generations_count() {
+                    let generation = match stream.generations_count() {
                         0 => 0,
                         n => n - 1,
                     };

--- a/air/src/execution_step/air/fold/utils.rs
+++ b/air/src/execution_step/air/fold/utils.rs
@@ -22,7 +22,6 @@ use crate::SecurityTetraplet;
 
 use air_parser::ast;
 
-use std::cell::RefCell;
 use std::ops::Deref;
 use std::rc::Rc;
 
@@ -48,11 +47,10 @@ pub(crate) fn construct_scalar_iterable_value<'ctx>(
 
 /// Constructs iterable value for given stream iterable.
 pub(crate) fn construct_stream_iterable_values(
-    stream: &RefCell<Stream>,
+    stream: &Stream,
     start: Generation,
     end: Generation,
 ) -> Vec<IterableValue> {
-    let stream = stream.borrow();
     let stream_iter = match stream.slice_iter(start, end) {
         Some(stream_iter) => stream_iter,
         None => return vec![],

--- a/air/src/execution_step/air/fold_stream.rs
+++ b/air/src/execution_step/air/fold_stream.rs
@@ -25,12 +25,10 @@ use super::TraceHandler;
 use crate::execution_step::boxed_value::Stream;
 use crate::log_instruction;
 use crate::trace_to_exec_err;
-use air_parser::ast;
 use stream_cursor::StreamCursor;
 
+use air_parser::ast;
 use air_parser::ast::FoldStream;
-
-use std::cell::RefCell;
 
 impl<'i> ExecutableInstruction<'i> for FoldStream<'i> {
     fn execute(&self, exec_ctx: &mut ExecutionCtx<'i>, trace_ctx: &mut TraceHandler) -> ExecutionResult<()> {
@@ -118,16 +116,16 @@ fn should_stop_iteration(iteration_result: &ExecutionResult<bool>) -> bool {
 
 /// Safety: this function should be called iff stream is present in context
 fn add_new_generation_if_non_empty(stream: &ast::Stream<'_>, exec_ctx: &mut ExecutionCtx<'_>) {
-    let stream = exec_ctx.streams.get(stream.name, stream.position).unwrap();
-    stream.borrow_mut().add_new_generation_if_non_empty();
+    let stream = exec_ctx.streams.get_mut(stream.name, stream.position).unwrap();
+    stream.add_new_generation_if_non_empty();
 }
 
 /// Safety: this function should be called iff stream is present in context
 fn remove_new_generation_if_non_empty<'ctx>(
     stream: &ast::Stream<'_>,
     exec_ctx: &'ctx mut ExecutionCtx<'_>,
-) -> &'ctx RefCell<Stream> {
-    let stream = exec_ctx.streams.get(stream.name, stream.position).unwrap();
-    stream.borrow_mut().remove_last_generation_if_empty();
+) -> &'ctx Stream {
+    let stream = exec_ctx.streams.get_mut(stream.name, stream.position).unwrap();
+    stream.remove_last_generation_if_empty();
     stream
 }

--- a/air/src/execution_step/air/fold_stream/stream_cursor.rs
+++ b/air/src/execution_step/air/fold_stream/stream_cursor.rs
@@ -19,8 +19,6 @@ use crate::execution_step::air::fold::IterableValue;
 use crate::execution_step::boxed_value::Generation;
 use crate::execution_step::boxed_value::Stream;
 
-use std::cell::RefCell;
-
 pub(super) struct StreamCursor {
     last_seen_generation: u32,
 }
@@ -32,10 +30,10 @@ impl StreamCursor {
         }
     }
 
-    pub(super) fn construct_iterables(&mut self, stream: &RefCell<Stream>) -> Vec<IterableValue> {
+    pub(super) fn construct_iterables(&mut self, stream: &Stream) -> Vec<IterableValue> {
         let iterables =
             construct_stream_iterable_values(stream, Generation::Nth(self.last_seen_generation), Generation::Last);
-        self.last_seen_generation = stream.borrow().non_empty_generations_count() as u32;
+        self.last_seen_generation = stream.non_empty_generations_count() as u32;
 
         iterables
     }

--- a/air/src/execution_step/boxed_value/jvaluable/stream.rs
+++ b/air/src/execution_step/boxed_value/jvaluable/stream.rs
@@ -32,7 +32,7 @@ use std::ops::Deref;
 
 #[derive(Debug)]
 pub(crate) struct StreamJvaluableIngredients<'stream> {
-    pub(crate) stream: std::cell::Ref<'stream, Stream>,
+    pub(crate) stream: &'stream Stream,
     pub(crate) generation: Generation,
 }
 
@@ -63,7 +63,7 @@ impl JValuable for StreamJvaluableIngredients<'_> {
     }
 
     fn as_jvalue(&self) -> Cow<'_, JValue> {
-        let jvalue = self.stream.deref().clone().as_jvalue(self.generation).unwrap();
+        let jvalue = self.stream.as_jvalue(self.generation).unwrap();
         Cow::Owned(jvalue)
     }
 
@@ -83,7 +83,7 @@ impl JValuable for StreamJvaluableIngredients<'_> {
 use crate::execution_step::boxed_value::StreamIter;
 
 impl<'stream> StreamJvaluableIngredients<'stream> {
-    pub(crate) fn new(stream: std::cell::Ref<'stream, Stream>, generation: Generation) -> Self {
+    pub(crate) fn new(stream: &'stream Stream, generation: Generation) -> Self {
         Self { stream, generation }
     }
 
@@ -98,7 +98,7 @@ impl<'stream> StreamJvaluableIngredients<'stream> {
                     Generation::Last => unreachable!(),
                 };
 
-                Err(StreamDontHaveSuchGeneration(self.stream.deref().clone(), generation as usize).into())
+                Err(StreamDontHaveSuchGeneration(self.stream.clone(), generation as usize).into())
             }
         }
     }

--- a/air/src/execution_step/resolver/resolve.rs
+++ b/air/src/execution_step/resolver/resolve.rs
@@ -100,7 +100,7 @@ pub(crate) fn resolve_variable<'ctx, 'i>(
         } => {
             match ctx.streams.get(name, position) {
                 Some(stream) => {
-                    let ingredients = StreamJvaluableIngredients::new(stream.borrow(), generation);
+                    let ingredients = StreamJvaluableIngredients::new(stream, generation);
                     Ok(Box::new(ingredients))
                 }
                 // return an empty stream for not found stream


### PR DESCRIPTION
It was a technical debt that streams were wrapped into `RefCell` after introducing `new` operator for streams. This PR resolves this. 