### PR TITLE
Add API to save anomaly data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,11 +233,11 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "avm-data-store"
-version = "0.1.0"
+version = "0.2.0"
 
 [[package]]
 name = "avm-server"
-version = "0.20.2"
+version = "0.21.0"
 dependencies = [
  "air-interpreter-interface",
  "avm-data-store",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,6 +234,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "avm-data-store"
 version = "0.2.0"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "avm-server"

--- a/avm/server/Cargo.toml
+++ b/avm/server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "avm-server"
 description = "Fluence AIR VM"
-version = "0.20.2"
+version = "0.21.0"
 authors = ["Fluence Labs"]
 edition = "2018"
 license = "Apache-2.0"
@@ -17,7 +17,7 @@ path = "src/lib.rs"
 
 [dependencies]
 air-interpreter-interface = { version = "0.10.0", path = "../../crates/air-lib/interpreter-interface" }
-avm-data-store = { version = "0.1.0", path = "../../crates/data-store" }
+avm-data-store = { version = "0.2.0", path = "../../crates/data-store" }
 fluence-faas = "0.16.2"
 polyplets = { version = "0.2.0", path = "../../crates/air-lib/polyplets" }
 

--- a/avm/server/src/avm.rs
+++ b/avm/server/src/avm.rs
@@ -108,7 +108,7 @@ impl<E> AVM<E> {
 
         // persist resulted data
         self.data_store.store_data(&outcome.data, particle_id)?;
-        let outcome = AVMOutcome::from_raw_outcome(outcome)?;
+        let outcome = AVMOutcome::from_raw_outcome(outcome, memory_delta, execution_time)?;
 
         Ok(outcome)
     }

--- a/avm/server/src/avm.rs
+++ b/avm/server/src/avm.rs
@@ -139,7 +139,13 @@ impl<E> AVM<E> {
             serde_json::to_vec(avm_outcome).map_err(AVMError::AnomalyDataSeError)?;
 
         self.data_store
-            .collect_anomaly_data(&ser_particle, &prev_data, &current_data, &ser_avm_outcome)
+            .collect_anomaly_data(
+                &particle_parameters.particle_id,
+                &ser_particle,
+                &prev_data,
+                &current_data,
+                &ser_avm_outcome,
+            )
             .map_err(Into::into)
     }
 }

