### PR TITLE
Fix Display of `Value::LastError` with a lambda

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,7 @@ dependencies = [
  "lalrpop",
  "lalrpop-util",
  "multimap",
+ "non-empty-vec",
  "regex",
  "serde",
  "serde_json",

--- a/air/tests/test_module/instructions/fail.rs
+++ b/air/tests/test_module/instructions/fail.rs
@@ -59,7 +59,7 @@ fn fail_with_literals() {
     let expected_error = CatchableError::UserError {
         error: rc!(json!( {
         "error_code": 1337i64,
-        "instruction": "fail 1337 error message",
+        "instruction": r#"fail 1337 "error message""#,
         "message": "error message",
         "peer_id": test_params.init_peer_id,
         })),

--- a/crates/air-lib/air-parser/Cargo.toml
+++ b/crates/air-lib/air-parser/Cargo.toml
@@ -33,6 +33,7 @@ thiserror = "1.0.23"
 [dev-dependencies]
 fstrings = "0.2.3"
 criterion = "0.3.3"
+non-empty-vec = { version = "0.2.0" }
 
 [[bench]]
 name = "parser"

--- a/crates/air-lib/air-parser/src/ast/instruction_arguments/traits.rs
+++ b/crates/air-lib/air-parser/src/ast/instruction_arguments/traits.rs
@@ -152,7 +152,7 @@ fn display_last_error(
     last_error_accessor: &Option<LambdaAST>,
 ) -> fmt::Result {
     match last_error_accessor {
-        Some(accessor) => write!(f, "%last_error%.$.{}", air_lambda_ast::format_ast(accessor)),
+        Some(accessor) => write!(f, "%last_error%.${}", air_lambda_ast::format_ast(accessor)),
         None => write!(f, "%last_error%"),
     }
 }

--- a/crates/air-lib/air-parser/src/ast/instructions/traits.rs
+++ b/crates/air-lib/air-parser/src/ast/instructions/traits.rs
@@ -63,7 +63,7 @@ impl fmt::Display for Fail<'_> {
             Fail::Literal {
                 ret_code,
                 error_message,
-            } => write!(f, "fail {} {}", ret_code, error_message),
+            } => write!(f, r#"fail {} "{}""#, ret_code, error_message),
             Fail::LastError => write!(f, "fail %last_error%"),
         }
     }

--- a/crates/air-lib/air-parser/src/ast/tests/instruction_arguments.rs
+++ b/crates/air-lib/air-parser/src/ast/tests/instruction_arguments.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Fluence Labs Limited
+ * Copyright 2022 Fluence Labs Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-mod instruction_arguments;
-mod instructions;
-mod values;
+use crate::ast::Value;
+use air_lambda_ast::ValueAccessor;
+use non_empty_vec::NonEmpty;
 
-#[cfg(test)]
-pub mod tests;
-
-pub use instruction_arguments::*;
-pub use instructions::*;
-pub use values::*;
-
-pub use crate::parser::Span;
+#[test]
+// https://github.com/fluencelabs/aquavm/issues/263
+fn issue_263() {
+    let val = Value::LastError(Some(NonEmpty::new(ValueAccessor::FieldAccessByName {
+        field_name: "message",
+    })));
+    assert_eq!(val.to_string(), "%last_error%.$.message");
+}

--- a/crates/air-lib/air-parser/src/ast/tests/instructions.rs
+++ b/crates/air-lib/air-parser/src/ast/tests/instructions.rs
@@ -14,5 +14,20 @@
  * limitations under the License.
  */
 
-pub mod instruction_arguments;
-pub mod instructions;
+#[test]
+fn display_fail_scalar() {
+    let ast = crate::parse("(fail x)").unwrap();
+    assert_eq!(ast.to_string(), "fail x");
+}
+
+#[test]
+fn display_fail_literal() {
+    let ast = crate::parse(r#"(fail 123 "string")"#).unwrap();
+    assert_eq!(ast.to_string(), r#"fail 123 "string""#);
+}
+
+#[test]
+fn display_fail_last_error() {
+    let ast = crate::parse("(fail %last_error%)").unwrap();
+    assert_eq!(ast.to_string(), "fail %last_error%");
+}

--- a/crates/air-lib/air-parser/src/ast/tests/mod.rs
+++ b/crates/air-lib/air-parser/src/ast/tests/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Fluence Labs Limited
+ * Copyright 2022 Fluence Labs Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,15 +14,4 @@
  * limitations under the License.
  */
 
-mod instruction_arguments;
-mod instructions;
-mod values;
-
-#[cfg(test)]
-pub mod tests;
-
-pub use instruction_arguments::*;
-pub use instructions::*;
-pub use values::*;
-
-pub use crate::parser::Span;
+pub mod instruction_arguments;


### PR DESCRIPTION
There was a small typo in the `fn display_last_error`.

Closes #263