### PR TITLE
Use pooled AVMRunner for tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,8 @@ dependencies = [
  "avm-server",
  "fstrings",
  "marine-rs-sdk",
+ "object-pool",
+ "once_cell",
  "serde_json",
 ]
 
@@ -1492,6 +1494,15 @@ checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "object-pool"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee9a3e7196d09ec86002b939f1576e8e446d58def8fd48fe578e2c72d5328d68"
+dependencies = [
+ "parking_lot 0.11.2",
 ]
 
 [[package]]

--- a/air/tests/test_module/features/tetraplets/security_tetraplets/auth_module/Cargo.lock
+++ b/air/tests/test_module/features/tetraplets/security_tetraplets/auth_module/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "air"
-version = "0.21.0"
+version = "0.24.0"
 dependencies = [
  "air-execution-info-collector",
  "air-interpreter-data",
@@ -25,9 +25,11 @@ dependencies = [
  "air-trace-handler",
  "boolinator",
  "concat-idents",
+ "fstrings",
  "log",
  "maplit",
  "marine-rs-sdk",
+ "non-empty-vec",
  "polyplets 0.2.0",
  "serde",
  "serde_json",
@@ -53,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "air-interpreter-interface"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "fluence-it-types",
  "marine-rs-sdk",
@@ -304,6 +306,28 @@ checksum = "5006d09553345421af5dd2334cc945fc34dc2a73d7c1ed842a39a3803699619d"
 dependencies = [
  "it-to-bytes",
  "serde",
+]
+
+[[package]]
+name = "fstrings"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7845a0f15da505ac36baad0486612dab57f8b8d34e19c5470a265bbcdd572ae6"
+dependencies = [
+ "fstrings-proc-macro",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "fstrings-proc-macro"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b58c0e7581dc33478a32299182cbe5ae3b8c028be26728a47fb0a113c92d9d"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -593,6 +617,12 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"

--- a/air/tests/test_module/features/tetraplets/security_tetraplets/log_storage/Cargo.lock
+++ b/air/tests/test_module/features/tetraplets/security_tetraplets/log_storage/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "air"
-version = "0.21.0"
+version = "0.24.0"
 dependencies = [
  "air-execution-info-collector",
  "air-interpreter-data",
@@ -25,9 +25,11 @@ dependencies = [
  "air-trace-handler",
  "boolinator",
  "concat-idents",
+ "fstrings",
  "log",
  "maplit",
  "marine-rs-sdk",
+ "non-empty-vec",
  "polyplets 0.2.0",
  "serde",
  "serde_json",
@@ -53,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "air-interpreter-interface"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "fluence-it-types",
  "marine-rs-sdk",
@@ -296,6 +298,28 @@ checksum = "5006d09553345421af5dd2334cc945fc34dc2a73d7c1ed842a39a3803699619d"
 dependencies = [
  "it-to-bytes",
  "serde",
+]
+
+[[package]]
+name = "fstrings"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7845a0f15da505ac36baad0486612dab57f8b8d34e19c5470a265bbcdd572ae6"
+dependencies = [
+ "fstrings-proc-macro",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "fstrings-proc-macro"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b58c0e7581dc33478a32299182cbe5ae3b8c028be26728a47fb0a113c92d9d"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -593,6 +617,12 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"

--- a/avm/server/src/runner.rs
+++ b/avm/server/src/runner.rs
@@ -110,6 +110,11 @@ impl AVMRunner {
             max_memory_size: stats[0].max_memory_size,
         }
     }
+
+    #[inline]
+    pub fn set_peer_id(&mut self, current_peer_id: impl Into<String>) {
+        self.current_peer_id = current_peer_id.into();
+    }
 }
 
 fn prepare_args(

--- a/crates/air-lib/test-utils/Cargo.toml
+++ b/crates/air-lib/test-utils/Cargo.toml
@@ -20,4 +20,6 @@ avm-server = { path = "../../../avm/server" }
 marine-rs-sdk = "0.6.15"
 
 fstrings = "0.2.3"
+object-pool = "0.5.4"
+once_cell = "1.10.0"
 serde_json = "1.0.61"


### PR DESCRIPTION
Use pooled `avm::server::AVMRunner` instances of
air_iterpreter_server.wasm to reduce tests' running time.  It avoids
repeated WASM loading and compilation.

On my hardware, `cargo test --release` execution time (precompiled)
decreases from almost 6 minutes to 1.5 minutes.