--- a/avm/server/src/avm.rs
+++ b/avm/server/src/avm.rs
@@ -86,7 +86,7 @@ impl<E> AVM<E> {
         let current_data = data.into();
 
         let execution_start_time = Instant::now();
-        let memory_size_before = self.runner.memory_stats().memory_size;
+        let memory_size_before = self.memory_stats().memory_size;
         let outcome = self
             .runner
             .call(
@@ -101,7 +101,7 @@ impl<E> AVM<E> {
             .map_err(AVMError::RunnerError)?;
 
         let execution_time = execution_start_time.elapsed();
-        let memory_delta = self.runner.memory_stats().memory_size - memory_size_before;
+        let memory_delta = self.memory_stats().memory_size - memory_size_before;
         if self.data_store.detect_anomaly(execution_time, memory_delta) {
             self.save_anomaly_data(&current_data, &particle_parameters, &outcome)?;
         }

--- a/avm/server/src/errors.rs
+++ b/avm/server/src/errors.rs
@@ -38,6 +38,10 @@ pub enum AVMError<E> {
     /// This errors are encountered from a data store object.
     #[error(transparent)]
     DataStoreError(#[from] E),
+
+    /// This errors are encountered from a data store object.
+    #[error(transparent)]
+    AnomalyDataSeError(SerdeError),
 }
 
 #[derive(Debug, ThisError)]

--- a/avm/server/src/errors.rs
+++ b/avm/server/src/errors.rs
@@ -39,7 +39,7 @@ pub enum AVMError<E> {
     #[error(transparent)]
     DataStoreError(#[from] E),
 
-    /// This errors are encountered from a data store object.
+    /// This errors are encountered from serialization of data tracked during an anomaly.
     #[error(transparent)]
     AnomalyDataSeError(SerdeError),
 }

--- a/avm/server/src/interface/outcome.rs
+++ b/avm/server/src/interface/outcome.rs
@@ -39,8 +39,8 @@ pub struct AVMOutcome {
     /// Memory in bytes AVM linear heap was extended during execution by.
     pub memory_delta: usize,
 
-    /// Time of particle execution
-    /// (it count only execution time without operations with DataStore and so on)
+    /// Time of a particle execution
+    /// (it counts only execution time without operations with DataStore and so on)
     pub execution_time: Duration,
 }
 

--- a/avm/server/src/interface/particle_parameters.rs
+++ b/avm/server/src/interface/particle_parameters.rs
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 
+use serde::Deserialize;
+use serde::Serialize;
 use std::borrow::Cow;
 
 /// Represents parameters obtained from a particle.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ParticleParameters<'init_peer_id, 'particle_id> {
     pub init_peer_id: Cow<'init_peer_id, String>,
     pub particle_id: Cow<'particle_id, String>,

--- a/avm/server/src/lib.rs
+++ b/avm/server/src/lib.rs
@@ -54,7 +54,7 @@ pub use polyplets::SecurityTetraplet;
 
 pub use avm_data_store::DataStore;
 
-pub type AVMDataStore<E> = Box<dyn DataStore<E> + Send + Sync + 'static>;
+pub type AVMDataStore<E> = Box<dyn DataStore<Error = E> + Send + Sync + 'static>;
 
 pub type AVMResult<T, E> = std::result::Result<T, AVMError<E>>;
 

--- a/avm/server/src/lib.rs
+++ b/avm/server/src/lib.rs
@@ -52,6 +52,7 @@ pub use fluence_faas::IValue;
 
 pub use polyplets::SecurityTetraplet;
 
+pub use avm_data_store::AnomalyData;
 pub use avm_data_store::DataStore;
 
 pub type AVMDataStore<E> = Box<dyn DataStore<Error = E> + Send + Sync + 'static>;

--- a/crates/data-store/Cargo.toml
+++ b/crates/data-store/Cargo.toml
@@ -14,3 +14,6 @@ categories = ["wasm"]
 [lib]
 name = "avm_data_store"
 path = "src/lib.rs"
+
+[dependencies]
+serde = "1.0"

--- a/crates/data-store/Cargo.toml
+++ b/crates/data-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avm-data-store"
-version = "0.1.0"
+version = "0.2.0"
 description = "Definition of the AVM DataStore trait"
 authors = ["Fluence Labs"]
 edition = "2018"

--- a/crates/data-store/src/lib.rs
+++ b/crates/data-store/src/lib.rs
@@ -28,16 +28,21 @@ pub trait DataStore {
 
     fn read_data(&mut self, key: &str) -> Result<Vec<u8>, Self::Error>;
 
+    /// Cleanup data that become obsolete.
     fn cleanup_data(&mut self, key: &str) -> Result<(), Self::Error>;
 
-    fn should_collect_data(&self, execution_time: Duration) -> bool;
+    /// Returns true if an anomaly happened and it's necessary to save execution data
+    /// for debugging purposes.
+    ///  execution_time - is a time taken by the interpreter to execute provided script
+    ///  memory_delta - is a count of bytes on which an interpreter heap has been extended
+    ///                 during execution of a particle
+    fn detect_anomaly(&self, execution_time: Duration, memory_delta: usize) -> bool;
 
-    // TODO: consider collecting not only new data, but an entire RawAVMOutcome
-    fn collect_data(
+    fn collect_anomaly_data(
         &mut self,
-        particle_id: &str,
+        particle: &[u8], // it's byte because of the restriction on trait objects methods
         prev_data: &[u8],
         current_data: &[u8],
-        new_data: &[u8],
+        avm_outcome: &[u8], // it's byte because of the restriction on trait objects methods
     ) -> Result<(), Self::Error>;
 }

--- a/crates/data-store/src/lib.rs
+++ b/crates/data-store/src/lib.rs
@@ -33,13 +33,14 @@ pub trait DataStore {
 
     /// Returns true if an anomaly happened and it's necessary to save execution data
     /// for debugging purposes.
-    ///  execution_time - is a time taken by the interpreter to execute provided script
+    ///  execution_time - is time taken by the interpreter to execute provided script
     ///  memory_delta - is a count of bytes on which an interpreter heap has been extended
     ///                 during execution of a particle
     fn detect_anomaly(&self, execution_time: Duration, memory_delta: usize) -> bool;
 
     fn collect_anomaly_data(
         &mut self,
+        particle_id: &str,
         particle: &[u8], // it's byte because of the restriction on trait objects methods
         prev_data: &[u8],
         current_data: &[u8],

--- a/crates/data-store/src/lib.rs
+++ b/crates/data-store/src/lib.rs
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+use serde::Deserialize;
+use serde::Serialize;
 use std::time::Duration;
 
 /// This trait is used for
@@ -40,10 +42,37 @@ pub trait DataStore {
 
     fn collect_anomaly_data(
         &mut self,
-        particle_id: &str,
-        particle: &[u8], // it's byte because of the restriction on trait objects methods
-        prev_data: &[u8],
-        current_data: &[u8],
-        avm_outcome: &[u8], // it's byte because of the restriction on trait objects methods
+        key: &str,
+        anomaly_data: AnomalyData<'_>,
     ) -> Result<(), Self::Error>;
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct AnomalyData<'data> {
+    pub particle: &'data [u8], // it's byte because of the restriction on trait objects methods
+    pub prev_data: &'data [u8],
+    pub current_data: &'data [u8],
+    pub avm_outcome: &'data [u8], // it's byte because of the restriction on trait objects methods
+    pub execution_time: Duration,
+    pub memory_delta: usize,
+}
+
+impl<'data> AnomalyData<'data> {
+    pub fn new(
+        particle: &'data [u8],
+        prev_data: &'data [u8],
+        current_data: &'data [u8],
+        avm_outcome: &'data [u8],
+        execution_time: Duration,
+        memory_delta: usize,
+    ) -> Self {
+        Self {
+            particle,
+            prev_data,
+            current_data,
+            avm_outcome,
+            execution_time,
+            memory_delta,
+        }
+    }
 }


### PR DESCRIPTION
This PR adds two new methods in `DataStore` to determine anomaly and collect necessary data. Additionally
  - a generic parameter of `DataStore` turned to be associative
  - `AVMOutcome` contains additionally `memory_delta` and `execution_time`