### PR TITLE
Use rust-toolchain to setup rust

### DIFF
--- a/.github/workflows/air_tag_release.yml
+++ b/.github/workflows/air_tag_release.yml
@@ -6,7 +6,7 @@ on:
       - "v*"
 
 env:
-  CARGO_HOME: "/usr/local/cargo"
+  CARGO_HOME: "./cargo"
 
 jobs:
   pre-release:

--- a/.github/workflows/air_tag_release.yml
+++ b/.github/workflows/air_tag_release.yml
@@ -28,7 +28,7 @@ jobs:
         working-directory: ./air-interpreter
         run: marine build --release --features marine
 
-      - run: Release
+      - name: Release
         uses: marvinpinto/action-automatic-releases@latest
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/air_tag_release.yml
+++ b/.github/workflows/air_tag_release.yml
@@ -5,43 +5,31 @@ on:
     tags:
       - "v*"
 
+env:
+  CARGO_HOME: "/usr/local/cargo"
+
 jobs:
   pre-release:
     name: "Tagged Release"
-    runs-on: "ubuntu-latest"
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          target: wasm32-wasi
-          profile: minimal
-          override: true
+      - name: Setup rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
-      - name: Install marine
-        uses: actions-rs/cargo@v1
-        with:
-          toolchain: nightly
-          command: install
-          args: marine
+      - run: cargo install marine
 
-    ### Update & build
-      - uses: actions-rs/cargo@v1
-        with:
-          toolchain: nightly
-          command: update
+      - run: cargo update
 
       - name: marine build --release
         working-directory: ./air-interpreter
-        shell: bash
         run: marine build --release --features marine
 
-    ### Create release
-      - uses: marvinpinto/action-automatic-releases@latest
+      - run: Release
+        uses: marvinpinto/action-automatic-releases@latest
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: "latest"

--- a/.github/workflows/air_tag_release.yml
+++ b/.github/workflows/air_tag_release.yml
@@ -5,9 +5,6 @@ on:
     tags:
       - "v*"
 
-env:
-  CARGO_HOME: "./cargo"
-
 jobs:
   pre-release:
     name: "Tagged Release"

--- a/.github/workflows/aquavm.yml
+++ b/.github/workflows/aquavm.yml
@@ -22,24 +22,23 @@ jobs:
       - name: Setup rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
-      - name: "Download marine"
-        run: .github/download_marine.sh
+      - run: cargo install marine
 
-      - name: "Build Wasm binary for interpreter"
+      - name: Build Wasm binary for interpreter
         run: marine build --features marine
         working-directory: air-interpreter
 
-      - name: "Build Wasm binary for tests"
+      - name: Build Wasm binary for tests
         run: ./build_test_binaries.sh
         working-directory: air/tests/test_module
 
-      - name: "cargo fmt"
+      - name: Run cargo fmt
         run: cargo fmt --all -- --check
 
-      - name: "cargo check"
+      - name: Run cargo check
         run: cargo check
 
-      - name: "cargo test"
+      - name: Run cargo test
         run: |
           cargo test --release
           # Check that it does compile
@@ -49,5 +48,5 @@ jobs:
               RUSTFLAGS="-Z sanitizer=$san" cargo test --features test_with_native_code --target x86_64-unknown-linux-gnu
           done
 
-      - name: "cargo clippy"
+      - name: Run cargo clippy
         run: cargo clippy -v

--- a/.github/workflows/aquavm.yml
+++ b/.github/workflows/aquavm.yml
@@ -9,7 +9,7 @@ concurrency:
 
 env:
   RUST_TEST_THREADS: 1
-  CARGO_HOME: "/usr/local/cargo"
+  CARGO_HOME: "./cargo"
 
 jobs:
   aquavm:

--- a/.github/workflows/aquavm.yml
+++ b/.github/workflows/aquavm.yml
@@ -9,7 +9,7 @@ concurrency:
 
 env:
   RUST_TEST_THREADS: 1
-  CARGO_HOME: "./cargo"
+  CARGO_HOME: "${{ github.workspace }}/cargo"
 
 jobs:
   aquavm:

--- a/.github/workflows/aquavm.yml
+++ b/.github/workflows/aquavm.yml
@@ -7,27 +7,20 @@ concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: true
 
-jobs:
-  air:
-    name: "Run aquavm tests"
-    runs-on: builder
+env:
+  RUST_TEST_THREADS: 1
+  CARGO_HOME: "/usr/local/cargo"
 
