### PR TITLE
Run tests with sanitizers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ jobs:
           cargo fmt --all -- --check --color always
           cargo check
           cargo test --release
+          # The memory sanitizer on cargo test has false positive even on empty project.
           for san in address leak; do
               RUSTFLAGS="-Z sanitizer=$san" cargo test --features test_with_native_code --target x86_64-unknown-linux-gnu
           done

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,9 @@ jobs:
           cargo fmt --all -- --check --color always
           cargo check
           cargo test --release
+          for san in address leak; do
+              RUSTFLAGS="-Z sanitizer=$san" cargo test --features test_with_native_code --target x86_64-unknown-linux-gnu
+          done
           cargo clippy -v
 
       - save_cache:

--- a/avm/server/src/interface/call_service_result.rs
+++ b/avm/server/src/interface/call_service_result.rs
@@ -48,7 +48,7 @@ impl CallServiceResult {
         }
     }
 
-    pub fn into_raw(self) -> air_interpreter_interface::CallServiceResult {
+    pub(crate) fn into_raw(self) -> air_interpreter_interface::CallServiceResult {
         let CallServiceResult { ret_code, result } = self;
 
         air_interpreter_interface::CallServiceResult {
@@ -58,7 +58,7 @@ impl CallServiceResult {
     }
 }
 
-pub(crate) fn into_raw_result(call_results: CallResults) -> air_interpreter_interface::CallResults {
+pub fn into_raw_result(call_results: CallResults) -> air_interpreter_interface::CallResults {
     call_results
         .into_iter()
         .map(|(call_id, call_result)| (call_id, call_result.into_raw()))

--- a/avm/server/src/interface/call_service_result.rs
+++ b/avm/server/src/interface/call_service_result.rs
@@ -48,7 +48,7 @@ impl CallServiceResult {
         }
     }
 
-    pub(crate) fn into_raw(self) -> air_interpreter_interface::CallServiceResult {
+    pub fn into_raw(self) -> air_interpreter_interface::CallServiceResult {
         let CallServiceResult { ret_code, result } = self;
 
         air_interpreter_interface::CallServiceResult {

--- a/avm/server/src/interface/raw_outcome.rs
+++ b/avm/server/src/interface/raw_outcome.rs
@@ -33,7 +33,7 @@ pub struct RawAVMOutcome {
 }
 
 impl RawAVMOutcome {
-    pub(crate) fn from_interpreter_outcome(outcome: InterpreterOutcome) -> RunnerResult<Self> {
+    pub fn from_interpreter_outcome(outcome: InterpreterOutcome) -> RunnerResult<Self> {
         let InterpreterOutcome {
             ret_code,
             error_message,

--- a/crates/air-lib/test-utils/Cargo.toml
+++ b/crates/air-lib/test-utils/Cargo.toml
@@ -23,3 +23,6 @@ fstrings = "0.2.3"
 object-pool = "0.5.4"
 once_cell = "1.10.0"
 serde_json = "1.0.61"
+
+[features]
+test_with_native_code = []

--- a/crates/air-lib/test-utils/src/lib.rs
+++ b/crates/air-lib/test-utils/src/lib.rs
@@ -29,6 +29,11 @@ pub mod call_services;
 pub mod executed_state;
 pub mod test_runner;
 
+#[cfg(feature = "test_with_native_code")]
+mod native_test_runner;
+#[cfg(not(feature = "test_with_native_code"))]
+mod wasm_test_runner;
+
 pub use air::interpreter_data::*;
 pub use avm_server::raw_outcome::*;
 pub use avm_server::*;

--- a/crates/air-lib/test-utils/src/native_test_runner.rs
+++ b/crates/air-lib/test-utils/src/native_test_runner.rs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+use crate::test_runner::AirRunner;
 use air_interpreter_interface::RunParameters;
 use avm_server::avm_runner::*;
 use avm_server::into_raw_result;
@@ -22,14 +23,14 @@ pub struct NativeAirRunner {
     current_peer_id: String,
 }
 
-impl NativeAirRunner {
-    pub fn new(current_peer_id: impl Into<String>) -> Self {
+impl AirRunner for NativeAirRunner {
+    fn new(current_peer_id: impl Into<String>) -> Self {
         Self {
             current_peer_id: current_peer_id.into(),
         }
     }
 
-    pub fn call(
+    fn call(
         &mut self,
         air: impl Into<String>,
         prev_data: impl Into<Vec<u8>>,

--- a/crates/air-lib/test-utils/src/native_test_runner.rs
+++ b/crates/air-lib/test-utils/src/native_test_runner.rs
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2022 Fluence Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use super::CallServiceClosure;
+use air_interpreter_interface::{CallServiceResult, RunParameters};
+use avm_server::avm_runner::*;
+
+#[derive(Default)]
+pub struct NativeAirRunner {
+    current_peer_id: String,
+}
+
+impl NativeAirRunner {
+    pub fn new(current_peer_id: impl Into<String>) -> Self {
+        Self {
+            current_peer_id: current_peer_id.into(),
+        }
+    }
+
+    pub fn call(
+        &mut self,
+        air: impl Into<String>,
+        prev_data: impl Into<Vec<u8>>,
+        data: impl Into<Vec<u8>>,
+        init_peer_id: impl Into<String>,
+        timestamp: u64,
+        ttl: u32,
+        call_results: avm_server::CallResults,
+    ) -> Result<RawAVMOutcome, Box<dyn std::error::Error>> {
+        // some inner parts transformations
+        let raw_call_results: air_interpreter_interface::CallResults = call_results
+            .into_iter()
+            .map(|(call_id, call_result)| {
+                (
+                    call_id,
+                    CallServiceResult {
+                        ret_code: call_result.ret_code,
+                        result: call_result.result.to_string(),
+                    },
+                )
+            })
+            .collect::<_>();
+        let raw_call_results = serde_json::to_vec(&raw_call_results).unwrap();
+
+        let outcome = air::execute_air(
+            air.into(),
+            prev_data.into(),
+            data.into(),
+            RunParameters {
+                init_peer_id: init_peer_id.into(),
+                current_peer_id: self.current_peer_id.clone(),
+                timestamp,
+                ttl,
+            },
+            raw_call_results,
+        );
+        let outcome = RawAVMOutcome::from_interpreter_outcome(outcome)?;
+
+        Ok(outcome)
+    }
+}
+
+pub struct TestRunner {
+    pub runner: NativeAirRunner,
+    pub call_service: CallServiceClosure,
+}
+
+pub fn create_avm(
+    call_service: CallServiceClosure,
+    current_peer_id: impl Into<String>,
+) -> TestRunner {
+    TestRunner {
+        runner: NativeAirRunner::new(current_peer_id),
+        call_service,
+    }
+}

--- a/crates/air-lib/test-utils/src/native_test_runner.rs
+++ b/crates/air-lib/test-utils/src/native_test_runner.rs
@@ -16,18 +16,8 @@
 
 use air_interpreter_interface::RunParameters;
 use avm_server::avm_runner::*;
+use avm_server::into_raw_result;
 
-// Borrowed from private module in the avm/server/src/interface/call_service_result.rs
-pub(crate) fn into_raw_result(
-    call_results: avm_server::CallResults,
-) -> air_interpreter_interface::CallResults {
-    call_results
-        .into_iter()
-        .map(|(call_id, call_result)| (call_id, call_result.into_raw()))
-        .collect::<_>()
-}
-
-#[derive(Default)]
 pub struct NativeAirRunner {
     current_peer_id: String,
 }

--- a/crates/air-lib/test-utils/src/native_test_runner.rs
+++ b/crates/air-lib/test-utils/src/native_test_runner.rs
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-use super::CallServiceClosure;
 use air_interpreter_interface::RunParameters;
 use avm_server::avm_runner::*;
 
@@ -28,6 +27,7 @@ pub(crate) fn into_raw_result(
         .collect::<_>()
 }
 
+#[derive(Default)]
 pub struct NativeAirRunner {
     current_peer_id: String,
 }
@@ -68,20 +68,5 @@ impl NativeAirRunner {
         let outcome = RawAVMOutcome::from_interpreter_outcome(outcome)?;
 
         Ok(outcome)
-    }
-}
-
-pub struct TestRunner {
-    pub runner: NativeAirRunner,
-    pub call_service: CallServiceClosure,
-}
-
-pub fn create_avm(
-    call_service: CallServiceClosure,
-    current_peer_id: impl Into<String>,
-) -> TestRunner {
-    TestRunner {
-        runner: NativeAirRunner::new(current_peer_id),
-        call_service,
     }
 }

--- a/crates/air-lib/test-utils/src/test_runner.rs
+++ b/crates/air-lib/test-utils/src/test_runner.rs
@@ -15,9 +15,9 @@
  */
 
 #[cfg(feature = "test_with_native_code")]
-use crate::native_test_runner::NativeAirRunner as Runner;
+use crate::native_test_runner::NativeAirRunner as AirRunnerImpl;
 #[cfg(not(feature = "test_with_native_code"))]
-use crate::wasm_test_runner::WasmAirRunner as Runner;
+use crate::wasm_test_runner::WasmAirRunner as AirRunnerImpl;
 
 use super::CallServiceClosure;
 use avm_server::avm_runner::*;
@@ -25,8 +25,23 @@ use avm_server::avm_runner::*;
 use std::collections::HashMap;
 use std::collections::HashSet;
 
-pub struct TestRunner {
-    pub runner: Runner,
+pub trait AirRunner {
+    fn new(current_call_id: impl Into<String>) -> Self;
+
+    fn call(
+        &mut self,
+        air: impl Into<String>,
+        prev_data: impl Into<Vec<u8>>,
+        data: impl Into<Vec<u8>>,
+        init_peer_id: impl Into<String>,
+        timestamp: u64,
+        ttl: u32,
+        call_results: avm_server::CallResults,
+    ) -> Result<RawAVMOutcome, Box<dyn std::error::Error>>;
+}
+
+pub struct TestRunner<R = AirRunnerImpl> {
+    pub runner: R,
     pub call_service: CallServiceClosure,
 }
 
@@ -37,7 +52,7 @@ pub struct TestRunParameters {
     pub ttl: u32,
 }
 
-impl TestRunner {
+impl<R: AirRunner> TestRunner<R> {
     pub fn call(
         &mut self,
         air: impl Into<String>,
@@ -98,7 +113,7 @@ pub fn create_avm(
     call_service: CallServiceClosure,
     current_peer_id: impl Into<String>,
 ) -> TestRunner {
-    let runner = Runner::new(current_peer_id);
+    let runner = AirRunnerImpl::new(current_peer_id);
 
     TestRunner {
         runner,

--- a/crates/air-lib/test-utils/src/test_runner.rs
+++ b/crates/air-lib/test-utils/src/test_runner.rs
@@ -89,8 +89,8 @@ impl NativeAirRunner {
             },
             raw_call_results,
         );
-        let outcome = RawAVMOutcome::from_interpreter_outcome(outcome)
-            .map_err(|e| e.to_string())?;
+        let outcome =
+            RawAVMOutcome::from_interpreter_outcome(outcome).map_err(|e| e.to_string())?;
 
         Ok(outcome)
     }

--- a/crates/air-lib/test-utils/src/test_runner.rs
+++ b/crates/air-lib/test-utils/src/test_runner.rs
@@ -15,22 +15,94 @@
  */
 
 use super::CallServiceClosure;
+#[cfg(feature = "test_with_native_code")]
+use air_interpreter_interface::{CallServiceResult, RunParameters};
 use avm_server::avm_runner::*;
 
+#[cfg(not(feature = "test_with_native_code"))]
 use once_cell::sync::OnceCell;
 use std::collections::HashMap;
 use std::collections::HashSet;
+#[cfg(not(feature = "test_with_native_code"))]
 use std::path::PathBuf;
 
 // 10 Mb
+#[cfg(not(feature = "test_with_native_code"))]
 const AVM_MAX_HEAP_SIZE: u64 = 10 * 1024 * 1024;
+#[cfg(not(feature = "test_with_native_code"))]
 const AIR_WASM_PATH: &str = "../target/wasm32-wasi/debug/air_interpreter_server.wasm";
 
+#[cfg(not(feature = "test_with_native_code"))]
 pub struct TestRunner {
     pub runner: object_pool::Reusable<'static, AVMRunner>,
     pub call_service: CallServiceClosure,
 }
 
+#[cfg(feature = "test_with_native_code")]
+#[derive(Default)]
+pub struct NativeAirRunner {
+    current_peer_id: String,
+}
+
+#[cfg(feature = "test_with_native_code")]
+impl NativeAirRunner {
+    pub fn new(current_peer_id: impl Into<String>) -> Self {
+        Self {
+            current_peer_id: current_peer_id.into(),
+        }
+    }
+
+    pub fn call(
+        &mut self,
+        air: impl Into<String>,
+        prev_data: impl Into<Vec<u8>>,
+        data: impl Into<Vec<u8>>,
+        init_peer_id: impl Into<String>,
+        timestamp: u64,
+        ttl: u32,
+        call_results: avm_server::CallResults,
+    ) -> Result<RawAVMOutcome, String> {
+        // some inner parts transformations
+        let raw_call_results: air_interpreter_interface::CallResults = call_results
+            .into_iter()
+            .map(|(call_id, call_result)| {
+                (
+                    call_id,
+                    CallServiceResult {
+                        ret_code: call_result.ret_code,
+                        result: call_result.result.to_string(),
+                    },
+                )
+            })
+            .collect::<_>();
+        let raw_call_results = serde_json::to_vec(&raw_call_results).unwrap();
+
+        let outcome = air::execute_air(
+            air.into(),
+            prev_data.into(),
+            data.into(),
+            RunParameters {
+                init_peer_id: init_peer_id.into(),
+                current_peer_id: self.current_peer_id.clone(),
+                timestamp,
+                ttl,
+            },
+            raw_call_results,
+        );
+        let outcome = RawAVMOutcome::from_interpreter_outcome(outcome)
+            .map_err(|e| e.to_string())?;
+
+        Ok(outcome)
+    }
+}
+
+#[cfg(feature = "test_with_native_code")]
+pub struct TestRunner {
+    pub runner: NativeAirRunner,
+    pub call_service: CallServiceClosure,
+}
+
+#[cfg(not(feature = "test_with_native_code"))]
 fn make_pooled_avm_runner() -> AVMRunner {
     let fake_current_peer_id = "";
     let logging_mask = i32::MAX;
@@ -73,7 +145,7 @@ impl TestRunner {
         let mut next_peer_pks = HashSet::new();
 
         loop {
-            let mut outcome = self
+            let mut outcome: RawAVMOutcome = self
                 .runner
                 .call(
                     air.clone(),
@@ -108,6 +180,7 @@ impl TestRunner {
     }
 }
 
+#[cfg(not(feature = "test_with_native_code"))]
 pub fn create_avm(
     call_service: CallServiceClosure,
     current_peer_id: impl Into<String>,
@@ -127,6 +200,17 @@ pub fn create_avm(
 
     TestRunner {
         runner,
+        call_service,
+    }
+}
+
+#[cfg(feature = "test_with_native_code")]
+pub fn create_avm(
+    call_service: CallServiceClosure,
+    current_peer_id: impl Into<String>,
+) -> TestRunner {
+    TestRunner {
+        runner: NativeAirRunner::new(current_peer_id),
         call_service,
     }
 }

--- a/crates/air-lib/test-utils/src/test_runner.rs
+++ b/crates/air-lib/test-utils/src/test_runner.rs
@@ -15,14 +15,20 @@
  */
 
 #[cfg(feature = "test_with_native_code")]
-pub use crate::native_test_runner::{create_avm, TestRunner};
+use crate::native_test_runner::NativeAirRunner as Runner;
 #[cfg(not(feature = "test_with_native_code"))]
-pub use crate::wasm_test_runner::{create_avm, TestRunner};
+use crate::wasm_test_runner::WasmAirRunner as Runner;
 
+use super::CallServiceClosure;
 use avm_server::avm_runner::*;
 
 use std::collections::HashMap;
 use std::collections::HashSet;
+
+pub struct TestRunner {
+    pub runner: Runner,
+    pub call_service: CallServiceClosure,
+}
 
 #[derive(Debug, Default, Clone)]
 pub struct TestRunParameters {
@@ -85,6 +91,18 @@ impl TestRunner {
             prev_data = outcome.data;
             data = vec![];
         }
+    }
+}
+
+pub fn create_avm(
+    call_service: CallServiceClosure,
+    current_peer_id: impl Into<String>,
+) -> TestRunner {
+    let runner = Runner::new(current_peer_id);
+
+    TestRunner {
+        runner,
+        call_service,
     }
 }
 

--- a/crates/air-lib/test-utils/src/wasm_test_runner.rs
+++ b/crates/air-lib/test-utils/src/wasm_test_runner.rs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+use crate::test_runner::AirRunner;
 use avm_server::avm_runner::*;
 
 use once_cell::sync::OnceCell;
@@ -38,8 +39,8 @@ fn make_pooled_avm_runner() -> AVMRunner {
     .expect("vm should be created")
 }
 
-impl WasmAirRunner {
-    pub fn new(current_peer_id: impl Into<String>) -> Self {
+impl AirRunner for WasmAirRunner {
+    fn new(current_peer_id: impl Into<String>) -> Self {
         static POOL_CELL: OnceCell<object_pool::Pool<AVMRunner>> = OnceCell::new();
 
         let pool = POOL_CELL.get_or_init(|| {
@@ -56,7 +57,7 @@ impl WasmAirRunner {
         Self(runner)
     }
 
-    pub fn call(
+    fn call(
         &mut self,
         air: impl Into<String>,
         prev_data: impl Into<Vec<u8>>,
@@ -75,9 +76,5 @@ impl WasmAirRunner {
             ttl,
             call_results,
         )?)
-    }
-
-    pub fn set_peer_id(&mut self, peer_id: impl Into<String>) {
-        self.0.set_peer_id(peer_id)
     }
 }

--- a/crates/air-lib/test-utils/src/wasm_test_runner.rs
+++ b/crates/air-lib/test-utils/src/wasm_test_runner.rs
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022 Fluence Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use super::CallServiceClosure;
+use avm_server::avm_runner::*;
+
+use once_cell::sync::OnceCell;
+use std::path::PathBuf;
+
+// 10 Mb
+const AVM_MAX_HEAP_SIZE: u64 = 10 * 1024 * 1024;
+const AIR_WASM_PATH: &str = "../target/wasm32-wasi/debug/air_interpreter_server.wasm";
+
+pub struct TestRunner {
+    pub runner: object_pool::Reusable<'static, AVMRunner>,
+    pub call_service: CallServiceClosure,
+}
+
+fn make_pooled_avm_runner() -> AVMRunner {
+    let fake_current_peer_id = "";
+    let logging_mask = i32::MAX;
+
+    AVMRunner::new(
+        PathBuf::from(AIR_WASM_PATH),
+        fake_current_peer_id,
+        Some(AVM_MAX_HEAP_SIZE),
+        logging_mask,
+    )
+    .expect("vm should be created")
+}
+
+pub fn create_avm(
+    call_service: CallServiceClosure,
+    current_peer_id: impl Into<String>,
+) -> TestRunner {
+    static POOL_CELL: OnceCell<object_pool::Pool<AVMRunner>> = OnceCell::new();
+
+    let pool = POOL_CELL.get_or_init(|| {
+        object_pool::Pool::new(
+            // we create an empty pool and let it fill on demand
+            0,
+            || unreachable!(),
+        )
+    });
+
+    let mut runner = pool.pull(make_pooled_avm_runner);
+    runner.set_peer_id(current_peer_id);
+
+    TestRunner {
+        runner,
+        call_service,
+    }
+}


### PR DESCRIPTION
As sanitizers are not available for WASM yet, AquaVM is run as native code with `--feature test_with_native_code` for these tests.

Closes #247.