### PR TITLE
Fix canon positions

### DIFF
--- a/air/src/execution_step/air/ap/apply_to_arguments.rs
+++ b/air/src/execution_step/air/ap/apply_to_arguments.rs
@@ -38,7 +38,7 @@ pub(super) fn apply_to_arg(
         Boolean(value) => apply_const(*value, exec_ctx, trace_ctx),
         EmptyArray => apply_const(serde_json::json!([]), exec_ctx, trace_ctx),
         Scalar(scalar) => apply_scalar(scalar, exec_ctx, trace_ctx, should_touch_trace)?,
-        CanonStream(canon_stream) => apply_canon_stream(canon_stream, exec_ctx)?,
+        CanonStream(canon_stream) => apply_canon_stream(canon_stream, exec_ctx, trace_ctx)?,
     };
 
     Ok(result)
@@ -121,10 +121,11 @@ fn apply_scalar_wl_impl(
 fn apply_canon_stream(
     canon_stream: &ast::CanonStreamWithLambda<'_>,
     exec_ctx: &ExecutionCtx<'_>,
+    trace_ctx: &TraceHandler,
 ) -> ExecutionResult<ValueAggregate> {
     match &canon_stream.lambda {
-        Some(lambda) => apply_canon_stream_with_lambda(canon_stream.name, lambda, exec_ctx),
-        None => apply_canon_stream_without_lambda(canon_stream.name, exec_ctx),
+        Some(lambda) => apply_canon_stream_with_lambda(canon_stream.name, lambda, exec_ctx, trace_ctx),
+        None => apply_canon_stream_without_lambda(canon_stream.name, exec_ctx, trace_ctx),
     }
 }
 
@@ -132,31 +133,31 @@ fn apply_canon_stream_with_lambda(
     stream_name: &str,
     lambda: &LambdaAST<'_>,
     exec_ctx: &ExecutionCtx<'_>,
+    trace_ctx: &TraceHandler,
 ) -> ExecutionResult<ValueAggregate> {
+    // TODO: refactor this code after boxed value
     use crate::execution_step::boxed_value::JValuable;
 
     let canon_stream = exec_ctx.scalars.get_canon_stream(stream_name)?;
     let (result, tetraplet) = JValuable::apply_lambda_with_tetraplets(&canon_stream, lambda, exec_ctx)?;
-    // TODO: refactor this code after boxed value
-    let value = ValueAggregate::new(
-        Rc::new(result.into_owned()),
-        Rc::new(tetraplet),
-        canon_stream.position(),
-    );
+    let position = trace_ctx.trace_pos();
+
+    let value = ValueAggregate::new(Rc::new(result.into_owned()), Rc::new(tetraplet), position);
     Ok(value)
 }
 
 fn apply_canon_stream_without_lambda(
     stream_name: &str,
     exec_ctx: &ExecutionCtx<'_>,
+    trace_ctx: &TraceHandler,
 ) -> ExecutionResult<ValueAggregate> {
     use crate::execution_step::boxed_value::JValuable;
 
     let canon_stream = exec_ctx.scalars.get_canon_stream(stream_name)?;
     // TODO: refactor this code after boxed value
     let value = JValuable::as_jvalue(&canon_stream).into_owned();
-
     let tetraplet = canon_stream.tetraplet().clone();
-    let value = ValueAggregate::new(Rc::new(value), tetraplet, canon_stream.position());
+    let position = trace_ctx.trace_pos();
+    let value = ValueAggregate::new(Rc::new(value), tetraplet, position);
     Ok(value)
 }

--- a/air/src/execution_step/air/canon.rs
+++ b/air/src/execution_step/air/canon.rs
@@ -112,7 +112,7 @@ fn create_canon_stream_from_pos(
         .collect::<Result<Vec<_>, _>>()?;
 
     let peer_id = crate::execution_step::air::resolve_to_string(&ast_canon.peer_pk, exec_ctx)?;
-    let canon_stream = CanonStream::new(values, peer_id, ast_canon.stream.position.into());
+    let canon_stream = CanonStream::new(values, peer_id);
     Ok(canon_stream)
 }
 
@@ -153,7 +153,8 @@ fn create_canon_stream_from_name(
                 ast_canon.stream.name.to_string(),
             )))
         })?;
-    let canon_stream = CanonStream::from_stream(stream, peer_id, ast_canon.canon_stream.position.into());
+
+    let canon_stream = CanonStream::from_stream(stream, peer_id);
     let stream_elements_pos = stream
         .iter(Generation::Last)
         // it's always safe to iter over all generations

--- a/air/src/execution_step/boxed_value/canon_stream.rs
+++ b/air/src/execution_step/boxed_value/canon_stream.rs
@@ -19,7 +19,6 @@ use super::ValueAggregate;
 use crate::execution_step::Generation;
 use crate::JValue;
 