-    env:
-      RUST_BACKTRACE: 1
-      RUST_TEST_THREADS: 1
-      CARGO_TERM_COLOR: always
+jobs:
+  aquavm:
+    name: "Run tests"
+    runs-on: builder
 
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly-2022-06-29
-          target: wasm32-wasi
-          components: rustfmt, clippy
-
-      - name: "Cache rust"
-        uses: Swatinem/rust-cache@v1
+      - name: Setup rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: "Download marine"
         run: .github/download_marine.sh

--- a/.github/workflows/publish_crates.yml
+++ b/.github/workflows/publish_crates.yml
@@ -5,43 +5,24 @@ on:
     branches:
       - "master"
 
+env:
+  CARGO_HOME: "/usr/local/cargo"
+
 jobs:
   cargo-publish:
     name: "Publish crates"
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      ### Prepare cargo & toolchains
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            ~/.cargo/bin
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly-2022-03-20
-          profile: minimal
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          toolchain: nightly-2022-03-20
-          command: update
-          args: --aggressive
+      - name: Setup rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Install cargo-workspaces
-        run: cargo install cargo-workspaces || true
+        run: cargo install cargo-workspaces
 
-      ### === Rust package release ===
       - name: Login to crates.io
         run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
 

--- a/.github/workflows/publish_crates.yml
+++ b/.github/workflows/publish_crates.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - "master"
 
-env:
-  CARGO_HOME: "./cargo"
-
 jobs:
   cargo-publish:
     name: "Publish crates"

--- a/.github/workflows/publish_crates.yml
+++ b/.github/workflows/publish_crates.yml
@@ -6,7 +6,7 @@ on:
       - "master"
 
 env:
-  CARGO_HOME: "/usr/local/cargo"
+  CARGO_HOME: "./cargo"
 
 jobs:
   cargo-publish:

--- a/.github/workflows/publish_interpreter.yml
+++ b/.github/workflows/publish_interpreter.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - "master"
 
+env:
+  CARGO_HOME: "/usr/local/cargo"
+
 jobs:
   npm-publish:
     name: "Publish AIR to NPM & crates.io"

--- a/.github/workflows/publish_interpreter.yml
+++ b/.github/workflows/publish_interpreter.yml
@@ -8,9 +8,6 @@ on:
     branches:
       - "master"
 
-env:
-  CARGO_HOME: "./cargo"
-
 jobs:
   npm-publish:
     name: "Publish AIR to NPM & crates.io"

--- a/.github/workflows/publish_interpreter.yml
+++ b/.github/workflows/publish_interpreter.yml
@@ -9,7 +9,7 @@ on:
       - "master"
 
 env:
-  CARGO_HOME: "/usr/local/cargo"
+  CARGO_HOME: "./cargo"
 
 jobs:
   npm-publish:

--- a/.github/workflows/publish_interpreter.yml
+++ b/.github/workflows/publish_interpreter.yml
@@ -12,48 +12,21 @@ jobs:
   npm-publish:
     name: "Publish AIR to NPM & crates.io"
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      ### Prepare cargo & toolchains
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            ~/.cargo/bin
-            target
-          key: ${{ runner.os }}-cargo-v2-${{ hashFiles('**/Cargo.lock') }}
-      - name: Install Rust toolchain with wasm32-unknown-unknown
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly-2022-03-20
-          target: wasm32-unknown-unknown
-          profile: minimal
-          override: true
-      - name: Install wasm32-wasi
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly-2022-03-20
-          target: wasm32-wasi
-          profile: minimal
-      - uses: actions-rs/cargo@v1
-        with:
-          toolchain: nightly-2022-03-20
-          command: update
-          args: --aggressive
+      - name: Setup rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
-      ### Calculate FINAL_VERSION
+      - run: cargo update --aggressive
+
       - name: Install jq & sponge
         run: sudo apt-get update && sudo apt-get --yes --force-yes install jq moreutils
 
       - name: Install cargo-show toml-cli
-        run: cargo install cargo-show toml-cli || true
+        run: cargo install cargo-show toml-cli
 
       - name: Get versions from npm & crates.io, and take the highest one
         run: |
@@ -97,13 +70,11 @@ jobs:
           echo "FINAL_VERSION=$MAX_VERSION" | tee -a $GITHUB_ENV
           echo "JS_PKG_NAME=$JS_PKG_NAME" | tee -a $GITHUB_ENV
 
