### PR TITLE
Make fold by streams truly deterministic

### DIFF
--- a/air/src/execution_step/air/ap/utils.rs
+++ b/air/src/execution_step/air/ap/utils.rs
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-use super::ExecutionCtx;
 use super::ExecutionResult;
 use crate::execution_step::Generation;
 
@@ -54,14 +53,14 @@ fn match_position_variable(
     }
 }
 
-pub(super) fn to_ap_result(merger_ap_result: &MergerApResult, instr: &Ap<'_>, exec_ctx: &ExecutionCtx<'_>) -> ApResult {
+pub(super) fn to_ap_result(merger_ap_result: &MergerApResult, maybe_generation: Option<u32>) -> ApResult {
     if let MergerApResult::ApResult { res_generation } = merger_ap_result {
         let res_generation = option_to_vec(*res_generation);
 
         return ApResult::new(res_generation);
     }
 
-    let res_generation = variable_to_generations(&instr.result, exec_ctx);
+    let res_generation = option_to_vec(maybe_generation);
     ApResult::new(res_generation)
 }
 
@@ -69,24 +68,5 @@ fn option_to_vec(value: Option<u32>) -> Vec<u32> {
     match value {
         Some(value) => vec![value],
         None => vec![],
-    }
-}
-
-fn variable_to_generations(variable: &ast::Variable<'_>, exec_ctx: &ExecutionCtx<'_>) -> Vec<u32> {
-    use ast::Variable::*;
-
-    match variable {
-        Scalar(_) => vec![],
-        Stream(stream) => {
-            // unwrap here is safe because this function will be called only
-            // when this stream's been created
-            let stream = exec_ctx.streams.get(stream.name, stream.position).unwrap();
-            let generation = match stream.generations_count() {
-                0 => 0,
-                n => n - 1,
-            };
-
-            vec![generation as u32]
-        }
     }
 }

--- a/air/src/execution_step/air/call/call_result_setter.rs
+++ b/air/src/execution_step/air/call/call_result_setter.rs
@@ -39,22 +39,10 @@ pub(crate) fn set_local_result<'i>(
             Ok(CallResult::executed_scalar(result_value))
         }
         CallOutputValue::Variable(Variable::Stream(stream)) => {
-            // TODO: refactor this generation handling
-            let generation = match exec_ctx.streams.get(stream.name, stream.position) {
-                Some(stream) => {
-                    let generation = match stream.generations_count() {
-                        0 => 0,
-                        n => n - 1,
-                    };
-                    Generation::Nth(generation as u32)
-                }
-                None => Generation::Last,
-            };
-
             let generation =
                 exec_ctx
                     .streams
-                    .add_stream_value(executed_result, generation, stream.name, stream.position)?;
+                    .add_stream_value(executed_result, Generation::Last, stream.name, stream.position)?;
             Ok(CallResult::executed_stream(result_value, generation))
         }
         CallOutputValue::None => Ok(CallResult::executed_scalar(result_value)),