-use air_interpreter_data::TracePos;
 use polyplets::SecurityTetraplet;
 
 use std::rc::Rc;
@@ -31,28 +30,25 @@ pub struct CanonStream {
     values: Vec<ValueAggregate>,
     // tetraplet is needed to handle adding canon streams as a whole to a stream
     tetraplet: Rc<SecurityTetraplet>,
-    position: TracePos,
 }
 
 impl CanonStream {
-    pub(crate) fn new(values: Vec<ValueAggregate>, peer_pk: String, position: TracePos) -> Self {
+    pub(crate) fn new(values: Vec<ValueAggregate>, peer_pk: String) -> Self {
         // tetraplet is comprised only from peer_pk here
         let tetraplet = SecurityTetraplet::new(peer_pk, "", "", "");
         Self {
             values,
             tetraplet: Rc::new(tetraplet),
-            position,
         }
     }
 
-    pub(crate) fn from_stream(stream: &Stream, peer_pk: String, position: TracePos) -> Self {
+    pub(crate) fn from_stream(stream: &Stream, peer_pk: String) -> Self {
         // it's always possible to iter over all generations of a stream
         let values = stream.iter(Generation::Last).unwrap().cloned().collect::<Vec<_>>();
         let tetraplet = SecurityTetraplet::new(peer_pk, "", "", "");
         Self {
             values,
             tetraplet: Rc::new(tetraplet),
-            position,
         }
     }
 
@@ -82,10 +78,6 @@ impl CanonStream {
 
     pub(crate) fn tetraplet(&self) -> &Rc<SecurityTetraplet> {
         &self.tetraplet
-    }
-
-    pub(crate) fn position(&self) -> TracePos {
-        self.position
     }
 }
 

--- a/air/tests/test_module/issues/issue_331.rs
+++ b/air/tests/test_module/issues/issue_331.rs
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 Fluence Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use air_interpreter_interface::INTERPRETER_SUCCESS;
+use air_test_utils::prelude::*;
+
+#[test]
+// test for github.com/fluencelabs/aquavm/issues/331
+fn issue_331() {
+    let peer_id_1 = "peer_id_1";
+    let mut peer_vm_1 = create_avm(set_variable_call_service(json!("")), peer_id_1);
+
+    let script = f!(r#"
+        (new $array-inline
+            (seq
+                (seq
+                    (seq
+                        (seq
+                            (call %init_peer_id% ("op" "array_length") [$status] array_length)
+                            (ap array_length $array-inline)
+                        )
+                        (seq
+                            (ap 2 $num)
+                            (canon %init_peer_id% $num #num_canon)
+                        )
+                    )
+                    (ap #num_canon.$.[0]! $array-inline)
+                )
+                (canon %init_peer_id% $array-inline #array-inline-0)
+           )
+        )
+    "#);
+
+    let parameters = TestRunParameters::new(peer_id_1, 1, 1);
+    let result = call_vm!(peer_vm_1, parameters, &script, "", "");
+    assert_eq!(result.ret_code, INTERPRETER_SUCCESS);
+}

--- a/air/tests/test_module/issues/mod.rs
+++ b/air/tests/test_module/issues/mod.rs
@@ -30,3 +30,4 @@ mod issue_295;
 mod issue_300;
 mod issue_304;
 mod issue_306;
+mod issue_331;

--- a/crates/air-lib/test-utils/src/test_runner.rs
+++ b/crates/air-lib/test-utils/src/test_runner.rs
@@ -22,6 +22,7 @@ use crate::wasm_test_runner::WasmAirRunner as AirRunnerImpl;
 use super::CallServiceClosure;
 use avm_server::avm_runner::*;
 
+use crate::print_trace;
 use std::collections::HashMap;
 use std::collections::HashSet;
 
@@ -87,6 +88,7 @@ impl<R: AirRunner> TestRunner<R> {
                     call_results,
                 )
                 .map_err(|e| e.to_string())?;
+            print_trace(&outcome, "");
 
             next_peer_pks.extend(outcome.next_peer_pks);
 

--- a/crates/air-lib/test-utils/src/test_runner.rs
+++ b/crates/air-lib/test-utils/src/test_runner.rs
@@ -22,7 +22,6 @@ use crate::wasm_test_runner::WasmAirRunner as AirRunnerImpl;
 use super::CallServiceClosure;
 use avm_server::avm_runner::*;
 
-use crate::print_trace;
 use std::collections::HashMap;
 use std::collections::HashSet;
 
@@ -88,7 +87,6 @@ impl<R: AirRunner> TestRunner<R> {
                     call_results,
                 )
                 .map_err(|e| e.to_string())?;
-            print_trace(&outcome, "");
 
             next_peer_pks.extend(outcome.next_peer_pks);
 


### PR DESCRIPTION
This PR changes scheme how positions in `ap` are assigned for values constructed from canonicalized streams.

Resolves #331.