-      ### === Rust package release ===
       - name: Install marine
-        run: cargo install marine || true
+        run: cargo install marine
 
       - name: Set interpreter version to ${{ env.FINAL_VERSION }} before the build
         run: |
-          PATH="~/.cargo/bin:$PATH"
           (
             cd air-interpreter
             toml set Cargo.toml package.version "${{ env.FINAL_VERSION }}" | sponge Cargo.toml
@@ -121,9 +92,7 @@ jobs:
         run: cp target/wasm32-wasi/release/air_interpreter_server.wasm crates/interpreter-wasm/air_interpreter_server.wasm
 
       - name: Set project version to ${{ env.FINAL_VERSION }}
-        run: |
-          PATH="~/.cargo/bin:$PATH"
-          toml set Cargo.toml package.version "${{ env.FINAL_VERSION }}" | sponge Cargo.toml
+        run: toml set Cargo.toml package.version "${{ env.FINAL_VERSION }}" | sponge Cargo.toml
         working-directory: crates/interpreter-wasm
 
       - name: Login to crates.io
@@ -133,7 +102,6 @@ jobs:
         run: cargo publish --allow-dirty
         working-directory: crates/interpreter-wasm
 
-      ### Create a pre-release
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -148,7 +116,6 @@ jobs:
           draft: false
           prerelease: false
 
-      ### === JavaScript package release ===
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
         continue-on-error: true
@@ -160,18 +127,18 @@ jobs:
           npm i
           npm run build
 
-      ### Set version
       - name: Set version to ${{ env.FINAL_VERSION }}
         run: yarn version --new-version ${{ env.FINAL_VERSION }} --no-git-tag-version
         working-directory: avm/client
 
-      ### Publish to NPM registry
-      - uses: actions/setup-node@v1
+      - name: Setup node
+        uses: actions/setup-node@v1
         with:
           node-version: "14"
           registry-url: "https://registry.npmjs.org"
 
-      - run: npm publish --access public
-        working-directory: avm/client
+      - name: Publish to npm registry
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public
+        working-directory: avm/client

--- a/.github/workflows/publish_interpreter_dev.yml
+++ b/.github/workflows/publish_interpreter_dev.yml
@@ -6,18 +6,18 @@ name: "publish-interpreter-branch"
 on:
   push:
     branches-ignore:
-      - master
+      - "master"
+
+env:
+  RUST_TEST_THREADS: 1
+  CARGO_HOME: "/usr/local/cargo"
 
 jobs:
   npm-publish-dev:
     name: "Publish AIR interpreter .wasm to NPM & crates.io"
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
 
     steps:
-      ### Extract branch name
       - name: Extract branch name
         if: github.event_name != 'pull_request'
         run: echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_ENV
@@ -30,39 +30,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      ### Prepare cargo & toolchains
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            ~/.cargo/bin
-          key: ${{ runner.os }}-cargo-v2-${{ hashFiles('**/Cargo.lock') }}
-      - name: Install Rust toolchain with wasm32-unknown-unknown
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly-2022-03-20
-          target: wasm32-unknown-unknown
-          profile: minimal
-          override: true
-      - name: Install wasm32-wasi
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly-2022-03-20
-          target: wasm32-wasi
-          profile: minimal
-      - uses: actions-rs/cargo@v1
-        with:
-          toolchain: nightly-2022-03-20
-          command: update
-          args: --aggressive
+      - name: Setup rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
-      ### Calculate FINAL_VERSION
+      - run: cargo update --aggressive
+
       - name: Install jq & sponge
         run: sudo apt-get update && sudo apt-get --yes --force-yes install jq moreutils
 
       - name: Install cargo-show & toml-cli
-        run: cargo install cargo-show toml-cli || true
+        run: cargo install cargo-show toml-cli
 
       - name: Get versions from npm & crates.io, and take the highest one
         run: |
@@ -121,13 +98,11 @@ jobs:
           echo "PKG_NAME=$PKG_NAME" | tee -a $GITHUB_ENV
           echo "JS_PKG_NAME=$JS_PKG_NAME" | tee -a $GITHUB_ENV
 
-      ### === Rust package release ===
       - name: Install marine
-        run: cargo install marine || true
+        run: cargo install marine
 
       - name: Set interpreter version to ${{ env.FINAL_VERSION }} before the build
         run: |
-          PATH="~/.cargo/bin:$PATH"
           (
             cd air-interpreter
             toml set Cargo.toml package.version "${{ env.FINAL_VERSION }}" | sponge Cargo.toml
@@ -146,7 +121,6 @@ jobs:
 
       - name: Set project name@version to ${{ env.PKG_NAME }}@${{ env.FINAL_VERSION }}
         run: |
-          PATH="~/.cargo/bin:$PATH"
           toml set Cargo.toml package.version "${{ env.FINAL_VERSION }}" | sponge Cargo.toml
 
           NAME=$(toml get Cargo.toml package.name | jq -r .)
@@ -160,7 +134,6 @@ jobs:
         run: cargo publish --allow-dirty
         working-directory: crates/interpreter-wasm
 
-      ### === JavaScript package release ===
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
         continue-on-error: true
@@ -172,17 +145,18 @@ jobs:
           npm i
           npm run build
 
-      ### Set version to FINAL_VERSION
-      - run: yarn version --new-version ${{ env.FINAL_VERSION }} --no-git-tag-version || true
+      - name: Set version to ${{ env.FINAL_VERSION }}
+        run: yarn version --new-version ${{ env.FINAL_VERSION }} --no-git-tag-version || true
         working-directory: avm/client
 
-      ### Publish to NPM registry
-      - uses: actions/setup-node@v1
+      - name: Setup node
+        uses: actions/setup-node@v1
         with:
           node-version: "14"
           registry-url: "https://registry.npmjs.org"
 
-      - run: npm publish --access public --tag=beta
-        working-directory: avm/client
+      - name: Publish to npm registry
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public --tag=beta
+        working-directory: avm/client

--- a/.github/workflows/publish_interpreter_dev.yml
+++ b/.github/workflows/publish_interpreter_dev.yml
@@ -8,9 +8,6 @@ on:
     branches-ignore:
       - "master"
 
-env:
-  CARGO_HOME: "./cargo"
-
 jobs:
   npm-publish-dev:
     name: "Publish AIR interpreter .wasm to NPM & crates.io"

--- a/.github/workflows/publish_interpreter_dev.yml
+++ b/.github/workflows/publish_interpreter_dev.yml
@@ -9,7 +9,7 @@ on:
       - "master"
 
 env:
-  CARGO_HOME: "/usr/local/cargo"
+  CARGO_HOME: "./cargo"
 
 jobs:
   npm-publish-dev:

--- a/.github/workflows/publish_interpreter_dev.yml
+++ b/.github/workflows/publish_interpreter_dev.yml
@@ -9,7 +9,6 @@ on:
       - "master"
 
 env:
-  RUST_TEST_THREADS: 1
   CARGO_HOME: "/usr/local/cargo"
 
 jobs:

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -10,6 +10,7 @@ env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   RUSTUP_MAX_RETRIES: 10
+  CARGO_HOME: "/usr/local/cargo"
 
 jobs:
   rustdoc:

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -2,13 +2,13 @@ name: rustdoc
 on:
   push:
     branches:
-      - master
+      - "master"
+
   workflow_dispatch:
 
 env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
-  RUSTFLAGS: ""
   RUSTUP_MAX_RETRIES: 10
 
 jobs:
@@ -19,16 +19,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+      - name: Setup rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: nightly
-          profile: minimal
-          override: true
           components: rustfmt, rust-src
 
       - name: Build Documentation
-        run: RUSTDOCFLAGS="--enable-index-page -Zunstable-options" cargo +nightly doc --all --no-deps
+        env:
+          RUSTDOCFLAGS: "--enable-index-page -Zunstable-options"
+        run: cargo +nightly doc --all --no-deps
 
       - name: Deploy Docs
         uses: peaceiris/actions-gh-pages@v3.7.3

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -10,7 +10,6 @@ env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   RUSTUP_MAX_RETRIES: 10
-  CARGO_HOME: "./cargo"
 
 jobs:
   rustdoc:

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -10,7 +10,7 @@ env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   RUSTUP_MAX_RETRIES: 10
-  CARGO_HOME: "/usr/local/cargo"
+  CARGO_HOME: "./cargo"
 
 jobs:
   rustdoc:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ version = "0.1.0"
 dependencies = [
  "air-beautifier",
  "anyhow",
- "clap 3.2.20",
+ "clap 3.2.16",
 ]
 
 [[package]]
@@ -198,7 +198,7 @@ dependencies = [
  "anyhow",
  "avm-data-store",
  "avm-interface",
- "clap 3.2.20",
+ "clap 3.2.16",
  "itertools 0.10.3",
  "serde",
  "serde_json",
@@ -234,9 +234,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.64"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9a8f622bcf6ff3df478e9deba3e03e4e04b300f8e6a139e192c05fa3490afc7"
+checksum = "c794e162a5eff65c72ef524dfe393eb923c354e350bb78b9c7383df13f3bc142"
 
 [[package]]
 name = "arrayref"
@@ -313,7 +313,7 @@ dependencies = [
  "log",
  "maplit",
  "marine-runtime 0.20.0",
- "parking_lot 0.12.1",
+ "parking_lot 0.11.2",
  "polyplets",
  "serde",
  "serde_json",
@@ -419,6 +419,15 @@ dependencies = [
 
 [[package]]
 name = "cast"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
+dependencies = [
+ "rustc_version 0.4.0",
+]
+
+[[package]]
+name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
@@ -468,9 +477,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.20"
+version = "3.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b71c3ce99b7611011217b366d923f1d0a7e07a92bb2dbf1e84508c673ca3bd"
+checksum = "a3dbbb6653e7c55cc8595ad3e1f7be8f32aba4eb7ff7f0fd1163d4f3d137c0a9"
 dependencies = [
  "atty",
  "bitflags",
@@ -485,9 +494,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.2.18"
+version = "3.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "9ba52acd3b0a5c33aeada5cdaa3267cdc7c594a98731d4268cdc1532f4264cb4"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -617,12 +626,12 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.3.6"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b01d6de93b2b6c65e17c634a26653a29d107b3c98c607c765bf38d041531cd8f"
+checksum = "ab327ed7354547cc2ef43cbe20ef68b988e70b4b593cbd66a2a61733123a3d23"
 dependencies = [
  "atty",
- "cast",
+ "cast 0.2.7",
  "clap 2.34.0",
  "criterion-plot",
  "csv",
@@ -647,7 +656,7 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876"
 dependencies = [
- "cast",
+ "cast 0.3.0",
  "itertools 0.10.3",
 ]
 
@@ -1207,9 +1216,9 @@ checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
 name = "js-sys"
-version = "0.3.59"
+version = "0.3.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
+checksum = "52732a3d3ad72c58ad2dc70624f9c17b46ecd0943b9a4f1ee37c4c18c5d983e2"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1712,9 +1721,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.14.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "oorandom"
@@ -1874,9 +1883,9 @@ checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "plotters"
-version = "0.3.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2538b639e642295546c50fcd545198c9d64ee2a38620a628724a3b266d5fbf97"
+checksum = "45ca0ae5f169d0917a7c7f5a9c1a3d3d9598f18f529dd2b8373ed988efea307a"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -2000,7 +2009,7 @@ checksum = "beb71f708fe39b2c5e98076204c3cc094ee5a4c12c4cdb119a2b72dc34164f41"
 dependencies = [
  "bitflags",
  "cc",
- "rustc_version",
+ "rustc_version 0.2.3",
 ]
 
 [[package]]
@@ -2089,6 +2098,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver 1.0.13",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2165,9 +2183,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.144"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
+checksum = "e590c437916fb6b221e1d00df6e3294f3fccd70ca7e92541c475d6ed6ef5fee2"
 dependencies = [
  "serde_derive",
 ]
@@ -2203,9 +2221,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.144"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
+checksum = "34b5b8d809babe02f538c2cfec6f2c1ed10804c0e5a6a041a049a4f5588ccc2e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2214,9 +2232,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.85"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
+checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
 dependencies = [
  "itoa 1.0.3",
  "ryu",
@@ -2293,23 +2311,22 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
-version = "0.24.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+checksum = "aaf86bbcfd1fa9670b7a129f64fc0c9fcbbfe4f1bc4210e9e98fe71ffc12cde2"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.24.3"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+checksum = "d06aaeeee809dbc59eb4556183dd927df67db1540de5be8d3ec0b6636358a5ec"
 dependencies = [
- "heck 0.4.0",
+ "heck 0.3.3",
  "proc-macro2",
  "quote",
- "rustversion",
  "syn",
 ]
 
@@ -2373,18 +2390,18 @@ checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
-version = "1.0.34"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1b05ca9d106ba7d2e31a9dab4a64e7be2cce415321966ea3132c49a656e252"
+checksum = "f5f6586b7f764adc0231f4c79be7b920e766bb2f3e51b3661cdb263828f19994"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.34"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8f2591983642de85c921015f3f070c665a197ed69e417af436115e3a1407487"
+checksum = "12bafc5b54507e0149cdf1b145a5d80ab80a90bcd9275df43d4fff68460f6c21"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2810,7 +2827,7 @@ dependencies = [
  "nix",
  "page_size",
  "parking_lot 0.10.2",
- "rustc_version",
+ "rustc_version 0.2.3",
  "serde",
  "serde-bench",
  "serde_bytes",
@@ -2839,7 +2856,7 @@ dependencies = [
  "nix",
  "page_size",
  "parking_lot 0.10.2",
- "rustc_version",
+ "rustc_version 0.2.3",
  "serde",
  "serde-bench",
  "serde_bytes",
@@ -2919,9 +2936,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.59"
+version = "0.3.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed055ab27f941423197eb86b2035720b1a3ce40504df082cac2ecc6ed73335a1"
+checksum = "8be2398f326b7ba09815d0b403095f34dd708579220d099caae89be0b32137b2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ version = "0.1.0"
 dependencies = [
  "air-beautifier",
  "anyhow",
- "clap 3.2.16",
+ "clap 3.2.20",
 ]
 
 [[package]]
@@ -198,7 +198,7 @@ dependencies = [
  "anyhow",
  "avm-data-store",
  "avm-interface",
- "clap 3.2.16",
+ "clap 3.2.20",
  "itertools 0.10.3",
  "serde",
  "serde_json",
@@ -234,9 +234,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.60"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c794e162a5eff65c72ef524dfe393eb923c354e350bb78b9c7383df13f3bc142"
+checksum = "b9a8f622bcf6ff3df478e9deba3e03e4e04b300f8e6a139e192c05fa3490afc7"
 
 [[package]]
 name = "arrayref"
@@ -313,7 +313,7 @@ dependencies = [
  "log",
  "maplit",
  "marine-runtime 0.20.0",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.1",
  "polyplets",
  "serde",
  "serde_json",
@@ -419,15 +419,6 @@ dependencies = [
 
 [[package]]
 name = "cast"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
-dependencies = [
- "rustc_version 0.4.0",
-]
-
-[[package]]
-name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
@@ -477,9 +468,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.16"
+version = "3.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3dbbb6653e7c55cc8595ad3e1f7be8f32aba4eb7ff7f0fd1163d4f3d137c0a9"
+checksum = "23b71c3ce99b7611011217b366d923f1d0a7e07a92bb2dbf1e84508c673ca3bd"
 dependencies = [
  "atty",
  "bitflags",
@@ -494,9 +485,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.2.15"
+version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba52acd3b0a5c33aeada5cdaa3267cdc7c594a98731d4268cdc1532f4264cb4"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -626,12 +617,12 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.3.4"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab327ed7354547cc2ef43cbe20ef68b988e70b4b593cbd66a2a61733123a3d23"
+checksum = "b01d6de93b2b6c65e17c634a26653a29d107b3c98c607c765bf38d041531cd8f"
 dependencies = [
  "atty",
- "cast 0.2.7",
+ "cast",
  "clap 2.34.0",
  "criterion-plot",
  "csv",
@@ -656,7 +647,7 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876"
 dependencies = [
- "cast 0.3.0",
+ "cast",
  "itertools 0.10.3",
 ]
 
@@ -1216,9 +1207,9 @@ checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
 name = "js-sys"
-version = "0.3.42"
+version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52732a3d3ad72c58ad2dc70624f9c17b46ecd0943b9a4f1ee37c4c18c5d983e2"
+checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1721,9 +1712,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
 
 [[package]]
 name = "oorandom"
@@ -1883,9 +1874,9 @@ checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "plotters"
-version = "0.3.0"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ca0ae5f169d0917a7c7f5a9c1a3d3d9598f18f529dd2b8373ed988efea307a"
+checksum = "2538b639e642295546c50fcd545198c9d64ee2a38620a628724a3b266d5fbf97"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -2009,7 +2000,7 @@ checksum = "beb71f708fe39b2c5e98076204c3cc094ee5a4c12c4cdb119a2b72dc34164f41"
 dependencies = [
  "bitflags",
  "cc",
- "rustc_version 0.2.3",
+ "rustc_version",
 ]
 
 [[package]]
@@ -2098,15 +2089,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver 1.0.13",
-]
-
-[[package]]
 name = "rustversion"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2183,9 +2165,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.142"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e590c437916fb6b221e1d00df6e3294f3fccd70ca7e92541c475d6ed6ef5fee2"
+checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
 dependencies = [
  "serde_derive",
 ]
@@ -2221,9 +2203,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.142"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34b5b8d809babe02f538c2cfec6f2c1ed10804c0e5a6a041a049a4f5588ccc2e"
+checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2232,9 +2214,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.83"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
+checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
 dependencies = [
  "itoa 1.0.3",
  "ryu",
@@ -2311,22 +2293,23 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
-version = "0.21.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf86bbcfd1fa9670b7a129f64fc0c9fcbbfe4f1bc4210e9e98fe71ffc12cde2"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.21.1"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d06aaeeee809dbc59eb4556183dd927df67db1540de5be8d3ec0b6636358a5ec"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
- "heck 0.3.3",
+ "heck 0.4.0",
  "proc-macro2",
  "quote",
+ "rustversion",
  "syn",
 ]
 
@@ -2390,18 +2373,18 @@ checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
-version = "1.0.32"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5f6586b7f764adc0231f4c79be7b920e766bb2f3e51b3661cdb263828f19994"
+checksum = "8c1b05ca9d106ba7d2e31a9dab4a64e7be2cce415321966ea3132c49a656e252"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.32"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bafc5b54507e0149cdf1b145a5d80ab80a90bcd9275df43d4fff68460f6c21"
+checksum = "e8f2591983642de85c921015f3f070c665a197ed69e417af436115e3a1407487"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2827,7 +2810,7 @@ dependencies = [
  "nix",
  "page_size",
  "parking_lot 0.10.2",
- "rustc_version 0.2.3",
+ "rustc_version",
  "serde",
  "serde-bench",
  "serde_bytes",
@@ -2856,7 +2839,7 @@ dependencies = [
  "nix",
  "page_size",
  "parking_lot 0.10.2",
- "rustc_version 0.2.3",
+ "rustc_version",
  "serde",
  "serde-bench",
  "serde_bytes",
@@ -2936,9 +2919,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.42"
+version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be2398f326b7ba09815d0b403095f34dd708579220d099caae89be0b32137b2"
+checksum = "ed055ab27f941423197eb86b2035720b1a3ce40504df082cac2ecc6ed73335a1"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/crates/data-store/src/lib.rs
+++ b/crates/data-store/src/lib.rs
@@ -164,7 +164,7 @@ mod tests {
             &avm_outcome[..],
         );
 
-        let anomaly: AnomalyData =
+        let anomaly: AnomalyData<'_> =
             serde_json::from_str(&json_data).expect("deserialize JSON anomaly data");
 
         assert_eq!(

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # AquaVM can be built with "stable", "nightly" required only to build Marine tests
 channel = "nightly"
 components = [ "rustfmt", "clippy" ]
-targets = [ "x86_64-unknown-linux-gnu", "wasm32-wasi" ]
+targets = [ "x86_64-unknown-linux-gnu", "x86_64-apple-darwin", "wasm32-wasi" ]
 profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "stable"
+components = [ "rustfmt", "clippy" ]
+targets = [ "x86_64-unknown-linux-gnu", "wasm32-wasi" ]
+profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,5 @@
 [toolchain]
+# AquaVM can be built with "stable", "nightly" required only to build Marine tests
 channel = "nightly"
 components = [ "rustfmt", "clippy" ]
 targets = [ "x86_64-unknown-linux-gnu", "wasm32-wasi" ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "stable"
+channel = "nightly"
 components = [ "rustfmt", "clippy" ]
 targets = [ "x86_64-unknown-linux-gnu", "wasm32-wasi" ]
 profile = "minimal"


### PR DESCRIPTION
- Added `rust-toolchain.toml` file so rust toolchain is the same when running rust locally and with CI.
No need to specify channel or components in github workflow file now.


- Changed `Setup rust toolchain` step to use different action. Old one is not maintained anymore. Beware that it sets these env variables by default:
    ```
    CARGO_INCREMENTAL=0
    CARGO_PROFILE_DEV_DEBUG=0
    CARGO_TERM_COLOR=always
    RUST_BACKTRACE=short
    RUSTFLAGS=-D warnings
    ```