--- a/air/src/execution_step/air/fold_stream/stream_cursor.rs
+++ b/air/src/execution_step/air/fold_stream/stream_cursor.rs
@@ -33,7 +33,7 @@ impl StreamCursor {
     pub(super) fn construct_iterables(&mut self, stream: &Stream) -> Vec<IterableValue> {
         let iterables =
             construct_stream_iterable_values(stream, Generation::Nth(self.last_seen_generation), Generation::Last);
-        self.last_seen_generation = stream.non_empty_generations_count() as u32;
+        self.last_seen_generation = stream.generations_count() as u32;
 
         iterables
     }

--- a/air/src/execution_step/boxed_value/stream.rs
+++ b/air/src/execution_step/boxed_value/stream.rs
@@ -57,17 +57,7 @@ impl Stream {
     }
 
     pub(crate) fn generations_count(&self) -> usize {
-        let generations_count = self.0.len();
-
         // the last generation could be empty due to the logic of from_generations_count ctor
-        if generations_count > 0 && self.0[generations_count - 1].is_empty() {
-            generations_count - 1
-        } else {
-            generations_count
-        }
-    }
-
-    pub(crate) fn non_empty_generations_count(&self) -> usize {
         self.0.iter().filter(|gen| !gen.is_empty()).count()
     }
 

--- a/air/tests/test_module/instructions/ap.rs
+++ b/air/tests/test_module/instructions/ap.rs
@@ -59,22 +59,20 @@ fn ap_with_string_literal() {
     let vm_1_peer_id = "vm_1_peer_id";
     let mut vm_1 = create_avm(echo_call_service(), vm_1_peer_id);
 
-    let script = format!(
-        r#"
+    let some_string = "some_string";
+    let script = f!(r#"
         (seq
-            (ap "some_string" $stream)
-            (call "{}" ("" "") [$stream])
+            (ap "{some_string}" $stream)
+            (call "{vm_1_peer_id}" ("" "") [$stream])
         )
-        "#,
-        vm_1_peer_id
-    );
+        "#);
 
     let result = checked_call_vm!(vm_1, "", script, "", "");
 
     let actual_trace = trace_from_result(&result);
     let expected_state = vec![
         executed_state::ap(Some(0)),
-        executed_state::scalar(json!(["some_string"])),
+        executed_state::scalar(json!([some_string])),
     ];
 
     assert_eq!(actual_trace, expected_state);

--- a/air/tests/test_module/instructions/fold.rs
+++ b/air/tests/test_module/instructions/fold.rs
@@ -46,7 +46,7 @@ fn lfold() {
     assert_eq!(actual_trace[0], expected_state);
 
     for i in 1..=5 {
-        let expected_state = executed_state::stream_string(format!("{}", i), 0);
+        let expected_state = executed_state::stream_string(format!("{}", i), i as u32 - 1);
         assert_eq!(actual_trace[i], expected_state);
     }
 }
@@ -80,7 +80,7 @@ fn rfold() {
     assert_eq!(actual_trace[0], expected_state);
 
     for i in 1..=5 {
-        let expected_state = executed_state::stream_string(format!("{}", 6 - i), 0);
+        let expected_state = executed_state::stream_string(format!("{}", 6 - i), i as u32 - 1);
         assert_eq!(actual_trace[i], expected_state);
     }
 }
@@ -124,8 +124,9 @@ fn inner_fold() {
 
     for i in 1..=5 {
         for j in 1..=5 {
-            let expected_state = executed_state::stream_string(i.to_string(), 0);
-            assert_eq!(actual_trace[1 + 5 * (i - 1) + j], expected_state);
+            let state_id = 1 + 5 * (i - 1) + j;
+            let expected_state = executed_state::stream_string(i.to_string(), state_id as u32 - 2);
+            assert_eq!(actual_trace[state_id], expected_state);
         }
     }
 }
@@ -269,7 +270,7 @@ fn lambda() {
     assert_eq!(actual_trace[0], expected_state);
 
     for i in 1..=5 {
-        let expected_state = executed_state::stream_string(format!("{}", i), 0);
+        let expected_state = executed_state::stream_string(format!("{}", i), i as u32 - 1);
         assert_eq!(actual_trace[i], expected_state);
     }
 }

--- a/air/tests/test_module/integration/data_merge.rs
+++ b/air/tests/test_module/integration/data_merge.rs
@@ -18,7 +18,7 @@ use air_test_utils::prelude::*;
 use std::collections::HashMap;
 
 #[test]
-fn data_merge() {
+fn data_merge__() {
     use executed_state::*;
 
     let set_variable_id = "set_variable";
@@ -73,7 +73,7 @@ fn data_merge() {
         stream_string(vm_1_id, 0),
         par(1, 0),
         request_sent_by(vm_1_id),
-        stream_string(vm_1_id, 0),
+        stream_string(vm_1_id, 1),
         request_sent_by(vm_1_id),
     ];
 
@@ -105,12 +105,12 @@ fn data_merge() {
         par(1, 2),
         stream_string(vm_1_id, 0),
         par(1, 0),
-        stream_string(vm_2_id, 1),
+        stream_string(vm_2_id, 2),
         par(1, 2),
         stream_string(vm_1_id, 0),
         par(1, 0),
         stream_string(vm_2_id, 1),
-        stream_string(vm_1_id, 0),
+        stream_string(vm_1_id, 1),
         request_sent_by(vm_1_id),
     ];
 
@@ -124,12 +124,12 @@ fn data_merge() {
         par(1, 2),
         stream_string(vm_1_id, 0),
         par(1, 0),
-        stream_string(vm_2_id, 1),
+        stream_string(vm_2_id, 2),
         par(1, 2),
         stream_string(vm_1_id, 0),
         par(1, 0),
         stream_string(vm_2_id, 1),
-        stream_string(vm_1_id, 0),
+        stream_string(vm_1_id, 1),
         scalar_string(vm_2_id),
     ];
 

--- a/air/tests/test_module/integration/recursive_streams.rs
+++ b/air/tests/test_module/integration/recursive_streams.rs
@@ -59,12 +59,12 @@ fn recursive_stream_with_early_exit() {
     let actual_trace = trace_from_result(&result);
     let expected_state = vec![
         executed_state::stream_number(1, 0),
-        executed_state::stream_number(1, 0),
-        executed_state::fold(vec![executed_state::subtrace_lore(
-            0,
-            SubTraceDesc::new(3, 1),
-            SubTraceDesc::new(4, 0),
-        )]),
+        executed_state::stream_number(1, 1),
+        executed_state::fold(vec![
+            executed_state::subtrace_lore(0, SubTraceDesc::new(3, 1), SubTraceDesc::new(4, 0)),
+            executed_state::subtrace_lore(1, SubTraceDesc::new(4, 1), SubTraceDesc::new(5, 0)),
+        ]),
+        executed_state::scalar_string("stop"),
         executed_state::scalar_string("stop"),
     ];
 
@@ -125,7 +125,7 @@ fn recursive_stream_many_iterations() {
     let actual_trace = trace_from_result(&result);
     let actual_fold = &actual_trace[2];
     let expected_fold = executed_state::fold(vec![
-        executed_state::subtrace_lore(0, SubTraceDesc::new(3, 2), SubTraceDesc::new(7, 0)),
+        executed_state::subtrace_lore(0, SubTraceDesc::new(3, 2), SubTraceDesc::new(5, 0)),
         executed_state::subtrace_lore(1, SubTraceDesc::new(5, 2), SubTraceDesc::new(7, 0)),
         executed_state::subtrace_lore(4, SubTraceDesc::new(7, 2), SubTraceDesc::new(9, 0)),
         executed_state::subtrace_lore(6, SubTraceDesc::new(9, 2), SubTraceDesc::new(11, 0)),


### PR DESCRIPTION
It's was tech debt after inroducing an async VM that streams were considered in previous sync model. It means that it's supposed that AquaVM starts only when `current_data` come. But after async PR, there is one more reason (namely providing service results) to do that. To make fold by stream deterministic especially in case when `next` in `fold` isn't the last state it's necessary to increase stream generation on each AquaVM launch.

This PR fixes this behaviour and makes fold by stream truly deterministic.