### PR TITLE
Bump `marine-runtime` to `0.20.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,7 +288,7 @@ dependencies = [
 
 [[package]]
 name = "avm-interface"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "air-interpreter-interface",
  "air-utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,7 +313,7 @@ dependencies = [
  "eyre",
  "log",
  "maplit",
- "marine-runtime",
+ "marine-runtime 0.20.0",
  "parking_lot 0.11.2",
  "polyplets",
  "serde",
@@ -923,7 +923,7 @@ dependencies = [
  "log",
  "maplit",
  "marine-min-it-version",
- "marine-runtime",
+ "marine-runtime 0.18.1",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1495,6 +1495,35 @@ name = "marine-runtime"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7ed0ecac893ecc26c925cbe00c6a1eb8ac9f8d9e60ebc9c0bd390fba08617f2"
+dependencies = [
+ "bytesize",
+ "cmd_lib",
+ "it-json-serde",
+ "itertools 0.9.0",
+ "log",
+ "marine-core",
+ "marine-module-interface",
+ "marine-rs-sdk",
+ "marine-rs-sdk-main",
+ "marine-utils",
+ "safe-transmute",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with",
+ "thiserror",
+ "toml",
+ "wasmer-interface-types-fl",
+ "wasmer-runtime-core-fl",
+ "wasmer-runtime-fl",
+ "wasmer-wasi-fl",
+]
+
+[[package]]
+name = "marine-runtime"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24f103b4f74e7cb5cf5c5d4b7d4d73e128c96e84c86074e0fa34ca2b8450e075"
 dependencies = [
  "bytesize",
  "cmd_lib",

--- a/avm/interface/Cargo.toml
+++ b/avm/interface/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "avm-interface"
 description = "Fluence AIR VM interfacing"
-version = "0.25.0"
+version = "0.26.0"
 authors = ["Fluence Labs"]
 edition = "2018"
 license = "Apache-2.0"

--- a/avm/server/Cargo.toml
+++ b/avm/server/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/lib.rs"
 air-interpreter-interface = { version = "0.11.0", path = "../../crates/air-lib/interpreter-interface" }
 air-utils = { version = "0.1.0", path = "../../crates/air-lib/utils" }
 avm-data-store = { version = "0.4.0", path = "../../crates/data-store" }
-marine-runtime = "0.18.0"
+marine-runtime = "0.20.0"
 polyplets = { version = "0.3.0", path = "../../crates/air-lib/polyplets" }
 avm-interface = { version = "0.25.0", path = "../../avm/interface" }
 

--- a/avm/server/Cargo.toml
+++ b/avm/server/Cargo.toml
@@ -21,7 +21,7 @@ air-utils = { version = "0.1.0", path = "../../crates/air-lib/utils" }
 avm-data-store = { version = "0.4.0", path = "../../crates/data-store" }
 marine-runtime = "0.20.0"
 polyplets = { version = "0.3.0", path = "../../crates/air-lib/polyplets" }
-avm-interface = { version = "0.25.0", path = "../../avm/interface" }
+avm-interface = { version = "0.26.0", path = "../../avm/interface" }
 
 eyre = "0.6.5"
 thiserror = "1.0.29"

--- a/avm/server/src/runner.rs
+++ b/avm/server/src/runner.rs
@@ -259,6 +259,7 @@ fn make_marine_config(
     MarineConfig {
         modules_dir: Some(air_wasm_dir),
         modules_config: vec![ModuleDescriptor {
+            load_from: None,
             file_name: String::from(air_wasm_file),
             import_name: String::from(air_wasm_file),
             config: air_module_config,


### PR DESCRIPTION
Needed for marine e2e to be able to build avm-server using marine-runtime from master.