### PR TITLE
bump wasm-bindgen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,7 +46,6 @@ dependencies = [
  "strum_macros",
  "thiserror",
  "tracing",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2685,23 +2684,23 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.65"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3edbcc9536ab7eababcc6d2374a0b7bfe13a2b6d562c5e07f370456b1a8f33d"
+checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.65"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ed2fb8c84bfad20ea66b26a3743f3e7ba8735a69fe7d95118c33ec8fc1244d"
+checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
 dependencies = [
  "bumpalo",
- "lazy_static",
  "log",
+ "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -2710,9 +2709,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.65"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb071268b031a64d92fc6cf691715ca5a40950694d8f683c5bb43db7c730929e"
+checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2720,9 +2719,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.65"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf592c807080719d1ff2f245a687cbadb3ed28b2077ed7084b47aba8b691f2c6"
+checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2733,9 +2732,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.65"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b6c0220ded549d63860c78c38f3bcc558d1ca3f4efa74942c536ddbbb55e87"
+checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
 
 [[package]]
 name = "wasmer-clif-backend-fl"

--- a/air-interpreter/Cargo.toml
+++ b/air-interpreter/Cargo.toml
@@ -24,8 +24,7 @@ air-log-targets = { path = "../crates/air-lib/log-targets" }
 
 marine-rs-sdk = { version = "0.7.0", features = ["logger"] }
 
-# Keep 0.2.65 until this is resolved https://github.com/rustwasm/wasm-pack/issues/886
-wasm-bindgen = "=0.2.65"
+wasm-bindgen = "=0.2.82"
 
 log = "0.4.11"
 serde = { version = "1.0.118", features = [ "derive", "rc" ] }

--- a/air/Cargo.toml
+++ b/air/Cargo.toml
@@ -40,9 +40,6 @@ strum = "0.21"
 strum_macros = "0.21"
 tracing = "0.1.35"
 
-# Keep 0.2.65 until this is resolved https://github.com/rustwasm/wasm-pack/issues/886
-wasm-bindgen = "=0.2.65"
-
 [dev_dependencies]
 air-test-utils = { path = "../crates/air-lib/test-utils" }
 air-testing-framework = { path = "../crates/testing-framework" }


### PR DESCRIPTION
Bump `wasm-bindgen` crate version in order to merge #309. Also unused `wasm-bingen` from the main `air` crate was removed.