### PR TITLE
Fix rustdoc generation

### DIFF
--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -22,7 +22,8 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          # fix version until https://github.com/rust-lang/rust/issues/99261 is resolved
+          toolchain: nightly-2022-07-13
           profile: minimal
           override: true
           components: rustfmt, rust-src


### PR DESCRIPTION
It fails because of rust-lang/rust#99261 at nightly-2022-07-14.
Enforce nightly-2022-07-13.