### PR TITLE
Make clippy happier by resolving some warnings

### DIFF
--- a/air/src/execution_step/air/mod.rs
+++ b/air/src/execution_step/air/mod.rs
@@ -94,13 +94,14 @@ impl<'i> ExecutableInstruction<'i> for Instruction<'i> {
 #[macro_export]
 macro_rules! log_instruction {
     ($instr_name:expr, $exec_ctx:expr, $trace_ctx:expr) => {
+        use std::fmt::Write as _;
         log::debug!(target: air_log_targets::INSTRUCTION, "> {}", stringify!($instr_name));
 
         let mut variables = String::from("  scalars:");
-        variables.push_str(&format!("\n    {}", $exec_ctx.scalars));
+        write!(variables, "\n    {}", $exec_ctx.scalars).unwrap();
 
-        variables.push_str("  streams:");
-        variables.push_str(&format!("\n    {}", $exec_ctx.streams));
+        write!(variables, "  streams:").unwrap();
+        write!(variables, "\n    {}", $exec_ctx.streams).unwrap();
 
         log::trace!(target: air_log_targets::DATA_CACHE, "{}", variables);
         log::trace!(

--- a/air/src/execution_step/errors/execution_errors.rs
+++ b/air/src/execution_step/errors/execution_errors.rs
@@ -65,7 +65,7 @@ impl From<CatchableError> for ExecutionError {
 macro_rules! trace_to_exec_err {
     ($trace_expr: expr, $instruction: ident) => {
         $trace_expr.map_err(|trace_error| {
-            crate::execution_step::ExecutionError::Uncatchable(crate::execution_step::UncatchableError::TraceError {
+            $crate::execution_step::ExecutionError::Uncatchable($crate::execution_step::UncatchableError::TraceError {
                 trace_error,
                 instruction: $instruction.to_string(),
             })

--- a/air/src/execution_step/execution_context/last_error/last_error_descriptor.rs
+++ b/air/src/execution_step/execution_context/last_error/last_error_descriptor.rs
@@ -32,7 +32,7 @@ pub(crate) struct LastErrorDescriptor {
     error_can_be_set: bool,
 }
 
-impl<'s> LastErrorDescriptor {
+impl LastErrorDescriptor {
     pub(crate) fn try_to_set_from_error(
         &mut self,
         error: &(impl LastErrorAffectable + ToErrorCode + ToString),

--- a/air/src/execution_step/lambda_applier/mod.rs
+++ b/air/src/execution_step/lambda_applier/mod.rs
@@ -29,8 +29,8 @@ pub(crate) use applier::select_from_stream;
 macro_rules! lambda_to_execution_error {
     ($lambda_expr: expr) => {
         $lambda_expr.map_err(|lambda_error| {
-            crate::execution_step::ExecutionError::Catchable(std::rc::Rc::new(
-                crate::execution_step::CatchableError::LambdaApplierError(lambda_error),
+            $crate::execution_step::ExecutionError::Catchable(std::rc::Rc::new(
+                $crate::execution_step::CatchableError::LambdaApplierError(lambda_error),
             ))
         })
     };


### PR DESCRIPTION
1. Use $crate inside macros.
2. Remove unused lifetime.
3. Use write! instead of String::push_str + format! to reduce allocation.