### PR TITLE
Get rid of unconditional logging code

### DIFF
--- a/air/src/execution_step/air/mod.rs
+++ b/air/src/execution_step/air/mod.rs
@@ -94,16 +94,17 @@ impl<'i> ExecutableInstruction<'i> for Instruction<'i> {
 #[macro_export]
 macro_rules! log_instruction {
     ($instr_name:expr, $exec_ctx:expr, $trace_ctx:expr) => {
-        use std::fmt::Write as _;
         log::debug!(target: air_log_targets::INSTRUCTION, "> {}", stringify!($instr_name));
 
-        let mut variables = String::from("  scalars:");
-        write!(variables, "\n    {}", $exec_ctx.scalars).unwrap();
-
-        write!(variables, "  streams:").unwrap();
-        write!(variables, "\n    {}", $exec_ctx.streams).unwrap();
-
-        log::trace!(target: air_log_targets::DATA_CACHE, "{}", variables);
+        log::trace!(
+            target: air_log_targets::DATA_CACHE,
+            "  scalars:
+    {}
+  streams:
+    {}",
+            $exec_ctx.scalars,
+            $exec_ctx.streams
+        );
         log::trace!(
             target: air_log_targets::NEXT_PEER_PKS,
             "  next peers pk: {:?}",


### PR DESCRIPTION
The `log_instruction` macro unconditionally pre-formatted some string to
be logged, even if logging is disabled, making whole AquaVM very slow.

After getting it fixed, native execution time dropped from 5sec to
thousands of milliseconds.