### PR TITLE
use Rust 2022-02-24 in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,8 @@ jobs:
           keys:
             - air01-{{ checksum "Cargo.lock" }}
       - run: |
-          rustup toolchain install nightly-2021-07-13-x86_64-unknown-linux-gnu
-          rustup default nightly-2021-07-13-x86_64-unknown-linux-gnu
+          rustup toolchain install nightly-2022-02-24-x86_64-unknown-linux-gnu
+          rustup default nightly-2022-02-24-x86_64-unknown-linux-gnu
 
           rustup target add wasm32-wasi
           rustup component add rustfmt

--- a/.github/workflows/publish_crates.yml
+++ b/.github/workflows/publish_crates.yml
@@ -29,12 +29,12 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2021-07-13
+          toolchain: nightly-2022-02-24
           profile: minimal
           override: true
       - uses: actions-rs/cargo@v1
         with:
-          toolchain: nightly-2021-07-13
+          toolchain: nightly-2022-02-24
           command: update
           args: --aggressive
 

--- a/.github/workflows/publish_interpreter.yml
+++ b/.github/workflows/publish_interpreter.yml
@@ -32,19 +32,19 @@ jobs:
       - name: Install Rust toolchain with wasm32-unknown-unknown
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2021-07-13
+          toolchain: nightly-2022-02-24
           target: wasm32-unknown-unknown
           profile: minimal
           override: true
       - name: Install wasm32-wasi
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2021-07-13
+          toolchain: nightly-2022-02-24
           target: wasm32-wasi
           profile: minimal
       - uses: actions-rs/cargo@v1
         with:
-          toolchain: nightly-2021-07-13
+          toolchain: nightly-2022-02-24
           command: update
           args: --aggressive
 

--- a/.github/workflows/publish_interpreter_dev.yml
+++ b/.github/workflows/publish_interpreter_dev.yml
@@ -41,19 +41,19 @@ jobs:
       - name: Install Rust toolchain with wasm32-unknown-unknown
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2021-07-13
+          toolchain: nightly-2022-02-24
           target: wasm32-unknown-unknown
           profile: minimal
           override: true
       - name: Install wasm32-wasi
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2021-07-13
+          toolchain: nightly-2022-02-24
           target: wasm32-wasi
           profile: minimal
       - uses: actions-rs/cargo@v1
         with:
-          toolchain: nightly-2021-07-13
+          toolchain: nightly-2022-02-24
           command: update
           args: --aggressive
 


### PR DESCRIPTION
`cargo-workspaces` fails to install on `nightly-2021-07-13`, as a result a part of crates can't be published in CI.