### PR TITLE
refactor(parser): use `AirPos` type for AIR script position

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,6 +90,7 @@ dependencies = [
 name = "air-interpreter-data"
 version = "0.3.0"
 dependencies = [
+ "air-parser",
  "air-utils",
  "once_cell",
  "semver 1.0.14",

--- a/air/src/execution_step/air/new.rs
+++ b/air/src/execution_step/air/new.rs
@@ -66,9 +66,7 @@ fn epilog<'i>(new: &New<'i>, exec_ctx: &mut ExecutionCtx<'i>) -> ExecutionResult
     let position = new.span.left;
     match &new.argument {
         NewArgument::Stream(stream) => {
-            exec_ctx
-                .streams
-                .meet_scope_end(stream.name.to_string(), position as u32);
+            exec_ctx.streams.meet_scope_end(stream.name.to_string(), position);
             Ok(())
         }
         NewArgument::Scalar(scalar) => exec_ctx.scalars.meet_new_end_scalar(scalar.name),

--- a/air/src/execution_step/boxed_value/variable.rs
+++ b/air/src/execution_step/boxed_value/variable.rs
@@ -15,7 +15,7 @@
  */
 
 use super::Generation;
-use air_parser::ast;
+use air_parser::{ast, TextPos};
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum Variable<'i> {
@@ -25,7 +25,7 @@ pub(crate) enum Variable<'i> {
     Stream {
         name: &'i str,
         generation: Generation,
-        position: usize,
+        position: TextPos,
     },
     CanonStream {
         name: &'i str,
@@ -37,7 +37,7 @@ impl<'i> Variable<'i> {
         Self::Scalar { name }
     }
 
-    pub(crate) fn stream(name: &'i str, generation: Generation, position: usize) -> Self {
+    pub(crate) fn stream(name: &'i str, generation: Generation, position: TextPos) -> Self {
         Self::Stream {
             name,
             generation,

--- a/air/src/execution_step/boxed_value/variable.rs
+++ b/air/src/execution_step/boxed_value/variable.rs
@@ -15,7 +15,7 @@
  */
 
 use super::Generation;
-use air_parser::{ast, TextPos};
+use air_parser::{ast, AirPos};
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum Variable<'i> {
@@ -25,7 +25,7 @@ pub(crate) enum Variable<'i> {
     Stream {
         name: &'i str,
         generation: Generation,
-        position: TextPos,
+        position: AirPos,
     },
     CanonStream {
         name: &'i str,
@@ -37,7 +37,7 @@ impl<'i> Variable<'i> {
         Self::Scalar { name }
     }
 
-    pub(crate) fn stream(name: &'i str, generation: Generation, position: TextPos) -> Self {
+    pub(crate) fn stream(name: &'i str, generation: Generation, position: AirPos) -> Self {
         Self::Stream {
             name,
             generation,

--- a/air/src/execution_step/execution_context/streams_variables.rs
+++ b/air/src/execution_step/execution_context/streams_variables.rs
@@ -21,7 +21,7 @@ use crate::execution_step::ValueAggregate;
 
 use air_interpreter_data::GlobalStreamGens;
 use air_interpreter_data::RestrictedStreamGens;
-use air_parser::TextPos;
+use air_parser::AirPos;
 
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::collections::HashMap;
@@ -67,13 +67,13 @@ impl Streams {
         }
     }
 
-    pub(crate) fn get(&self, name: &str, position: TextPos) -> Option<&Stream> {
+    pub(crate) fn get(&self, name: &str, position: AirPos) -> Option<&Stream> {
         self.streams
             .get(name)
             .and_then(|descriptors| find_closest(descriptors.iter(), position))
     }
 
-    pub(crate) fn get_mut(&mut self, name: &str, position: TextPos) -> Option<&mut Stream> {
+    pub(crate) fn get_mut(&mut self, name: &str, position: AirPos) -> Option<&mut Stream> {
         self.streams
             .get_mut(name)
             .and_then(|descriptors| find_closest_mut(descriptors.iter_mut(), position))
@@ -84,7 +84,7 @@ impl Streams {
         value: ValueAggregate,
         generation: Generation,
         stream_name: &str,
-        position: TextPos,
+        position: AirPos,
     ) -> ExecutionResult<u32> {
         match self.get_mut(stream_name, position) {
             Some(stream) => stream.add_value(value, generation),
@@ -123,7 +123,7 @@ impl Streams {
         }
     }
 
-    pub(crate) fn meet_scope_end(&mut self, name: String, position: TextPos) {
+    pub(crate) fn meet_scope_end(&mut self, name: String, position: AirPos) {
         // unwraps are safe here because met_scope_end must be called after met_scope_start
         let stream_descriptors = self.streams.get_mut(&name).unwrap();
         // delete a stream after exit from a scope
@@ -156,14 +156,14 @@ impl Streams {
         (global_streams, self.collected_restricted_stream_gens)
     }
 
-    fn stream_generation_from_data(&self, name: &str, position: TextPos, iteration: usize) -> Option<u32> {
+    fn stream_generation_from_data(&self, name: &str, position: AirPos, iteration: usize) -> Option<u32> {
         self.data_restricted_stream_gens
             .get(name)
             .and_then(|scopes| scopes.get(&position).and_then(|iterations| iterations.get(iteration)))
             .copied()
     }
 
-    fn collect_stream_generation(&mut self, name: String, position: TextPos, generation: u32) {
+    fn collect_stream_generation(&mut self, name: String, position: AirPos, generation: u32) {
         match self.collected_restricted_stream_gens.entry(name) {
             Occupied(mut streams) => match streams.get_mut().entry(position) {
                 Occupied(mut iterations) => iterations.get_mut().push(generation),
@@ -196,7 +196,7 @@ impl StreamDescriptor {
 
 fn find_closest<'d>(
     descriptors: impl DoubleEndedIterator<Item = &'d StreamDescriptor>,
-    position: TextPos,
+    position: AirPos,
 ) -> Option<&'d Stream> {
     // descriptors are placed in a order of decreasing scopes, so it's enough to get the latest suitable
     for descriptor in descriptors.rev() {
@@ -210,7 +210,7 @@ fn find_closest<'d>(
 
 fn find_closest_mut<'d>(
     descriptors: impl DoubleEndedIterator<Item = &'d mut StreamDescriptor>,
-    position: TextPos,
+    position: AirPos,
 ) -> Option<&'d mut Stream> {
     // descriptors are placed in a order of decreasing scopes, so it's enough to get the latest suitable
     for descriptor in descriptors.rev() {

--- a/air/src/execution_step/execution_context/streams_variables.rs
+++ b/air/src/execution_step/execution_context/streams_variables.rs
@@ -21,6 +21,7 @@ use crate::execution_step::ValueAggregate;
 
 use air_interpreter_data::GlobalStreamGens;
 use air_interpreter_data::RestrictedStreamGens;
+use air_parser::TextPos;
 
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::collections::HashMap;
@@ -66,13 +67,13 @@ impl Streams {
         }
     }
 
-    pub(crate) fn get(&self, name: &str, position: usize) -> Option<&Stream> {
+    pub(crate) fn get(&self, name: &str, position: TextPos) -> Option<&Stream> {
         self.streams
             .get(name)
             .and_then(|descriptors| find_closest(descriptors.iter(), position))
     }
 
-    pub(crate) fn get_mut(&mut self, name: &str, position: usize) -> Option<&mut Stream> {
+    pub(crate) fn get_mut(&mut self, name: &str, position: TextPos) -> Option<&mut Stream> {
         self.streams
             .get_mut(name)
             .and_then(|descriptors| find_closest_mut(descriptors.iter_mut(), position))
@@ -83,7 +84,7 @@ impl Streams {
         value: ValueAggregate,
         generation: Generation,
         stream_name: &str,
-        position: usize,
+        position: TextPos,
     ) -> ExecutionResult<u32> {
         match self.get_mut(stream_name, position) {
             Some(stream) => stream.add_value(value, generation),
@@ -107,7 +108,7 @@ impl Streams {
     pub(crate) fn meet_scope_start(&mut self, name: impl Into<String>, span: Span, iteration: u32) {
         let name = name.into();
         let generations_count = self
-            .stream_generation_from_data(&name, span.left as u32, iteration as usize)
+            .stream_generation_from_data(&name, span.left, iteration as usize)
             .unwrap_or_default();
 
         let new_stream = Stream::from_generations_count(generations_count as usize);
@@ -122,7 +123,7 @@ impl Streams {
         }
     }
 
-    pub(crate) fn meet_scope_end(&mut self, name: String, position: u32) {
+    pub(crate) fn meet_scope_end(&mut self, name: String, position: TextPos) {
         // unwraps are safe here because met_scope_end must be called after met_scope_start
         let stream_descriptors = self.streams.get_mut(&name).unwrap();
         // delete a stream after exit from a scope
@@ -155,14 +156,14 @@ impl Streams {
         (global_streams, self.collected_restricted_stream_gens)
     }
 
-    fn stream_generation_from_data(&self, name: &str, position: u32, iteration: usize) -> Option<u32> {
+    fn stream_generation_from_data(&self, name: &str, position: TextPos, iteration: usize) -> Option<u32> {
         self.data_restricted_stream_gens
             .get(name)
             .and_then(|scopes| scopes.get(&position).and_then(|iterations| iterations.get(iteration)))
             .copied()
     }
 
-    fn collect_stream_generation(&mut self, name: String, position: u32, generation: u32) {
+    fn collect_stream_generation(&mut self, name: String, position: TextPos, generation: u32) {
         match self.collected_restricted_stream_gens.entry(name) {
             Occupied(mut streams) => match streams.get_mut().entry(position) {
                 Occupied(mut iterations) => iterations.get_mut().push(generation),
@@ -183,7 +184,7 @@ impl Streams {
 impl StreamDescriptor {
     pub(self) fn global(stream: Stream) -> Self {
         Self {
-            span: Span::new(0, usize::MAX),
+            span: Span::new(0.into(), usize::MAX.into()),
             stream,
         }
     }
@@ -195,7 +196,7 @@ impl StreamDescriptor {
 
 fn find_closest<'d>(
     descriptors: impl DoubleEndedIterator<Item = &'d StreamDescriptor>,
-    position: usize,
+    position: TextPos,
 ) -> Option<&'d Stream> {
     // descriptors are placed in a order of decreasing scopes, so it's enough to get the latest suitable
     for descriptor in descriptors.rev() {
@@ -209,7 +210,7 @@ fn find_closest<'d>(
 
 fn find_closest_mut<'d>(
     descriptors: impl DoubleEndedIterator<Item = &'d mut StreamDescriptor>,
-    position: usize,
+    position: TextPos,
 ) -> Option<&'d mut Stream> {
     // descriptors are placed in a order of decreasing scopes, so it's enough to get the latest suitable
     for descriptor in descriptors.rev() {

--- a/air/tests/test_module/instructions/new.rs
+++ b/air/tests/test_module/instructions/new.rs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+use air_parser::TextPos;
 use air_test_utils::prelude::*;
 
 #[test]
@@ -90,7 +91,7 @@ fn new_with_global_streams_seq() {
     let actual_restricted_streams = data.restricted_streams;
     let expected_restricted_streams = maplit::hashmap! {
         "$stream".to_string() => maplit::hashmap! {
-            282 => vec![1,1]
+            TextPos::from(282) => vec![1,1]
         }
     };
     assert_eq!(actual_restricted_streams, expected_restricted_streams);
@@ -217,7 +218,7 @@ fn new_in_fold_with_ap() {
     let actual_restricted_streams = data.restricted_streams;
     let expected_restricted_streams = maplit::hashmap! {
         "$s1".to_string() => maplit::hashmap! {
-            146 => vec![1,1,1,1,1]
+            TextPos::from(146) => vec![1,1,1,1,1]
         }
     };
     assert_eq!(actual_restricted_streams, expected_restricted_streams);
@@ -263,10 +264,10 @@ fn new_with_streams_with_errors() {
     let actual_restricted_streams = data.restricted_streams;
     let expected_restricted_streams = maplit::hashmap! {
         "$restricted_stream_2".to_string() => maplit::hashmap! {
-            216 => vec![1]
+            TextPos::from(216) => vec![1]
         },
         "$restricted_stream_1".to_string() => maplit::hashmap! {
-            141 => vec![0]
+            TextPos::from(141) => vec![0]
         }
     };
     assert_eq!(actual_restricted_streams, expected_restricted_streams);

--- a/air/tests/test_module/instructions/new.rs
+++ b/air/tests/test_module/instructions/new.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use air_parser::TextPos;
+use air_parser::AirPos;
 use air_test_utils::prelude::*;
 
 #[test]
@@ -91,7 +91,7 @@ fn new_with_global_streams_seq() {
     let actual_restricted_streams = data.restricted_streams;
     let expected_restricted_streams = maplit::hashmap! {
         "$stream".to_string() => maplit::hashmap! {
-            TextPos::from(282) => vec![1,1]
+            AirPos::from(282) => vec![1,1]
         }
     };
     assert_eq!(actual_restricted_streams, expected_restricted_streams);
@@ -218,7 +218,7 @@ fn new_in_fold_with_ap() {
     let actual_restricted_streams = data.restricted_streams;
     let expected_restricted_streams = maplit::hashmap! {
         "$s1".to_string() => maplit::hashmap! {
-            TextPos::from(146) => vec![1,1,1,1,1]
+            AirPos::from(146) => vec![1,1,1,1,1]
         }
     };
     assert_eq!(actual_restricted_streams, expected_restricted_streams);
@@ -264,10 +264,10 @@ fn new_with_streams_with_errors() {
     let actual_restricted_streams = data.restricted_streams;
     let expected_restricted_streams = maplit::hashmap! {
         "$restricted_stream_2".to_string() => maplit::hashmap! {
-            TextPos::from(216) => vec![1]
+            AirPos::from(216) => vec![1]
         },
         "$restricted_stream_1".to_string() => maplit::hashmap! {
-            TextPos::from(141) => vec![0]
+            AirPos::from(141) => vec![0]
         }
     };
     assert_eq!(actual_restricted_streams, expected_restricted_streams);

--- a/air/tests/test_module/issues/issue_173.rs
+++ b/air/tests/test_module/issues/issue_173.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use air_parser::TextPos;
+use air_parser::AirPos;
 use air_test_utils::prelude::*;
 
 #[test]
@@ -94,7 +94,7 @@ fn issue_173() {
     let actual_restricted_streams = data.restricted_streams;
     let expected_restricted_streams = maplit::hashmap! {
         "$stream".to_string() => maplit::hashmap! {
-            TextPos::from(282) => vec![1,1]
+            AirPos::from(282) => vec![1,1]
         }
     };
     assert_eq!(actual_restricted_streams, expected_restricted_streams);

--- a/air/tests/test_module/issues/issue_173.rs
+++ b/air/tests/test_module/issues/issue_173.rs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+use air_parser::TextPos;
 use air_test_utils::prelude::*;
 
 #[test]
@@ -93,7 +94,7 @@ fn issue_173() {
     let actual_restricted_streams = data.restricted_streams;
     let expected_restricted_streams = maplit::hashmap! {
         "$stream".to_string() => maplit::hashmap! {
-            282 => vec![1,1]
+            TextPos::from(282) => vec![1,1]
         }
     };
     assert_eq!(actual_restricted_streams, expected_restricted_streams);

--- a/crates/air-lib/air-parser/src/ast/instruction_arguments/impls.rs
+++ b/crates/air-lib/air-parser/src/ast/instruction_arguments/impls.rs
@@ -19,6 +19,7 @@ use super::CallOutputValue;
 use super::NewArgument;
 use super::Scalar;
 use super::Stream;
+use crate::parser::lexer::TextPos;
 
 impl<'i> NewArgument<'i> {
     pub fn name(&self) -> &'i str {
@@ -31,11 +32,11 @@ impl<'i> NewArgument<'i> {
 }
 
 impl<'i> ApResult<'i> {
-    pub fn scalar(name: &'i str, position: usize) -> Self {
+    pub fn scalar(name: &'i str, position: TextPos) -> Self {
         Self::Scalar(Scalar { name, position })
     }
 
-    pub fn stream(name: &'i str, position: usize) -> Self {
+    pub fn stream(name: &'i str, position: TextPos) -> Self {
         Self::Stream(Stream { name, position })
     }
 
@@ -48,11 +49,11 @@ impl<'i> ApResult<'i> {
 }
 
 impl<'i> CallOutputValue<'i> {
-    pub fn scalar(name: &'i str, position: usize) -> Self {
+    pub fn scalar(name: &'i str, position: TextPos) -> Self {
         Self::Scalar(Scalar { name, position })
     }
 
-    pub fn stream(name: &'i str, position: usize) -> Self {
+    pub fn stream(name: &'i str, position: TextPos) -> Self {
         Self::Stream(Stream { name, position })
     }
 }

--- a/crates/air-lib/air-parser/src/ast/instruction_arguments/impls.rs
+++ b/crates/air-lib/air-parser/src/ast/instruction_arguments/impls.rs
@@ -19,7 +19,7 @@ use super::CallOutputValue;
 use super::NewArgument;
 use super::Scalar;
 use super::Stream;
-use crate::parser::lexer::TextPos;
+use crate::parser::lexer::AirPos;
 
 impl<'i> NewArgument<'i> {
     pub fn name(&self) -> &'i str {
@@ -32,11 +32,11 @@ impl<'i> NewArgument<'i> {
 }
 
 impl<'i> ApResult<'i> {
-    pub fn scalar(name: &'i str, position: TextPos) -> Self {
+    pub fn scalar(name: &'i str, position: AirPos) -> Self {
         Self::Scalar(Scalar { name, position })
     }
 
-    pub fn stream(name: &'i str, position: TextPos) -> Self {
+    pub fn stream(name: &'i str, position: AirPos) -> Self {
         Self::Stream(Stream { name, position })
     }
 
@@ -49,11 +49,11 @@ impl<'i> ApResult<'i> {
 }
 
 impl<'i> CallOutputValue<'i> {
-    pub fn scalar(name: &'i str, position: TextPos) -> Self {
+    pub fn scalar(name: &'i str, position: AirPos) -> Self {
         Self::Scalar(Scalar { name, position })
     }
 
-    pub fn stream(name: &'i str, position: TextPos) -> Self {
+    pub fn stream(name: &'i str, position: AirPos) -> Self {
         Self::Stream(Stream { name, position })
     }
 }

--- a/crates/air-lib/air-parser/src/ast/values.rs
+++ b/crates/air-lib/air-parser/src/ast/values.rs
@@ -17,7 +17,7 @@
 mod impls;
 mod traits;
 
-use crate::parser::lexer::TextPos;
+use crate::parser::lexer::AirPos;
 
 use air_lambda_parser::LambdaAST;
 use serde::Deserialize;
@@ -27,7 +27,7 @@ use serde::Serialize;
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct Scalar<'i> {
     pub name: &'i str,
-    pub position: TextPos,
+    pub position: AirPos,
 }
 
 /// A scalar value with possible lambda expression.
@@ -36,14 +36,14 @@ pub struct ScalarWithLambda<'i> {
     pub name: &'i str,
     #[serde(borrow)]
     pub lambda: Option<LambdaAST<'i>>,
-    pub position: TextPos,
+    pub position: AirPos,
 }
 
 /// A stream without lambda.
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct Stream<'i> {
     pub name: &'i str,
-    pub position: TextPos,
+    pub position: AirPos,
 }
 
 /// A stream with possible lambda expression.
@@ -52,14 +52,14 @@ pub struct StreamWithLambda<'i> {
     pub name: &'i str,
     #[serde(borrow)]
     pub lambda: Option<LambdaAST<'i>>,
-    pub position: TextPos,
+    pub position: AirPos,
 }
 
 /// A canonicalized stream without lambda.
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct CanonStream<'i> {
     pub name: &'i str,
-    pub position: TextPos,
+    pub position: AirPos,
 }
 
 /// A canonicalized stream with lambda.
@@ -68,7 +68,7 @@ pub struct CanonStreamWithLambda<'i> {
     pub name: &'i str,
     #[serde(borrow)]
     pub lambda: Option<LambdaAST<'i>>,
-    pub position: TextPos,
+    pub position: AirPos,
 }
 
 /// A variable that could be either scalar or stream without lambda.

--- a/crates/air-lib/air-parser/src/ast/values.rs
+++ b/crates/air-lib/air-parser/src/ast/values.rs
@@ -17,8 +17,9 @@
 mod impls;
 mod traits;
 
-use air_lambda_parser::LambdaAST;
+use crate::parser::lexer::TextPos;
 
+use air_lambda_parser::LambdaAST;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -26,7 +27,7 @@ use serde::Serialize;
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct Scalar<'i> {
     pub name: &'i str,
-    pub position: usize,
+    pub position: TextPos,
 }
 
 /// A scalar value with possible lambda expression.
@@ -35,14 +36,14 @@ pub struct ScalarWithLambda<'i> {
     pub name: &'i str,
     #[serde(borrow)]
     pub lambda: Option<LambdaAST<'i>>,
-    pub position: usize,
+    pub position: TextPos,
 }
 
 /// A stream without lambda.
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct Stream<'i> {
     pub name: &'i str,
-    pub position: usize,
+    pub position: TextPos,
 }
 
 /// A stream with possible lambda expression.
@@ -51,14 +52,14 @@ pub struct StreamWithLambda<'i> {
     pub name: &'i str,
     #[serde(borrow)]
     pub lambda: Option<LambdaAST<'i>>,
-    pub position: usize,
+    pub position: TextPos,
 }
 
 /// A canonicalized stream without lambda.
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct CanonStream<'i> {
     pub name: &'i str,
-    pub position: usize,
+    pub position: TextPos,
 }
 
 /// A canonicalized stream with lambda.
@@ -67,7 +68,7 @@ pub struct CanonStreamWithLambda<'i> {
     pub name: &'i str,
     #[serde(borrow)]
     pub lambda: Option<LambdaAST<'i>>,
-    pub position: usize,
+    pub position: TextPos,
 }
 
 /// A variable that could be either scalar or stream without lambda.

--- a/crates/air-lib/air-parser/src/ast/values/impls.rs
+++ b/crates/air-lib/air-parser/src/ast/values/impls.rs
@@ -19,7 +19,7 @@ use air_lambda_parser::LambdaAST;
 use air_lambda_parser::ValueAccessor;
 
 impl<'i> ScalarWithLambda<'i> {
-    pub fn new(name: &'i str, lambda: Option<LambdaAST<'i>>, position: TextPos) -> Self {
+    pub fn new(name: &'i str, lambda: Option<LambdaAST<'i>>, position: AirPos) -> Self {
         Self {
             name,
             lambda,
@@ -30,7 +30,7 @@ impl<'i> ScalarWithLambda<'i> {
     pub(crate) fn from_value_path(
         name: &'i str,
         accessors: Vec<ValueAccessor<'i>>,
-        position: TextPos,
+        position: AirPos,
     ) -> Self {
         let lambda = LambdaAST::try_from_accessors(accessors).ok();
         Self {
@@ -42,7 +42,7 @@ impl<'i> ScalarWithLambda<'i> {
 }
 
 impl<'i> StreamWithLambda<'i> {
-    pub fn new(name: &'i str, lambda: Option<LambdaAST<'i>>, position: TextPos) -> Self {
+    pub fn new(name: &'i str, lambda: Option<LambdaAST<'i>>, position: AirPos) -> Self {
         Self {
             name,
             lambda,
@@ -54,7 +54,7 @@ impl<'i> StreamWithLambda<'i> {
     pub(crate) fn from_value_path(
         name: &'i str,
         accessors: Vec<ValueAccessor<'i>>,
-        position: TextPos,
+        position: AirPos,
     ) -> Self {
         let lambda = LambdaAST::try_from_accessors(accessors).ok();
         Self {
@@ -66,13 +66,13 @@ impl<'i> StreamWithLambda<'i> {
 }
 
 impl<'i> CanonStream<'i> {
-    pub fn new(name: &'i str, position: TextPos) -> Self {
+    pub fn new(name: &'i str, position: AirPos) -> Self {
         Self { name, position }
     }
 }
 
 impl<'i> CanonStreamWithLambda<'i> {
-    pub fn new(name: &'i str, lambda: Option<LambdaAST<'i>>, position: TextPos) -> Self {
+    pub fn new(name: &'i str, lambda: Option<LambdaAST<'i>>, position: AirPos) -> Self {
         Self {
             name,
             lambda,
@@ -82,23 +82,23 @@ impl<'i> CanonStreamWithLambda<'i> {
 }
 
 impl<'i> Scalar<'i> {
-    pub fn new(name: &'i str, position: TextPos) -> Self {
+    pub fn new(name: &'i str, position: AirPos) -> Self {
         Self { name, position }
     }
 }
 
 impl<'i> Stream<'i> {
-    pub fn new(name: &'i str, position: TextPos) -> Self {
+    pub fn new(name: &'i str, position: AirPos) -> Self {
         Self { name, position }
     }
 }
 
 impl<'i> Variable<'i> {
-    pub fn scalar(name: &'i str, position: TextPos) -> Self {
+    pub fn scalar(name: &'i str, position: AirPos) -> Self {
         Self::Scalar(Scalar::new(name, position))
     }
 
-    pub fn stream(name: &'i str, position: TextPos) -> Self {
+    pub fn stream(name: &'i str, position: AirPos) -> Self {
         Self::Stream(Stream::new(name, position))
     }
 
@@ -112,27 +112,27 @@ impl<'i> Variable<'i> {
 }
 
 impl<'i> VariableWithLambda<'i> {
-    pub fn scalar(name: &'i str, position: TextPos) -> Self {
+    pub fn scalar(name: &'i str, position: AirPos) -> Self {
         Self::Scalar(ScalarWithLambda::new(name, None, position))
     }
 
-    pub fn scalar_wl(name: &'i str, lambda: LambdaAST<'i>, position: TextPos) -> Self {
+    pub fn scalar_wl(name: &'i str, lambda: LambdaAST<'i>, position: AirPos) -> Self {
         Self::Scalar(ScalarWithLambda::new(name, Some(lambda), position))
     }
 
-    pub fn stream(name: &'i str, position: TextPos) -> Self {
+    pub fn stream(name: &'i str, position: AirPos) -> Self {
         Self::Stream(StreamWithLambda::new(name, None, position))
     }
 
-    pub fn stream_wl(name: &'i str, lambda: LambdaAST<'i>, position: TextPos) -> Self {
+    pub fn stream_wl(name: &'i str, lambda: LambdaAST<'i>, position: AirPos) -> Self {
         Self::Stream(StreamWithLambda::new(name, Some(lambda), position))
     }
 
-    pub fn canon_stream(name: &'i str, position: TextPos) -> Self {
+    pub fn canon_stream(name: &'i str, position: AirPos) -> Self {
         Self::CanonStream(CanonStreamWithLambda::new(name, None, position))
     }
 
-    pub fn canon_stream_wl(name: &'i str, lambda: LambdaAST<'i>, position: TextPos) -> Self {
+    pub fn canon_stream_wl(name: &'i str, lambda: LambdaAST<'i>, position: AirPos) -> Self {
         Self::CanonStream(CanonStreamWithLambda::new(name, Some(lambda), position))
     }
 
@@ -156,7 +156,7 @@ impl<'i> VariableWithLambda<'i> {
     pub(crate) fn from_raw_value_path(
         name: &'i str,
         lambda: Vec<ValueAccessor<'i>>,
-        position: TextPos,
+        position: AirPos,
     ) -> Self {
         let scalar = ScalarWithLambda::from_value_path(name, lambda, position);
         Self::Scalar(scalar)
@@ -166,7 +166,7 @@ impl<'i> VariableWithLambda<'i> {
     pub(crate) fn from_raw_lambda_stream(
         name: &'i str,
         lambda: Vec<ValueAccessor<'i>>,
-        position: TextPos,
+        position: AirPos,
     ) -> Self {
         let stream = StreamWithLambda::from_value_path(name, lambda, position);
         Self::Stream(stream)

--- a/crates/air-lib/air-parser/src/ast/values/impls.rs
+++ b/crates/air-lib/air-parser/src/ast/values/impls.rs
@@ -19,7 +19,7 @@ use air_lambda_parser::LambdaAST;
 use air_lambda_parser::ValueAccessor;
 
 impl<'i> ScalarWithLambda<'i> {
-    pub fn new(name: &'i str, lambda: Option<LambdaAST<'i>>, position: usize) -> Self {
+    pub fn new(name: &'i str, lambda: Option<LambdaAST<'i>>, position: TextPos) -> Self {
         Self {
             name,
             lambda,
@@ -30,7 +30,7 @@ impl<'i> ScalarWithLambda<'i> {
     pub(crate) fn from_value_path(
         name: &'i str,
         accessors: Vec<ValueAccessor<'i>>,
-        position: usize,
+        position: TextPos,
     ) -> Self {
         let lambda = LambdaAST::try_from_accessors(accessors).ok();
         Self {
@@ -42,7 +42,7 @@ impl<'i> ScalarWithLambda<'i> {
 }
 
 impl<'i> StreamWithLambda<'i> {
-    pub fn new(name: &'i str, lambda: Option<LambdaAST<'i>>, position: usize) -> Self {
+    pub fn new(name: &'i str, lambda: Option<LambdaAST<'i>>, position: TextPos) -> Self {
         Self {
             name,
             lambda,
@@ -54,7 +54,7 @@ impl<'i> StreamWithLambda<'i> {
     pub(crate) fn from_value_path(
         name: &'i str,
         accessors: Vec<ValueAccessor<'i>>,
-        position: usize,
+        position: TextPos,
     ) -> Self {
         let lambda = LambdaAST::try_from_accessors(accessors).ok();
         Self {
@@ -66,13 +66,13 @@ impl<'i> StreamWithLambda<'i> {
 }
 
 impl<'i> CanonStream<'i> {
-    pub fn new(name: &'i str, position: usize) -> Self {
+    pub fn new(name: &'i str, position: TextPos) -> Self {
         Self { name, position }
     }
 }
 
 impl<'i> CanonStreamWithLambda<'i> {
-    pub fn new(name: &'i str, lambda: Option<LambdaAST<'i>>, position: usize) -> Self {
+    pub fn new(name: &'i str, lambda: Option<LambdaAST<'i>>, position: TextPos) -> Self {
         Self {
             name,
             lambda,
@@ -82,23 +82,23 @@ impl<'i> CanonStreamWithLambda<'i> {
 }
 
 impl<'i> Scalar<'i> {
-    pub fn new(name: &'i str, position: usize) -> Self {
+    pub fn new(name: &'i str, position: TextPos) -> Self {
         Self { name, position }
     }
 }
 
 impl<'i> Stream<'i> {
-    pub fn new(name: &'i str, position: usize) -> Self {
+    pub fn new(name: &'i str, position: TextPos) -> Self {
         Self { name, position }
     }
 }
 
 impl<'i> Variable<'i> {
-    pub fn scalar(name: &'i str, position: usize) -> Self {
+    pub fn scalar(name: &'i str, position: TextPos) -> Self {
         Self::Scalar(Scalar::new(name, position))
     }
 
-    pub fn stream(name: &'i str, position: usize) -> Self {
+    pub fn stream(name: &'i str, position: TextPos) -> Self {
         Self::Stream(Stream::new(name, position))
     }
 
@@ -112,27 +112,27 @@ impl<'i> Variable<'i> {
 }
 
 impl<'i> VariableWithLambda<'i> {
-    pub fn scalar(name: &'i str, position: usize) -> Self {
+    pub fn scalar(name: &'i str, position: TextPos) -> Self {
         Self::Scalar(ScalarWithLambda::new(name, None, position))
     }
 
-    pub fn scalar_wl(name: &'i str, lambda: LambdaAST<'i>, position: usize) -> Self {
+    pub fn scalar_wl(name: &'i str, lambda: LambdaAST<'i>, position: TextPos) -> Self {
         Self::Scalar(ScalarWithLambda::new(name, Some(lambda), position))
     }
 
-    pub fn stream(name: &'i str, position: usize) -> Self {
+    pub fn stream(name: &'i str, position: TextPos) -> Self {
         Self::Stream(StreamWithLambda::new(name, None, position))
     }
 
-    pub fn stream_wl(name: &'i str, lambda: LambdaAST<'i>, position: usize) -> Self {
+    pub fn stream_wl(name: &'i str, lambda: LambdaAST<'i>, position: TextPos) -> Self {
         Self::Stream(StreamWithLambda::new(name, Some(lambda), position))
     }
 
-    pub fn canon_stream(name: &'i str, position: usize) -> Self {
+    pub fn canon_stream(name: &'i str, position: TextPos) -> Self {
         Self::CanonStream(CanonStreamWithLambda::new(name, None, position))
     }
 
-    pub fn canon_stream_wl(name: &'i str, lambda: LambdaAST<'i>, position: usize) -> Self {
+    pub fn canon_stream_wl(name: &'i str, lambda: LambdaAST<'i>, position: TextPos) -> Self {
         Self::CanonStream(CanonStreamWithLambda::new(name, Some(lambda), position))
     }
 
@@ -156,7 +156,7 @@ impl<'i> VariableWithLambda<'i> {
     pub(crate) fn from_raw_value_path(
         name: &'i str,
         lambda: Vec<ValueAccessor<'i>>,
-        position: usize,
+        position: TextPos,
     ) -> Self {
         let scalar = ScalarWithLambda::from_value_path(name, lambda, position);
         Self::Scalar(scalar)
@@ -166,7 +166,7 @@ impl<'i> VariableWithLambda<'i> {
     pub(crate) fn from_raw_lambda_stream(
         name: &'i str,
         lambda: Vec<ValueAccessor<'i>>,
-        position: usize,
+        position: TextPos,
     ) -> Self {
         let stream = StreamWithLambda::from_value_path(name, lambda, position);
         Self::Stream(stream)

--- a/crates/air-lib/air-parser/src/lib.rs
+++ b/crates/air-lib/air-parser/src/lib.rs
@@ -28,7 +28,7 @@
 pub mod ast;
 mod parser;
 
-pub use parser::lexer::TextPos;
+pub use parser::lexer::AirPos;
 pub use parser::parse;
 pub use parser::AIRLexer;
 pub use parser::AIRParser;

--- a/crates/air-lib/air-parser/src/lib.rs
+++ b/crates/air-lib/air-parser/src/lib.rs
@@ -28,6 +28,7 @@
 pub mod ast;
 mod parser;
 
+pub use parser::lexer::TextPos;
 pub use parser::parse;
 pub use parser::AIRLexer;
 pub use parser::AIRParser;

--- a/crates/air-lib/air-parser/src/parser/air.lalrpop
+++ b/crates/air-lib/air-parser/src/parser/air.lalrpop
@@ -2,14 +2,14 @@ use crate::ast::*;
 use crate::parser::ParserError;
 use crate::parser::VariableValidator;
 use crate::parser::Span;
-use crate::parser::lexer::{TextPos, Token};
+use crate::parser::lexer::{AirPos, Token};
 
 use air_lambda_parser::LambdaAST;
 use lalrpop_util::ErrorRecovery;
 use std::rc::Rc;
 
 // the only thing why input matters here is just introducing lifetime for Token
-grammar<'err, 'input, 'v>(input: &'input str, errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>, validator: &'v mut VariableValidator<'input>);
+grammar<'err, 'input, 'v>(input: &'input str, errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>, validator: &'v mut VariableValidator<'input>);
 
 pub AIR = Instr;
 
@@ -230,7 +230,7 @@ CanonStreamArgument: CanonStream<'input> = {
 }
 
 extern {
-    type Location = TextPos;
+    type Location = AirPos;
     type Error = ParserError;
 
     enum Token<'input> {
@@ -239,12 +239,12 @@ extern {
         "[" => Token::OpenSquareBracket,
         "]" => Token::CloseSquareBracket,
 
-        Scalar => Token::Scalar { name:<&'input str>, position: <TextPos> },
-        ScalarWithLambda => Token::ScalarWithLambda { name: <&'input str>, lambda: <LambdaAST<'input>>, position: <TextPos> },
-        Stream => Token::Stream { name: <&'input str>, position: <TextPos> },
-        StreamWithLambda => Token::StreamWithLambda {name: <&'input str>, lambda:<LambdaAST<'input>>, position: <TextPos>},
-        CanonStream => Token::CanonStream { name: <&'input str>, position: <TextPos> },
-        CanonStreamWithLambda => Token::CanonStreamWithLambda {name: <&'input str>, lambda:<LambdaAST<'input>>, position: <TextPos>},
+        Scalar => Token::Scalar { name:<&'input str>, position: <AirPos> },
+        ScalarWithLambda => Token::ScalarWithLambda { name: <&'input str>, lambda: <LambdaAST<'input>>, position: <AirPos> },
+        Stream => Token::Stream { name: <&'input str>, position: <AirPos> },
+        StreamWithLambda => Token::StreamWithLambda {name: <&'input str>, lambda:<LambdaAST<'input>>, position: <AirPos>},
+        CanonStream => Token::CanonStream { name: <&'input str>, position: <AirPos> },
+        CanonStreamWithLambda => Token::CanonStreamWithLambda {name: <&'input str>, lambda:<LambdaAST<'input>>, position: <AirPos>},
 
         Literal => Token::StringLiteral(<&'input str>),
         I64 => Token::I64(<i64>),

--- a/crates/air-lib/air-parser/src/parser/air.lalrpop
+++ b/crates/air-lib/air-parser/src/parser/air.lalrpop
@@ -2,14 +2,14 @@ use crate::ast::*;
 use crate::parser::ParserError;
 use crate::parser::VariableValidator;
 use crate::parser::Span;
-use crate::parser::lexer::Token;
+use crate::parser::lexer::{TextPos, Token};
 
 use air_lambda_parser::LambdaAST;
 use lalrpop_util::ErrorRecovery;
 use std::rc::Rc;
 
 // the only thing why input matters here is just introducing lifetime for Token
-grammar<'err, 'input, 'v>(input: &'input str, errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>, validator: &'v mut VariableValidator<'input>);
+grammar<'err, 'input, 'v>(input: &'input str, errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>, validator: &'v mut VariableValidator<'input>);
 
 pub AIR = Instr;
 
@@ -230,7 +230,7 @@ CanonStreamArgument: CanonStream<'input> = {
 }
 
 extern {
-    type Location = usize;
+    type Location = TextPos;
     type Error = ParserError;
 
     enum Token<'input> {
@@ -239,12 +239,12 @@ extern {
         "[" => Token::OpenSquareBracket,
         "]" => Token::CloseSquareBracket,
 
-        Scalar => Token::Scalar { name:<&'input str>, position: <usize> },
-        ScalarWithLambda => Token::ScalarWithLambda { name: <&'input str>, lambda: <LambdaAST<'input>>, position: <usize> },
-        Stream => Token::Stream { name: <&'input str>, position: <usize> },
-        StreamWithLambda => Token::StreamWithLambda {name: <&'input str>, lambda:<LambdaAST<'input>>, position: <usize>},
-        CanonStream => Token::CanonStream { name: <&'input str>, position: <usize> },
-        CanonStreamWithLambda => Token::CanonStreamWithLambda {name: <&'input str>, lambda:<LambdaAST<'input>>, position: <usize>},
+        Scalar => Token::Scalar { name:<&'input str>, position: <TextPos> },
+        ScalarWithLambda => Token::ScalarWithLambda { name: <&'input str>, lambda: <LambdaAST<'input>>, position: <TextPos> },
+        Stream => Token::Stream { name: <&'input str>, position: <TextPos> },
+        StreamWithLambda => Token::StreamWithLambda {name: <&'input str>, lambda:<LambdaAST<'input>>, position: <TextPos>},
+        CanonStream => Token::CanonStream { name: <&'input str>, position: <TextPos> },
+        CanonStreamWithLambda => Token::CanonStreamWithLambda {name: <&'input str>, lambda:<LambdaAST<'input>>, position: <TextPos>},
 
         Literal => Token::StringLiteral(<&'input str>),
         I64 => Token::I64(<i64>),

--- a/crates/air-lib/air-parser/src/parser/air.rs
+++ b/crates/air-lib/air-parser/src/parser/air.rs
@@ -1,10 +1,10 @@
 // auto-generated: "lalrpop 0.19.8"
-// sha3: 0d3a4987502c5607e415ce9fce0608dd62b94d4272ee7d24aa2945f78c8f2d02
+// sha3: 6015184229228a3f428f95fb29c56509f070f983a1754f1cde84c27a9f0a417d
 use crate::ast::*;
 use crate::parser::ParserError;
 use crate::parser::VariableValidator;
 use crate::parser::Span;
-use crate::parser::lexer::Token;
+use crate::parser::lexer::{TextPos, Token};
 use air_lambda_parser::LambdaAST;
 use lalrpop_util::ErrorRecovery;
 use std::rc::Rc;
@@ -23,7 +23,7 @@ mod __parse__AIR {
     use crate::parser::ParserError;
     use crate::parser::VariableValidator;
     use crate::parser::Span;
-    use crate::parser::lexer::Token;
+    use crate::parser::lexer::{TextPos, Token};
     use air_lambda_parser::LambdaAST;
     use lalrpop_util::ErrorRecovery;
     use std::rc::Rc;
@@ -39,16 +39,16 @@ mod __parse__AIR {
      {
         Variant0(Token<'input>),
         Variant1(bool),
-        Variant2((&'input str, usize)),
-        Variant3((&'input str, LambdaAST<'input>, usize)),
+        Variant2((&'input str, TextPos)),
+        Variant3((&'input str, LambdaAST<'input>, TextPos)),
         Variant4(f64),
         Variant5(i64),
         Variant6(LambdaAST<'input>),
         Variant7(&'input str),
-        Variant8(__lalrpop_util::ErrorRecovery<usize, Token<'input>, ParserError>),
+        Variant8(__lalrpop_util::ErrorRecovery<TextPos, Token<'input>, ParserError>),
         Variant9(Value<'input>),
         Variant10(alloc::vec::Vec<Value<'input>>),
-        Variant11(usize),
+        Variant11(TextPos),
         Variant12(Box<Instruction<'input>>),
         Variant13(ApArgument<'input>),
         Variant14(ApResult<'input>),
@@ -735,14 +735,14 @@ mod __parse__AIR {
     where 'input: 'err, 'input: 'v
     {
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
         __phantom: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     }
     impl<'err, 'input, 'v> __state_machine::ParserDefinition for __StateMachine<'err, 'input, 'v>
     where 'input: 'err, 'input: 'v
     {
-        type Location = usize;
+        type Location = TextPos;
         type Error = ParserError;
         type Token = Token<'input>;
         type TokenIndex = usize;
@@ -1499,10 +1499,10 @@ mod __parse__AIR {
         >(
             &self,
             input: &'input str,
-            errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+            errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
             validator: &'v mut VariableValidator<'input>,
             __tokens0: __TOKENS,
-        ) -> Result<Box<Instruction<'input>>, __lalrpop_util::ParseError<usize, Token<'input>, ParserError>>
+        ) -> Result<Box<Instruction<'input>>, __lalrpop_util::ParseError<TextPos, Token<'input>, ParserError>>
         {
             let __tokens = __tokens0.into_iter();
             let mut __tokens = __tokens.map(|t| __ToTriple::to_triple(t));
@@ -1523,7 +1523,7 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
         __error_state: i16,
         __states: & [i16],
@@ -1561,14 +1561,14 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
         __action: i16,
-        __lookahead_start: Option<&usize>,
+        __lookahead_start: Option<&TextPos>,
         __states: &mut alloc::vec::Vec<i16>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
-    ) -> Option<Result<Box<Instruction<'input>>,__lalrpop_util::ParseError<usize, Token<'input>, ParserError>>>
+    ) -> Option<Result<Box<Instruction<'input>>,__lalrpop_util::ParseError<TextPos, Token<'input>, ParserError>>>
     {
         let (__pop_states, __nonterminal) = match __action {
             0 => {
@@ -1865,8 +1865,8 @@ mod __parse__AIR {
     fn __pop_Variant3<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, (&'input str, LambdaAST<'input>, usize), usize)
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
+    ) -> (TextPos, (&'input str, LambdaAST<'input>, TextPos), TextPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant3(__v), __r)) => (__l, __v, __r),
@@ -1876,8 +1876,8 @@ mod __parse__AIR {
     fn __pop_Variant2<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, (&'input str, usize), usize)
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
+    ) -> (TextPos, (&'input str, TextPos), TextPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant2(__v), __r)) => (__l, __v, __r),
@@ -1887,8 +1887,8 @@ mod __parse__AIR {
     fn __pop_Variant13<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, ApArgument<'input>, usize)
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
+    ) -> (TextPos, ApArgument<'input>, TextPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant13(__v), __r)) => (__l, __v, __r),
@@ -1898,8 +1898,8 @@ mod __parse__AIR {
     fn __pop_Variant14<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, ApResult<'input>, usize)
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
+    ) -> (TextPos, ApResult<'input>, TextPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant14(__v), __r)) => (__l, __v, __r),
@@ -1909,8 +1909,8 @@ mod __parse__AIR {
     fn __pop_Variant12<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Box<Instruction<'input>>, usize)
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
+    ) -> (TextPos, Box<Instruction<'input>>, TextPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant12(__v), __r)) => (__l, __v, __r),
@@ -1920,8 +1920,8 @@ mod __parse__AIR {
     fn __pop_Variant16<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, CallInstrValue<'input>, usize)
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
+    ) -> (TextPos, CallInstrValue<'input>, TextPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant16(__v), __r)) => (__l, __v, __r),
@@ -1931,8 +1931,8 @@ mod __parse__AIR {
     fn __pop_Variant17<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, CallOutputValue<'input>, usize)
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
+    ) -> (TextPos, CallOutputValue<'input>, TextPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant17(__v), __r)) => (__l, __v, __r),
@@ -1942,8 +1942,8 @@ mod __parse__AIR {
     fn __pop_Variant19<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, CanonStream<'input>, usize)
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
+    ) -> (TextPos, CanonStream<'input>, TextPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant19(__v), __r)) => (__l, __v, __r),
@@ -1953,8 +1953,8 @@ mod __parse__AIR {
     fn __pop_Variant20<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Fail<'input>, usize)
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
+    ) -> (TextPos, Fail<'input>, TextPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant20(__v), __r)) => (__l, __v, __r),
@@ -1964,8 +1964,8 @@ mod __parse__AIR {
     fn __pop_Variant21<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, FoldScalarIterable<'input>, usize)
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
+    ) -> (TextPos, FoldScalarIterable<'input>, TextPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant21(__v), __r)) => (__l, __v, __r),
@@ -1975,8 +1975,8 @@ mod __parse__AIR {
     fn __pop_Variant6<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, LambdaAST<'input>, usize)
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
+    ) -> (TextPos, LambdaAST<'input>, TextPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant6(__v), __r)) => (__l, __v, __r),
@@ -1986,8 +1986,8 @@ mod __parse__AIR {
     fn __pop_Variant22<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, NewArgument<'input>, usize)
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
+    ) -> (TextPos, NewArgument<'input>, TextPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant22(__v), __r)) => (__l, __v, __r),
@@ -1997,8 +1997,8 @@ mod __parse__AIR {
     fn __pop_Variant23<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Number, usize)
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
+    ) -> (TextPos, Number, TextPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant23(__v), __r)) => (__l, __v, __r),
@@ -2008,19 +2008,30 @@ mod __parse__AIR {
     fn __pop_Variant24<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Stream<'input>, usize)
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
+    ) -> (TextPos, Stream<'input>, TextPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant24(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
+    fn __pop_Variant11<
+      'input,
+    >(
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
+    ) -> (TextPos, TextPos, TextPos)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant11(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
     fn __pop_Variant0<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Token<'input>, usize)
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
+    ) -> (TextPos, Token<'input>, TextPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant0(__v), __r)) => (__l, __v, __r),
@@ -2030,8 +2041,8 @@ mod __parse__AIR {
     fn __pop_Variant25<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Triplet<'input>, usize)
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
+    ) -> (TextPos, Triplet<'input>, TextPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant25(__v), __r)) => (__l, __v, __r),
@@ -2041,8 +2052,8 @@ mod __parse__AIR {
     fn __pop_Variant9<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Value<'input>, usize)
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
+    ) -> (TextPos, Value<'input>, TextPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant9(__v), __r)) => (__l, __v, __r),
@@ -2052,8 +2063,8 @@ mod __parse__AIR {
     fn __pop_Variant15<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Vec<Value<'input>>, usize)
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
+    ) -> (TextPos, Vec<Value<'input>>, TextPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant15(__v), __r)) => (__l, __v, __r),
@@ -2063,8 +2074,8 @@ mod __parse__AIR {
     fn __pop_Variant8<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, __lalrpop_util::ErrorRecovery<usize, Token<'input>, ParserError>, usize)
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
+    ) -> (TextPos, __lalrpop_util::ErrorRecovery<TextPos, Token<'input>, ParserError>, TextPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant8(__v), __r)) => (__l, __v, __r),
@@ -2074,8 +2085,8 @@ mod __parse__AIR {
     fn __pop_Variant10<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, alloc::vec::Vec<Value<'input>>, usize)
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
+    ) -> (TextPos, alloc::vec::Vec<Value<'input>>, TextPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant10(__v), __r)) => (__l, __v, __r),
@@ -2085,8 +2096,8 @@ mod __parse__AIR {
     fn __pop_Variant1<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, bool, usize)
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
+    ) -> (TextPos, bool, TextPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant1(__v), __r)) => (__l, __v, __r),
@@ -2096,8 +2107,8 @@ mod __parse__AIR {
     fn __pop_Variant18<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, core::option::Option<CallOutputValue<'input>>, usize)
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
+    ) -> (TextPos, core::option::Option<CallOutputValue<'input>>, TextPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant18(__v), __r)) => (__l, __v, __r),
@@ -2107,8 +2118,8 @@ mod __parse__AIR {
     fn __pop_Variant4<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, f64, usize)
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
+    ) -> (TextPos, f64, TextPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant4(__v), __r)) => (__l, __v, __r),
@@ -2118,30 +2129,19 @@ mod __parse__AIR {
     fn __pop_Variant5<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, i64, usize)
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
+    ) -> (TextPos, i64, TextPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant5(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant11<
-      'input,
-    >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, usize, usize)
-     {
-        match __symbols.pop() {
-            Some((__l, __Symbol::Variant11(__v), __r)) => (__l, __v, __r),
-            _ => __symbol_type_mismatch()
-        }
-    }
     fn __pop_Variant7<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, &'input str, usize)
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
+    ) -> (TextPos, &'input str, TextPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant7(__v), __r)) => (__l, __v, __r),
@@ -2154,10 +2154,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2175,10 +2175,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2195,10 +2195,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2216,10 +2216,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2237,10 +2237,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2260,10 +2260,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2280,10 +2280,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2300,10 +2300,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2321,10 +2321,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2342,10 +2342,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2363,10 +2363,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2384,10 +2384,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2405,10 +2405,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2426,10 +2426,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2447,10 +2447,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2468,10 +2468,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2489,10 +2489,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2512,10 +2512,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2533,10 +2533,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2554,10 +2554,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2575,10 +2575,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2596,10 +2596,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2617,10 +2617,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2638,10 +2638,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2659,10 +2659,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2682,10 +2682,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2706,10 +2706,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2727,10 +2727,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2748,10 +2748,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2769,10 +2769,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2790,10 +2790,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2811,10 +2811,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2832,10 +2832,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2853,10 +2853,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2874,10 +2874,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2895,10 +2895,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2916,10 +2916,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2937,10 +2937,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2957,10 +2957,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2978,10 +2978,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2999,10 +2999,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3020,10 +3020,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3043,10 +3043,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3064,10 +3064,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3085,10 +3085,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3106,10 +3106,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3127,10 +3127,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3148,10 +3148,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3171,10 +3171,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3192,10 +3192,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3219,10 +3219,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3245,10 +3245,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3272,10 +3272,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3298,10 +3298,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3324,10 +3324,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3350,10 +3350,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3374,10 +3374,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3398,10 +3398,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3424,10 +3424,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3449,10 +3449,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3476,10 +3476,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3503,10 +3503,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3528,10 +3528,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3554,10 +3554,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3581,10 +3581,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3608,10 +3608,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3629,10 +3629,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3650,10 +3650,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3671,10 +3671,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3692,10 +3692,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3713,10 +3713,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3734,10 +3734,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3755,10 +3755,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3776,10 +3776,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3797,10 +3797,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3823,10 +3823,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3844,10 +3844,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3865,10 +3865,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3886,10 +3886,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3907,10 +3907,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3928,10 +3928,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3949,10 +3949,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3970,10 +3970,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3991,10 +3991,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -4014,10 +4014,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -4035,10 +4035,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -4056,10 +4056,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -4077,10 +4077,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -4098,10 +4098,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -4119,10 +4119,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        __lookahead_start: Option<&TextPos>,
+        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -4144,9 +4144,9 @@ fn __action0<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (usize, Box<Instruction<'input>>, usize),
+    (_, __0, _): (TextPos, Box<Instruction<'input>>, TextPos),
 ) -> Box<Instruction<'input>>
 {
     __0
@@ -4159,9 +4159,9 @@ fn __action1<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (usize, Box<Instruction<'input>>, usize),
+    (_, __0, _): (TextPos, Box<Instruction<'input>>, TextPos),
 ) -> Box<Instruction<'input>>
 {
     __0
@@ -4174,16 +4174,16 @@ fn __action2<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, left, _): (usize, usize, usize),
-    (_, _, _): (usize, Token<'input>, usize),
-    (_, _, _): (usize, Token<'input>, usize),
-    (_, triplet, _): (usize, Triplet<'input>, usize),
-    (_, args, _): (usize, Vec<Value<'input>>, usize),
-    (_, output, _): (usize, core::option::Option<CallOutputValue<'input>>, usize),
-    (_, _, _): (usize, Token<'input>, usize),
-    (_, right, _): (usize, usize, usize),
+    (_, left, _): (TextPos, TextPos, TextPos),
+    (_, _, _): (TextPos, Token<'input>, TextPos),
+    (_, _, _): (TextPos, Token<'input>, TextPos),
+    (_, triplet, _): (TextPos, Triplet<'input>, TextPos),
+    (_, args, _): (TextPos, Vec<Value<'input>>, TextPos),
+    (_, output, _): (TextPos, core::option::Option<CallOutputValue<'input>>, TextPos),
+    (_, _, _): (TextPos, Token<'input>, TextPos),
+    (_, right, _): (TextPos, TextPos, TextPos),
 ) -> Box<Instruction<'input>>
 {
     {
@@ -4205,16 +4205,16 @@ fn __action3<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, left, _): (usize, usize, usize),
-    (_, _, _): (usize, Token<'input>, usize),
-    (_, _, _): (usize, Token<'input>, usize),
-    (_, peer_pk, _): (usize, CallInstrValue<'input>, usize),
-    (_, stream, _): (usize, Stream<'input>, usize),
-    (_, canon_stream, _): (usize, CanonStream<'input>, usize),
-    (_, _, _): (usize, Token<'input>, usize),
-    (_, right, _): (usize, usize, usize),
+    (_, left, _): (TextPos, TextPos, TextPos),
+    (_, _, _): (TextPos, Token<'input>, TextPos),
+    (_, _, _): (TextPos, Token<'input>, TextPos),
+    (_, peer_pk, _): (TextPos, CallInstrValue<'input>, TextPos),
+    (_, stream, _): (TextPos, Stream<'input>, TextPos),
+    (_, canon_stream, _): (TextPos, CanonStream<'input>, TextPos),
+    (_, _, _): (TextPos, Token<'input>, TextPos),
+    (_, right, _): (TextPos, TextPos, TextPos),
 ) -> Box<Instruction<'input>>
 {
     {
@@ -4234,15 +4234,15 @@ fn __action4<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, left, _): (usize, usize, usize),
-    (_, _, _): (usize, Token<'input>, usize),
-    (_, _, _): (usize, Token<'input>, usize),
-    (_, arg, _): (usize, ApArgument<'input>, usize),
-    (_, result, _): (usize, ApResult<'input>, usize),
-    (_, _, _): (usize, Token<'input>, usize),
-    (_, right, _): (usize, usize, usize),
+    (_, left, _): (TextPos, TextPos, TextPos),
+    (_, _, _): (TextPos, Token<'input>, TextPos),
+    (_, _, _): (TextPos, Token<'input>, TextPos),
+    (_, arg, _): (TextPos, ApArgument<'input>, TextPos),
+    (_, result, _): (TextPos, ApResult<'input>, TextPos),
+    (_, _, _): (TextPos, Token<'input>, TextPos),
+    (_, right, _): (TextPos, TextPos, TextPos),
 ) -> Box<Instruction<'input>>
 {
     {
@@ -4262,13 +4262,13 @@ fn __action5<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, _, _): (usize, Token<'input>, usize),
-    (_, _, _): (usize, Token<'input>, usize),
-    (_, l, _): (usize, Box<Instruction<'input>>, usize),
-    (_, r, _): (usize, Box<Instruction<'input>>, usize),
-    (_, _, _): (usize, Token<'input>, usize),
+    (_, _, _): (TextPos, Token<'input>, TextPos),
+    (_, _, _): (TextPos, Token<'input>, TextPos),
+    (_, l, _): (TextPos, Box<Instruction<'input>>, TextPos),
+    (_, r, _): (TextPos, Box<Instruction<'input>>, TextPos),
+    (_, _, _): (TextPos, Token<'input>, TextPos),
 ) -> Box<Instruction<'input>>
 {
     Box::new(Instruction::Seq(Seq::new(l, r)))
@@ -4281,13 +4281,13 @@ fn __action6<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, _, _): (usize, Token<'input>, usize),
-    (_, _, _): (usize, Token<'input>, usize),
-    (_, l, _): (usize, Box<Instruction<'input>>, usize),
-    (_, r, _): (usize, Box<Instruction<'input>>, usize),
-    (_, _, _): (usize, Token<'input>, usize),
+    (_, _, _): (TextPos, Token<'input>, TextPos),
+    (_, _, _): (TextPos, Token<'input>, TextPos),
+    (_, l, _): (TextPos, Box<Instruction<'input>>, TextPos),
+    (_, r, _): (TextPos, Box<Instruction<'input>>, TextPos),
+    (_, _, _): (TextPos, Token<'input>, TextPos),
 ) -> Box<Instruction<'input>>
 {
     Box::new(Instruction::Par(Par::new(l, r)))
@@ -4300,11 +4300,11 @@ fn __action7<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (usize, Token<'input>, usize),
-    (_, __1, _): (usize, Token<'input>, usize),
-    (_, __2, _): (usize, Token<'input>, usize),
+    (_, __0, _): (TextPos, Token<'input>, TextPos),
+    (_, __1, _): (TextPos, Token<'input>, TextPos),
+    (_, __2, _): (TextPos, Token<'input>, TextPos),
 ) -> Box<Instruction<'input>>
 {
     Box::new(Instruction::Never(Never))
@@ -4317,11 +4317,11 @@ fn __action8<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (usize, Token<'input>, usize),
-    (_, __1, _): (usize, Token<'input>, usize),
-    (_, __2, _): (usize, Token<'input>, usize),
+    (_, __0, _): (TextPos, Token<'input>, TextPos),
+    (_, __1, _): (TextPos, Token<'input>, TextPos),
+    (_, __2, _): (TextPos, Token<'input>, TextPos),
 ) -> Box<Instruction<'input>>
 {
     Box::new(Instruction::Null(Null))
@@ -4334,15 +4334,15 @@ fn __action9<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, left, _): (usize, usize, usize),
-    (_, _, _): (usize, Token<'input>, usize),
-    (_, _, _): (usize, Token<'input>, usize),
-    (_, argument, _): (usize, NewArgument<'input>, usize),
-    (_, instruction, _): (usize, Box<Instruction<'input>>, usize),
-    (_, _, _): (usize, Token<'input>, usize),
-    (_, right, _): (usize, usize, usize),
+    (_, left, _): (TextPos, TextPos, TextPos),
+    (_, _, _): (TextPos, Token<'input>, TextPos),
+    (_, _, _): (TextPos, Token<'input>, TextPos),
+    (_, argument, _): (TextPos, NewArgument<'input>, TextPos),
+    (_, instruction, _): (TextPos, Box<Instruction<'input>>, TextPos),
+    (_, _, _): (TextPos, Token<'input>, TextPos),
+    (_, right, _): (TextPos, TextPos, TextPos),
 ) -> Box<Instruction<'input>>
 {
     {
@@ -4362,12 +4362,12 @@ fn __action10<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, _, _): (usize, Token<'input>, usize),
-    (_, _, _): (usize, Token<'input>, usize),
-    (_, fail_body, _): (usize, Fail<'input>, usize),
-    (_, _, _): (usize, Token<'input>, usize),
+    (_, _, _): (TextPos, Token<'input>, TextPos),
+    (_, _, _): (TextPos, Token<'input>, TextPos),
+    (_, fail_body, _): (TextPos, Fail<'input>, TextPos),
+    (_, _, _): (TextPos, Token<'input>, TextPos),
 ) -> Box<Instruction<'input>>
 {
     {
@@ -4382,16 +4382,16 @@ fn __action11<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, left, _): (usize, usize, usize),
-    (_, _, _): (usize, Token<'input>, usize),
-    (_, _, _): (usize, Token<'input>, usize),
-    (_, iterable, _): (usize, FoldScalarIterable<'input>, usize),
-    (_, iterator, _): (usize, (&'input str, usize), usize),
-    (_, i, _): (usize, Box<Instruction<'input>>, usize),
-    (_, _, _): (usize, Token<'input>, usize),
-    (_, right, _): (usize, usize, usize),
+    (_, left, _): (TextPos, TextPos, TextPos),
+    (_, _, _): (TextPos, Token<'input>, TextPos),
+    (_, _, _): (TextPos, Token<'input>, TextPos),
+    (_, iterable, _): (TextPos, FoldScalarIterable<'input>, TextPos),
+    (_, iterator, _): (TextPos, (&'input str, TextPos), TextPos),
+    (_, i, _): (TextPos, Box<Instruction<'input>>, TextPos),
+    (_, _, _): (TextPos, Token<'input>, TextPos),
+    (_, right, _): (TextPos, TextPos, TextPos),
 ) -> Box<Instruction<'input>>
 {
     {
@@ -4412,16 +4412,16 @@ fn __action12<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, left, _): (usize, usize, usize),
-    (_, _, _): (usize, Token<'input>, usize),
-    (_, _, _): (usize, Token<'input>, usize),
-    (_, stream, _): (usize, (&'input str, usize), usize),
-    (_, iterator, _): (usize, (&'input str, usize), usize),
-    (_, i, _): (usize, Box<Instruction<'input>>, usize),
-    (_, _, _): (usize, Token<'input>, usize),
-    (_, right, _): (usize, usize, usize),
+    (_, left, _): (TextPos, TextPos, TextPos),
+    (_, _, _): (TextPos, Token<'input>, TextPos),
+    (_, _, _): (TextPos, Token<'input>, TextPos),
+    (_, stream, _): (TextPos, (&'input str, TextPos), TextPos),
+    (_, iterator, _): (TextPos, (&'input str, TextPos), TextPos),
+    (_, i, _): (TextPos, Box<Instruction<'input>>, TextPos),
+    (_, _, _): (TextPos, Token<'input>, TextPos),
+    (_, right, _): (TextPos, TextPos, TextPos),
 ) -> Box<Instruction<'input>>
 {
     {
@@ -4443,14 +4443,14 @@ fn __action13<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, left, _): (usize, usize, usize),
-    (_, _, _): (usize, Token<'input>, usize),
-    (_, _, _): (usize, Token<'input>, usize),
-    (_, iterator, _): (usize, (&'input str, usize), usize),
-    (_, _, _): (usize, Token<'input>, usize),
-    (_, right, _): (usize, usize, usize),
+    (_, left, _): (TextPos, TextPos, TextPos),
+    (_, _, _): (TextPos, Token<'input>, TextPos),
+    (_, _, _): (TextPos, Token<'input>, TextPos),
+    (_, iterator, _): (TextPos, (&'input str, TextPos), TextPos),
+    (_, _, _): (TextPos, Token<'input>, TextPos),
+    (_, right, _): (TextPos, TextPos, TextPos),
 ) -> Box<Instruction<'input>>
 {
     {
@@ -4470,13 +4470,13 @@ fn __action14<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, _, _): (usize, Token<'input>, usize),
-    (_, _, _): (usize, Token<'input>, usize),
-    (_, l, _): (usize, Box<Instruction<'input>>, usize),
-    (_, r, _): (usize, Box<Instruction<'input>>, usize),
-    (_, _, _): (usize, Token<'input>, usize),
+    (_, _, _): (TextPos, Token<'input>, TextPos),
+    (_, _, _): (TextPos, Token<'input>, TextPos),
+    (_, l, _): (TextPos, Box<Instruction<'input>>, TextPos),
+    (_, r, _): (TextPos, Box<Instruction<'input>>, TextPos),
+    (_, _, _): (TextPos, Token<'input>, TextPos),
 ) -> Box<Instruction<'input>>
 {
     Box::new(Instruction::Xor(Xor(l, r)))
@@ -4489,16 +4489,16 @@ fn __action15<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, left, _): (usize, usize, usize),
-    (_, _, _): (usize, Token<'input>, usize),
-    (_, _, _): (usize, Token<'input>, usize),
-    (_, l, _): (usize, Value<'input>, usize),
-    (_, r, _): (usize, Value<'input>, usize),
-    (_, i, _): (usize, Box<Instruction<'input>>, usize),
-    (_, _, _): (usize, Token<'input>, usize),
-    (_, right, _): (usize, usize, usize),
+    (_, left, _): (TextPos, TextPos, TextPos),
+    (_, _, _): (TextPos, Token<'input>, TextPos),
+    (_, _, _): (TextPos, Token<'input>, TextPos),
+    (_, l, _): (TextPos, Value<'input>, TextPos),
+    (_, r, _): (TextPos, Value<'input>, TextPos),
+    (_, i, _): (TextPos, Box<Instruction<'input>>, TextPos),
+    (_, _, _): (TextPos, Token<'input>, TextPos),
+    (_, right, _): (TextPos, TextPos, TextPos),
 ) -> Box<Instruction<'input>>
 {
     {
@@ -4517,16 +4517,16 @@ fn __action16<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, left, _): (usize, usize, usize),
-    (_, _, _): (usize, Token<'input>, usize),
-    (_, _, _): (usize, Token<'input>, usize),
-    (_, l, _): (usize, Value<'input>, usize),
-    (_, r, _): (usize, Value<'input>, usize),
-    (_, i, _): (usize, Box<Instruction<'input>>, usize),
-    (_, _, _): (usize, Token<'input>, usize),
-    (_, right, _): (usize, usize, usize),
+    (_, left, _): (TextPos, TextPos, TextPos),
+    (_, _, _): (TextPos, Token<'input>, TextPos),
+    (_, _, _): (TextPos, Token<'input>, TextPos),
+    (_, l, _): (TextPos, Value<'input>, TextPos),
+    (_, r, _): (TextPos, Value<'input>, TextPos),
+    (_, i, _): (TextPos, Box<Instruction<'input>>, TextPos),
+    (_, _, _): (TextPos, Token<'input>, TextPos),
+    (_, right, _): (TextPos, TextPos, TextPos),
 ) -> Box<Instruction<'input>>
 {
     {
@@ -4545,9 +4545,9 @@ fn __action17<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (usize, __lalrpop_util::ErrorRecovery<usize, Token<'input>, ParserError>, usize),
+    (_, __0, _): (TextPos, __lalrpop_util::ErrorRecovery<TextPos, Token<'input>, ParserError>, TextPos),
 ) -> Box<Instruction<'input>>
 {
     { errors.push(__0); Box::new(Instruction::Error) }
@@ -4560,11 +4560,11 @@ fn __action18<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, _, _): (usize, Token<'input>, usize),
-    (_, args, _): (usize, alloc::vec::Vec<Value<'input>>, usize),
-    (_, _, _): (usize, Token<'input>, usize),
+    (_, _, _): (TextPos, Token<'input>, TextPos),
+    (_, args, _): (TextPos, alloc::vec::Vec<Value<'input>>, TextPos),
+    (_, _, _): (TextPos, Token<'input>, TextPos),
 ) -> Vec<Value<'input>>
 {
     args
@@ -4577,13 +4577,13 @@ fn __action19<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, peer_pk, _): (usize, CallInstrValue<'input>, usize),
-    (_, _, _): (usize, Token<'input>, usize),
-    (_, service_id, _): (usize, CallInstrValue<'input>, usize),
-    (_, function_name, _): (usize, CallInstrValue<'input>, usize),
-    (_, _, _): (usize, Token<'input>, usize),
+    (_, peer_pk, _): (TextPos, CallInstrValue<'input>, TextPos),
+    (_, _, _): (TextPos, Token<'input>, TextPos),
+    (_, service_id, _): (TextPos, CallInstrValue<'input>, TextPos),
+    (_, function_name, _): (TextPos, CallInstrValue<'input>, TextPos),
+    (_, _, _): (TextPos, Token<'input>, TextPos),
 ) -> Triplet<'input>
 {
     Triplet {
@@ -4600,9 +4600,9 @@ fn __action20<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, scalar, _): (usize, (&'input str, usize), usize),
+    (_, scalar, _): (TextPos, (&'input str, TextPos), TextPos),
 ) -> ApResult<'input>
 {
     ApResult::scalar(scalar.0, scalar.1)
@@ -4615,9 +4615,9 @@ fn __action21<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, stream, _): (usize, (&'input str, usize), usize),
+    (_, stream, _): (TextPos, (&'input str, TextPos), TextPos),
 ) -> ApResult<'input>
 {
     ApResult::stream(stream.0, stream.1)
@@ -4630,9 +4630,9 @@ fn __action22<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, scalar, _): (usize, (&'input str, usize), usize),
+    (_, scalar, _): (TextPos, (&'input str, TextPos), TextPos),
 ) -> CallOutputValue<'input>
 {
     CallOutputValue::scalar(scalar.0, scalar.1)
@@ -4645,9 +4645,9 @@ fn __action23<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, stream, _): (usize, (&'input str, usize), usize),
+    (_, stream, _): (TextPos, (&'input str, TextPos), TextPos),
 ) -> CallOutputValue<'input>
 {
     CallOutputValue::stream(stream.0, stream.1)
@@ -4660,9 +4660,9 @@ fn __action24<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, scalar, _): (usize, (&'input str, usize), usize),
+    (_, scalar, _): (TextPos, (&'input str, TextPos), TextPos),
 ) -> Fail<'input>
 {
     Fail::Scalar(ScalarWithLambda::new(scalar.0, None, scalar.1))
@@ -4675,9 +4675,9 @@ fn __action25<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, scalar, _): (usize, (&'input str, LambdaAST<'input>, usize), usize),
+    (_, scalar, _): (TextPos, (&'input str, LambdaAST<'input>, TextPos), TextPos),
 ) -> Fail<'input>
 {
     Fail::Scalar(ScalarWithLambda::new(scalar.0, Some(scalar.1), scalar.2))
@@ -4690,10 +4690,10 @@ fn __action26<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, ret_code, _): (usize, i64, usize),
-    (_, error_message, _): (usize, &'input str, usize),
+    (_, ret_code, _): (TextPos, i64, TextPos),
+    (_, error_message, _): (TextPos, &'input str, TextPos),
 ) -> Fail<'input>
 {
     Fail::Literal {
@@ -4709,9 +4709,9 @@ fn __action27<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, canon_stream, _): (usize, (&'input str, LambdaAST<'input>, usize), usize),
+    (_, canon_stream, _): (TextPos, (&'input str, LambdaAST<'input>, TextPos), TextPos),
 ) -> Fail<'input>
 {
     Fail::CanonStream {
@@ -4727,11 +4727,11 @@ fn __action28<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, left, _): (usize, usize, usize),
-    (_, l, _): (usize, Token<'input>, usize),
-    (_, right, _): (usize, usize, usize),
+    (_, left, _): (TextPos, TextPos, TextPos),
+    (_, l, _): (TextPos, Token<'input>, TextPos),
+    (_, right, _): (TextPos, TextPos, TextPos),
 ) -> Fail<'input>
 {
     {
@@ -4746,9 +4746,9 @@ fn __action29<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, scalar, _): (usize, (&'input str, usize), usize),
+    (_, scalar, _): (TextPos, (&'input str, TextPos), TextPos),
 ) -> FoldScalarIterable<'input>
 {
     FoldScalarIterable::Scalar(ScalarWithLambda::new(scalar.0, None, scalar.1))
@@ -4761,9 +4761,9 @@ fn __action30<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, scalar, _): (usize, (&'input str, LambdaAST<'input>, usize), usize),
+    (_, scalar, _): (TextPos, (&'input str, LambdaAST<'input>, TextPos), TextPos),
 ) -> FoldScalarIterable<'input>
 {
     FoldScalarIterable::Scalar(ScalarWithLambda::new(scalar.0, Some(scalar.1), scalar.2))
@@ -4776,9 +4776,9 @@ fn __action31<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, canon_stream, _): (usize, (&'input str, usize), usize),
+    (_, canon_stream, _): (TextPos, (&'input str, TextPos), TextPos),
 ) -> FoldScalarIterable<'input>
 {
     FoldScalarIterable::CanonStream(CanonStream::new(canon_stream.0, canon_stream.1))
@@ -4791,10 +4791,10 @@ fn __action32<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (usize, Token<'input>, usize),
-    (_, __1, _): (usize, Token<'input>, usize),
+    (_, __0, _): (TextPos, Token<'input>, TextPos),
+    (_, __1, _): (TextPos, Token<'input>, TextPos),
 ) -> FoldScalarIterable<'input>
 {
     FoldScalarIterable::EmptyArray
@@ -4807,9 +4807,9 @@ fn __action33<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (usize, CallInstrValue<'input>, usize),
+    (_, __0, _): (TextPos, CallInstrValue<'input>, TextPos),
 ) -> CallInstrValue<'input>
 {
     __0
@@ -4822,9 +4822,9 @@ fn __action34<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (usize, CallInstrValue<'input>, usize),
+    (_, __0, _): (TextPos, CallInstrValue<'input>, TextPos),
 ) -> CallInstrValue<'input>
 {
     __0
@@ -4837,9 +4837,9 @@ fn __action35<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (usize, CallInstrValue<'input>, usize),
+    (_, __0, _): (TextPos, CallInstrValue<'input>, TextPos),
 ) -> CallInstrValue<'input>
 {
     __0
@@ -4852,9 +4852,9 @@ fn __action36<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (usize, Token<'input>, usize),
+    (_, __0, _): (TextPos, Token<'input>, TextPos),
 ) -> CallInstrValue<'input>
 {
     CallInstrValue::InitPeerId
@@ -4867,9 +4867,9 @@ fn __action37<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, l, _): (usize, &'input str, usize),
+    (_, l, _): (TextPos, &'input str, TextPos),
 ) -> CallInstrValue<'input>
 {
     CallInstrValue::Literal(l)
@@ -4882,9 +4882,9 @@ fn __action38<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, scalar, _): (usize, (&'input str, usize), usize),
+    (_, scalar, _): (TextPos, (&'input str, TextPos), TextPos),
 ) -> CallInstrValue<'input>
 {
     CallInstrValue::Variable(VariableWithLambda::scalar(scalar.0, scalar.1))
@@ -4897,9 +4897,9 @@ fn __action39<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, scalar, _): (usize, (&'input str, LambdaAST<'input>, usize), usize),
+    (_, scalar, _): (TextPos, (&'input str, LambdaAST<'input>, TextPos), TextPos),
 ) -> CallInstrValue<'input>
 {
     CallInstrValue::Variable(VariableWithLambda::scalar_wl(scalar.0, scalar.1, scalar.2))
@@ -4912,9 +4912,9 @@ fn __action40<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, stream, _): (usize, (&'input str, usize), usize),
+    (_, stream, _): (TextPos, (&'input str, TextPos), TextPos),
 ) -> CallInstrValue<'input>
 {
     CallInstrValue::Variable(VariableWithLambda::stream(stream.0, stream.1))
@@ -4927,9 +4927,9 @@ fn __action41<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, stream, _): (usize, (&'input str, LambdaAST<'input>, usize), usize),
+    (_, stream, _): (TextPos, (&'input str, LambdaAST<'input>, TextPos), TextPos),
 ) -> CallInstrValue<'input>
 {
     CallInstrValue::Variable(VariableWithLambda::stream_wl(stream.0, stream.1, stream.2))
@@ -4942,9 +4942,9 @@ fn __action42<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, canon_stream, _): (usize, (&'input str, usize), usize),
+    (_, canon_stream, _): (TextPos, (&'input str, TextPos), TextPos),
 ) -> CallInstrValue<'input>
 {
     CallInstrValue::Variable(VariableWithLambda::canon_stream(canon_stream.0, canon_stream.1))
@@ -4957,9 +4957,9 @@ fn __action43<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, canon_stream, _): (usize, (&'input str, LambdaAST<'input>, usize), usize),
+    (_, canon_stream, _): (TextPos, (&'input str, LambdaAST<'input>, TextPos), TextPos),
 ) -> CallInstrValue<'input>
 {
     CallInstrValue::Variable(VariableWithLambda::canon_stream_wl(canon_stream.0, canon_stream.1, canon_stream.2))
@@ -4972,9 +4972,9 @@ fn __action44<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, scalar, _): (usize, (&'input str, usize), usize),
+    (_, scalar, _): (TextPos, (&'input str, TextPos), TextPos),
 ) -> NewArgument<'input>
 {
     NewArgument::Scalar(Scalar::new(scalar.0, scalar.1))
@@ -4987,9 +4987,9 @@ fn __action45<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, stream, _): (usize, (&'input str, usize), usize),
+    (_, stream, _): (TextPos, (&'input str, TextPos), TextPos),
 ) -> NewArgument<'input>
 {
     NewArgument::Stream(Stream::new(stream.0, stream.1))
@@ -5002,9 +5002,9 @@ fn __action46<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, canon_stream, _): (usize, (&'input str, usize), usize),
+    (_, canon_stream, _): (TextPos, (&'input str, TextPos), TextPos),
 ) -> NewArgument<'input>
 {
     NewArgument::CanonStream(CanonStream::new(canon_stream.0, canon_stream.1))
@@ -5017,9 +5017,9 @@ fn __action47<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, integer, _): (usize, i64, usize),
+    (_, integer, _): (TextPos, i64, TextPos),
 ) -> Number
 {
     Number::Int(integer)
@@ -5032,9 +5032,9 @@ fn __action48<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, float, _): (usize, f64, usize),
+    (_, float, _): (TextPos, f64, TextPos),
 ) -> Number
 {
     Number::Float(float)
@@ -5047,9 +5047,9 @@ fn __action49<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (usize, Value<'input>, usize),
+    (_, __0, _): (TextPos, Value<'input>, TextPos),
 ) -> Value<'input>
 {
     __0
@@ -5062,9 +5062,9 @@ fn __action50<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (usize, Token<'input>, usize),
+    (_, __0, _): (TextPos, Token<'input>, TextPos),
 ) -> Value<'input>
 {
     Value::InitPeerId
@@ -5077,9 +5077,9 @@ fn __action51<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (usize, Token<'input>, usize),
+    (_, __0, _): (TextPos, Token<'input>, TextPos),
 ) -> Value<'input>
 {
     Value::LastError(None)
@@ -5092,9 +5092,9 @@ fn __action52<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, le, _): (usize, LambdaAST<'input>, usize),
+    (_, le, _): (TextPos, LambdaAST<'input>, TextPos),
 ) -> Value<'input>
 {
     Value::LastError(Some(le))
@@ -5107,9 +5107,9 @@ fn __action53<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, l, _): (usize, &'input str, usize),
+    (_, l, _): (TextPos, &'input str, TextPos),
 ) -> Value<'input>
 {
     Value::Literal(l)
@@ -5122,9 +5122,9 @@ fn __action54<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (usize, Token<'input>, usize),
+    (_, __0, _): (TextPos, Token<'input>, TextPos),
 ) -> Value<'input>
 {
     Value::Timestamp
@@ -5137,9 +5137,9 @@ fn __action55<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (usize, Token<'input>, usize),
+    (_, __0, _): (TextPos, Token<'input>, TextPos),
 ) -> Value<'input>
 {
     Value::TTL
@@ -5152,9 +5152,9 @@ fn __action56<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, n, _): (usize, Number, usize),
+    (_, n, _): (TextPos, Number, TextPos),
 ) -> Value<'input>
 {
     Value::Number(n)
@@ -5167,9 +5167,9 @@ fn __action57<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, b, _): (usize, bool, usize),
+    (_, b, _): (TextPos, bool, TextPos),
 ) -> Value<'input>
 {
     Value::Boolean(b)
@@ -5182,10 +5182,10 @@ fn __action58<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (usize, Token<'input>, usize),
-    (_, __1, _): (usize, Token<'input>, usize),
+    (_, __0, _): (TextPos, Token<'input>, TextPos),
+    (_, __1, _): (TextPos, Token<'input>, TextPos),
 ) -> Value<'input>
 {
     Value::EmptyArray
@@ -5198,9 +5198,9 @@ fn __action59<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, scalar, _): (usize, (&'input str, usize), usize),
+    (_, scalar, _): (TextPos, (&'input str, TextPos), TextPos),
 ) -> Value<'input>
 {
     Value::Variable(VariableWithLambda::scalar(scalar.0, scalar.1))
@@ -5213,9 +5213,9 @@ fn __action60<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, scalar, _): (usize, (&'input str, LambdaAST<'input>, usize), usize),
+    (_, scalar, _): (TextPos, (&'input str, LambdaAST<'input>, TextPos), TextPos),
 ) -> Value<'input>
 {
     Value::Variable(VariableWithLambda::scalar_wl(scalar.0, scalar.1, scalar.2))
@@ -5228,9 +5228,9 @@ fn __action61<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, stream, _): (usize, (&'input str, usize), usize),
+    (_, stream, _): (TextPos, (&'input str, TextPos), TextPos),
 ) -> Value<'input>
 {
     Value::Variable(VariableWithLambda::stream(stream.0, stream.1))
@@ -5243,9 +5243,9 @@ fn __action62<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, stream, _): (usize, (&'input str, LambdaAST<'input>, usize), usize),
+    (_, stream, _): (TextPos, (&'input str, LambdaAST<'input>, TextPos), TextPos),
 ) -> Value<'input>
 {
     Value::Variable(VariableWithLambda::stream_wl(stream.0, stream.1, stream.2))
@@ -5258,9 +5258,9 @@ fn __action63<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, canon_stream, _): (usize, (&'input str, usize), usize),
+    (_, canon_stream, _): (TextPos, (&'input str, TextPos), TextPos),
 ) -> Value<'input>
 {
     Value::Variable(VariableWithLambda::canon_stream(canon_stream.0, canon_stream.1))
@@ -5273,9 +5273,9 @@ fn __action64<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, canon_stream, _): (usize, (&'input str, LambdaAST<'input>, usize), usize),
+    (_, canon_stream, _): (TextPos, (&'input str, LambdaAST<'input>, TextPos), TextPos),
 ) -> Value<'input>
 {
     Value::Variable(VariableWithLambda::canon_stream_wl(canon_stream.0, canon_stream.1, canon_stream.2))
@@ -5288,9 +5288,9 @@ fn __action65<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (usize, Token<'input>, usize),
+    (_, __0, _): (TextPos, Token<'input>, TextPos),
 ) -> ApArgument<'input>
 {
     ApArgument::InitPeerId
@@ -5303,9 +5303,9 @@ fn __action66<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (usize, Token<'input>, usize),
+    (_, __0, _): (TextPos, Token<'input>, TextPos),
 ) -> ApArgument<'input>
 {
     ApArgument::LastError(None)
@@ -5318,9 +5318,9 @@ fn __action67<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, le, _): (usize, LambdaAST<'input>, usize),
+    (_, le, _): (TextPos, LambdaAST<'input>, TextPos),
 ) -> ApArgument<'input>
 {
     ApArgument::LastError(Some(le))
@@ -5333,9 +5333,9 @@ fn __action68<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (usize, Token<'input>, usize),
+    (_, __0, _): (TextPos, Token<'input>, TextPos),
 ) -> ApArgument<'input>
 {
     ApArgument::Timestamp
@@ -5348,9 +5348,9 @@ fn __action69<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (usize, Token<'input>, usize),
+    (_, __0, _): (TextPos, Token<'input>, TextPos),
 ) -> ApArgument<'input>
 {
     ApArgument::TTL
@@ -5363,9 +5363,9 @@ fn __action70<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, l, _): (usize, &'input str, usize),
+    (_, l, _): (TextPos, &'input str, TextPos),
 ) -> ApArgument<'input>
 {
     ApArgument::Literal(l)
@@ -5378,9 +5378,9 @@ fn __action71<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, n, _): (usize, Number, usize),
+    (_, n, _): (TextPos, Number, TextPos),
 ) -> ApArgument<'input>
 {
     ApArgument::Number(n)
@@ -5393,9 +5393,9 @@ fn __action72<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, b, _): (usize, bool, usize),
+    (_, b, _): (TextPos, bool, TextPos),
 ) -> ApArgument<'input>
 {
     ApArgument::Boolean(b)
@@ -5408,10 +5408,10 @@ fn __action73<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (usize, Token<'input>, usize),
-    (_, __1, _): (usize, Token<'input>, usize),
+    (_, __0, _): (TextPos, Token<'input>, TextPos),
+    (_, __1, _): (TextPos, Token<'input>, TextPos),
 ) -> ApArgument<'input>
 {
     ApArgument::EmptyArray
@@ -5424,9 +5424,9 @@ fn __action74<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, scalar, _): (usize, (&'input str, usize), usize),
+    (_, scalar, _): (TextPos, (&'input str, TextPos), TextPos),
 ) -> ApArgument<'input>
 {
     ApArgument::Scalar(ScalarWithLambda::new(scalar.0, None, scalar.1))
@@ -5439,9 +5439,9 @@ fn __action75<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, scalar, _): (usize, (&'input str, LambdaAST<'input>, usize), usize),
+    (_, scalar, _): (TextPos, (&'input str, LambdaAST<'input>, TextPos), TextPos),
 ) -> ApArgument<'input>
 {
     ApArgument::Scalar(ScalarWithLambda::new(scalar.0, Some(scalar.1), scalar.2))
@@ -5454,9 +5454,9 @@ fn __action76<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, canon_stream, _): (usize, (&'input str, usize), usize),
+    (_, canon_stream, _): (TextPos, (&'input str, TextPos), TextPos),
 ) -> ApArgument<'input>
 {
     ApArgument::CanonStream(CanonStreamWithLambda::new(canon_stream.0, None, canon_stream.1))
@@ -5469,9 +5469,9 @@ fn __action77<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, canon_stream, _): (usize, (&'input str, LambdaAST<'input>, usize), usize),
+    (_, canon_stream, _): (TextPos, (&'input str, LambdaAST<'input>, TextPos), TextPos),
 ) -> ApArgument<'input>
 {
     ApArgument::CanonStream(CanonStreamWithLambda::new(canon_stream.0, Some(canon_stream.1), canon_stream.2))
@@ -5484,9 +5484,9 @@ fn __action78<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, stream, _): (usize, (&'input str, usize), usize),
+    (_, stream, _): (TextPos, (&'input str, TextPos), TextPos),
 ) -> Stream<'input>
 {
     Stream::new(stream.0, stream.1)
@@ -5499,9 +5499,9 @@ fn __action79<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, canon_stream, _): (usize, (&'input str, usize), usize),
+    (_, canon_stream, _): (TextPos, (&'input str, TextPos), TextPos),
 ) -> CanonStream<'input>
 {
     CanonStream::new(canon_stream.0, canon_stream.1)
@@ -5514,10 +5514,10 @@ fn __action80<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __lookbehind: &usize,
-    __lookahead: &usize,
+    __lookbehind: &TextPos,
+    __lookahead: &TextPos,
 ) -> alloc::vec::Vec<Value<'input>>
 {
     alloc::vec![]
@@ -5530,9 +5530,9 @@ fn __action81<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, v, _): (usize, alloc::vec::Vec<Value<'input>>, usize),
+    (_, v, _): (TextPos, alloc::vec::Vec<Value<'input>>, TextPos),
 ) -> alloc::vec::Vec<Value<'input>>
 {
     v
@@ -5545,9 +5545,9 @@ fn __action82<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (usize, Value<'input>, usize),
+    (_, __0, _): (TextPos, Value<'input>, TextPos),
 ) -> Value<'input>
 {
     __0
@@ -5560,11 +5560,11 @@ fn __action83<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __lookbehind: &usize,
-    __lookahead: &usize,
-) -> usize
+    __lookbehind: &TextPos,
+    __lookahead: &TextPos,
+) -> TextPos
 {
     __lookbehind.clone()
 }
@@ -5576,9 +5576,9 @@ fn __action84<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (usize, CallOutputValue<'input>, usize),
+    (_, __0, _): (TextPos, CallOutputValue<'input>, TextPos),
 ) -> core::option::Option<CallOutputValue<'input>>
 {
     Some(__0)
@@ -5591,10 +5591,10 @@ fn __action85<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __lookbehind: &usize,
-    __lookahead: &usize,
+    __lookbehind: &TextPos,
+    __lookahead: &TextPos,
 ) -> core::option::Option<CallOutputValue<'input>>
 {
     None
@@ -5607,11 +5607,11 @@ fn __action86<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __lookbehind: &usize,
-    __lookahead: &usize,
-) -> usize
+    __lookbehind: &TextPos,
+    __lookahead: &TextPos,
+) -> TextPos
 {
     __lookahead.clone()
 }
@@ -5623,9 +5623,9 @@ fn __action87<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (usize, Value<'input>, usize),
+    (_, __0, _): (TextPos, Value<'input>, TextPos),
 ) -> alloc::vec::Vec<Value<'input>>
 {
     alloc::vec![__0]
@@ -5638,10 +5638,10 @@ fn __action88<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, v, _): (usize, alloc::vec::Vec<Value<'input>>, usize),
-    (_, e, _): (usize, Value<'input>, usize),
+    (_, v, _): (TextPos, alloc::vec::Vec<Value<'input>>, TextPos),
+    (_, e, _): (TextPos, Value<'input>, TextPos),
 ) -> alloc::vec::Vec<Value<'input>>
 {
     { let mut v = v; v.push(e); v }
@@ -5654,9 +5654,9 @@ fn __action89<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (usize, Value<'input>, usize),
+    __0: (TextPos, Value<'input>, TextPos),
 ) -> alloc::vec::Vec<Value<'input>>
 {
     let __start0 = __0.0.clone();
@@ -5683,10 +5683,10 @@ fn __action90<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (usize, alloc::vec::Vec<Value<'input>>, usize),
-    __1: (usize, Value<'input>, usize),
+    __0: (TextPos, alloc::vec::Vec<Value<'input>>, TextPos),
+    __1: (TextPos, Value<'input>, TextPos),
 ) -> alloc::vec::Vec<Value<'input>>
 {
     let __start0 = __1.0.clone();
@@ -5714,10 +5714,10 @@ fn __action91<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (usize, Token<'input>, usize),
-    __1: (usize, Token<'input>, usize),
+    __0: (TextPos, Token<'input>, TextPos),
+    __1: (TextPos, Token<'input>, TextPos),
 ) -> Vec<Value<'input>>
 {
     let __start0 = __0.2.clone();
@@ -5747,11 +5747,11 @@ fn __action92<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (usize, Token<'input>, usize),
-    __1: (usize, alloc::vec::Vec<Value<'input>>, usize),
-    __2: (usize, Token<'input>, usize),
+    __0: (TextPos, Token<'input>, TextPos),
+    __1: (TextPos, alloc::vec::Vec<Value<'input>>, TextPos),
+    __2: (TextPos, Token<'input>, TextPos),
 ) -> Vec<Value<'input>>
 {
     let __start0 = __1.0.clone();
@@ -5780,10 +5780,10 @@ fn __action93<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (usize, Token<'input>, usize),
-    __1: (usize, usize, usize),
+    __0: (TextPos, Token<'input>, TextPos),
+    __1: (TextPos, TextPos, TextPos),
 ) -> Fail<'input>
 {
     let __start0 = __0.0.clone();
@@ -5813,15 +5813,15 @@ fn __action94<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (usize, Token<'input>, usize),
-    __1: (usize, Token<'input>, usize),
-    __2: (usize, Triplet<'input>, usize),
-    __3: (usize, Vec<Value<'input>>, usize),
-    __4: (usize, core::option::Option<CallOutputValue<'input>>, usize),
-    __5: (usize, Token<'input>, usize),
-    __6: (usize, usize, usize),
+    __0: (TextPos, Token<'input>, TextPos),
+    __1: (TextPos, Token<'input>, TextPos),
+    __2: (TextPos, Triplet<'input>, TextPos),
+    __3: (TextPos, Vec<Value<'input>>, TextPos),
+    __4: (TextPos, core::option::Option<CallOutputValue<'input>>, TextPos),
+    __5: (TextPos, Token<'input>, TextPos),
+    __6: (TextPos, TextPos, TextPos),
 ) -> Box<Instruction<'input>>
 {
     let __start0 = __0.0.clone();
@@ -5856,15 +5856,15 @@ fn __action95<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (usize, Token<'input>, usize),
-    __1: (usize, Token<'input>, usize),
-    __2: (usize, CallInstrValue<'input>, usize),
-    __3: (usize, Stream<'input>, usize),
-    __4: (usize, CanonStream<'input>, usize),
-    __5: (usize, Token<'input>, usize),
-    __6: (usize, usize, usize),
+    __0: (TextPos, Token<'input>, TextPos),
+    __1: (TextPos, Token<'input>, TextPos),
+    __2: (TextPos, CallInstrValue<'input>, TextPos),
+    __3: (TextPos, Stream<'input>, TextPos),
+    __4: (TextPos, CanonStream<'input>, TextPos),
+    __5: (TextPos, Token<'input>, TextPos),
+    __6: (TextPos, TextPos, TextPos),
 ) -> Box<Instruction<'input>>
 {
     let __start0 = __0.0.clone();
@@ -5899,14 +5899,14 @@ fn __action96<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (usize, Token<'input>, usize),
-    __1: (usize, Token<'input>, usize),
-    __2: (usize, ApArgument<'input>, usize),
-    __3: (usize, ApResult<'input>, usize),
-    __4: (usize, Token<'input>, usize),
-    __5: (usize, usize, usize),
+    __0: (TextPos, Token<'input>, TextPos),
+    __1: (TextPos, Token<'input>, TextPos),
+    __2: (TextPos, ApArgument<'input>, TextPos),
+    __3: (TextPos, ApResult<'input>, TextPos),
+    __4: (TextPos, Token<'input>, TextPos),
+    __5: (TextPos, TextPos, TextPos),
 ) -> Box<Instruction<'input>>
 {
     let __start0 = __0.0.clone();
@@ -5940,14 +5940,14 @@ fn __action97<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (usize, Token<'input>, usize),
-    __1: (usize, Token<'input>, usize),
-    __2: (usize, NewArgument<'input>, usize),
-    __3: (usize, Box<Instruction<'input>>, usize),
-    __4: (usize, Token<'input>, usize),
-    __5: (usize, usize, usize),
+    __0: (TextPos, Token<'input>, TextPos),
+    __1: (TextPos, Token<'input>, TextPos),
+    __2: (TextPos, NewArgument<'input>, TextPos),
+    __3: (TextPos, Box<Instruction<'input>>, TextPos),
+    __4: (TextPos, Token<'input>, TextPos),
+    __5: (TextPos, TextPos, TextPos),
 ) -> Box<Instruction<'input>>
 {
     let __start0 = __0.0.clone();
@@ -5981,15 +5981,15 @@ fn __action98<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (usize, Token<'input>, usize),
-    __1: (usize, Token<'input>, usize),
-    __2: (usize, FoldScalarIterable<'input>, usize),
-    __3: (usize, (&'input str, usize), usize),
-    __4: (usize, Box<Instruction<'input>>, usize),
-    __5: (usize, Token<'input>, usize),
-    __6: (usize, usize, usize),
+    __0: (TextPos, Token<'input>, TextPos),
+    __1: (TextPos, Token<'input>, TextPos),
+    __2: (TextPos, FoldScalarIterable<'input>, TextPos),
+    __3: (TextPos, (&'input str, TextPos), TextPos),
+    __4: (TextPos, Box<Instruction<'input>>, TextPos),
+    __5: (TextPos, Token<'input>, TextPos),
+    __6: (TextPos, TextPos, TextPos),
 ) -> Box<Instruction<'input>>
 {
     let __start0 = __0.0.clone();
@@ -6024,15 +6024,15 @@ fn __action99<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (usize, Token<'input>, usize),
-    __1: (usize, Token<'input>, usize),
-    __2: (usize, (&'input str, usize), usize),
-    __3: (usize, (&'input str, usize), usize),
-    __4: (usize, Box<Instruction<'input>>, usize),
-    __5: (usize, Token<'input>, usize),
-    __6: (usize, usize, usize),
+    __0: (TextPos, Token<'input>, TextPos),
+    __1: (TextPos, Token<'input>, TextPos),
+    __2: (TextPos, (&'input str, TextPos), TextPos),
+    __3: (TextPos, (&'input str, TextPos), TextPos),
+    __4: (TextPos, Box<Instruction<'input>>, TextPos),
+    __5: (TextPos, Token<'input>, TextPos),
+    __6: (TextPos, TextPos, TextPos),
 ) -> Box<Instruction<'input>>
 {
     let __start0 = __0.0.clone();
@@ -6067,13 +6067,13 @@ fn __action100<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (usize, Token<'input>, usize),
-    __1: (usize, Token<'input>, usize),
-    __2: (usize, (&'input str, usize), usize),
-    __3: (usize, Token<'input>, usize),
-    __4: (usize, usize, usize),
+    __0: (TextPos, Token<'input>, TextPos),
+    __1: (TextPos, Token<'input>, TextPos),
+    __2: (TextPos, (&'input str, TextPos), TextPos),
+    __3: (TextPos, Token<'input>, TextPos),
+    __4: (TextPos, TextPos, TextPos),
 ) -> Box<Instruction<'input>>
 {
     let __start0 = __0.0.clone();
@@ -6106,15 +6106,15 @@ fn __action101<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (usize, Token<'input>, usize),
-    __1: (usize, Token<'input>, usize),
-    __2: (usize, Value<'input>, usize),
-    __3: (usize, Value<'input>, usize),
-    __4: (usize, Box<Instruction<'input>>, usize),
-    __5: (usize, Token<'input>, usize),
-    __6: (usize, usize, usize),
+    __0: (TextPos, Token<'input>, TextPos),
+    __1: (TextPos, Token<'input>, TextPos),
+    __2: (TextPos, Value<'input>, TextPos),
+    __3: (TextPos, Value<'input>, TextPos),
+    __4: (TextPos, Box<Instruction<'input>>, TextPos),
+    __5: (TextPos, Token<'input>, TextPos),
+    __6: (TextPos, TextPos, TextPos),
 ) -> Box<Instruction<'input>>
 {
     let __start0 = __0.0.clone();
@@ -6149,15 +6149,15 @@ fn __action102<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (usize, Token<'input>, usize),
-    __1: (usize, Token<'input>, usize),
-    __2: (usize, Value<'input>, usize),
-    __3: (usize, Value<'input>, usize),
-    __4: (usize, Box<Instruction<'input>>, usize),
-    __5: (usize, Token<'input>, usize),
-    __6: (usize, usize, usize),
+    __0: (TextPos, Token<'input>, TextPos),
+    __1: (TextPos, Token<'input>, TextPos),
+    __2: (TextPos, Value<'input>, TextPos),
+    __3: (TextPos, Value<'input>, TextPos),
+    __4: (TextPos, Box<Instruction<'input>>, TextPos),
+    __5: (TextPos, Token<'input>, TextPos),
+    __6: (TextPos, TextPos, TextPos),
 ) -> Box<Instruction<'input>>
 {
     let __start0 = __0.0.clone();
@@ -6192,9 +6192,9 @@ fn __action103<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (usize, Token<'input>, usize),
+    __0: (TextPos, Token<'input>, TextPos),
 ) -> Fail<'input>
 {
     let __start0 = __0.2.clone();
@@ -6223,14 +6223,14 @@ fn __action104<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (usize, Token<'input>, usize),
-    __1: (usize, Token<'input>, usize),
-    __2: (usize, Triplet<'input>, usize),
-    __3: (usize, Vec<Value<'input>>, usize),
-    __4: (usize, core::option::Option<CallOutputValue<'input>>, usize),
-    __5: (usize, Token<'input>, usize),
+    __0: (TextPos, Token<'input>, TextPos),
+    __1: (TextPos, Token<'input>, TextPos),
+    __2: (TextPos, Triplet<'input>, TextPos),
+    __3: (TextPos, Vec<Value<'input>>, TextPos),
+    __4: (TextPos, core::option::Option<CallOutputValue<'input>>, TextPos),
+    __5: (TextPos, Token<'input>, TextPos),
 ) -> Box<Instruction<'input>>
 {
     let __start0 = __5.2.clone();
@@ -6264,14 +6264,14 @@ fn __action105<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (usize, Token<'input>, usize),
-    __1: (usize, Token<'input>, usize),
-    __2: (usize, CallInstrValue<'input>, usize),
-    __3: (usize, Stream<'input>, usize),
-    __4: (usize, CanonStream<'input>, usize),
-    __5: (usize, Token<'input>, usize),
+    __0: (TextPos, Token<'input>, TextPos),
+    __1: (TextPos, Token<'input>, TextPos),
+    __2: (TextPos, CallInstrValue<'input>, TextPos),
+    __3: (TextPos, Stream<'input>, TextPos),
+    __4: (TextPos, CanonStream<'input>, TextPos),
+    __5: (TextPos, Token<'input>, TextPos),
 ) -> Box<Instruction<'input>>
 {
     let __start0 = __5.2.clone();
@@ -6305,13 +6305,13 @@ fn __action106<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (usize, Token<'input>, usize),
-    __1: (usize, Token<'input>, usize),
-    __2: (usize, ApArgument<'input>, usize),
-    __3: (usize, ApResult<'input>, usize),
-    __4: (usize, Token<'input>, usize),
+    __0: (TextPos, Token<'input>, TextPos),
+    __1: (TextPos, Token<'input>, TextPos),
+    __2: (TextPos, ApArgument<'input>, TextPos),
+    __3: (TextPos, ApResult<'input>, TextPos),
+    __4: (TextPos, Token<'input>, TextPos),
 ) -> Box<Instruction<'input>>
 {
     let __start0 = __4.2.clone();
@@ -6344,13 +6344,13 @@ fn __action107<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (usize, Token<'input>, usize),
-    __1: (usize, Token<'input>, usize),
-    __2: (usize, NewArgument<'input>, usize),
-    __3: (usize, Box<Instruction<'input>>, usize),
-    __4: (usize, Token<'input>, usize),
+    __0: (TextPos, Token<'input>, TextPos),
+    __1: (TextPos, Token<'input>, TextPos),
+    __2: (TextPos, NewArgument<'input>, TextPos),
+    __3: (TextPos, Box<Instruction<'input>>, TextPos),
+    __4: (TextPos, Token<'input>, TextPos),
 ) -> Box<Instruction<'input>>
 {
     let __start0 = __4.2.clone();
@@ -6383,14 +6383,14 @@ fn __action108<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (usize, Token<'input>, usize),
-    __1: (usize, Token<'input>, usize),
-    __2: (usize, FoldScalarIterable<'input>, usize),
-    __3: (usize, (&'input str, usize), usize),
-    __4: (usize, Box<Instruction<'input>>, usize),
-    __5: (usize, Token<'input>, usize),
+    __0: (TextPos, Token<'input>, TextPos),
+    __1: (TextPos, Token<'input>, TextPos),
+    __2: (TextPos, FoldScalarIterable<'input>, TextPos),
+    __3: (TextPos, (&'input str, TextPos), TextPos),
+    __4: (TextPos, Box<Instruction<'input>>, TextPos),
+    __5: (TextPos, Token<'input>, TextPos),
 ) -> Box<Instruction<'input>>
 {
     let __start0 = __5.2.clone();
@@ -6424,14 +6424,14 @@ fn __action109<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (usize, Token<'input>, usize),
-    __1: (usize, Token<'input>, usize),
-    __2: (usize, (&'input str, usize), usize),
-    __3: (usize, (&'input str, usize), usize),
-    __4: (usize, Box<Instruction<'input>>, usize),
-    __5: (usize, Token<'input>, usize),
+    __0: (TextPos, Token<'input>, TextPos),
+    __1: (TextPos, Token<'input>, TextPos),
+    __2: (TextPos, (&'input str, TextPos), TextPos),
+    __3: (TextPos, (&'input str, TextPos), TextPos),
+    __4: (TextPos, Box<Instruction<'input>>, TextPos),
+    __5: (TextPos, Token<'input>, TextPos),
 ) -> Box<Instruction<'input>>
 {
     let __start0 = __5.2.clone();
@@ -6465,12 +6465,12 @@ fn __action110<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (usize, Token<'input>, usize),
-    __1: (usize, Token<'input>, usize),
-    __2: (usize, (&'input str, usize), usize),
-    __3: (usize, Token<'input>, usize),
+    __0: (TextPos, Token<'input>, TextPos),
+    __1: (TextPos, Token<'input>, TextPos),
+    __2: (TextPos, (&'input str, TextPos), TextPos),
+    __3: (TextPos, Token<'input>, TextPos),
 ) -> Box<Instruction<'input>>
 {
     let __start0 = __3.2.clone();
@@ -6502,14 +6502,14 @@ fn __action111<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (usize, Token<'input>, usize),
-    __1: (usize, Token<'input>, usize),
-    __2: (usize, Value<'input>, usize),
-    __3: (usize, Value<'input>, usize),
-    __4: (usize, Box<Instruction<'input>>, usize),
-    __5: (usize, Token<'input>, usize),
+    __0: (TextPos, Token<'input>, TextPos),
+    __1: (TextPos, Token<'input>, TextPos),
+    __2: (TextPos, Value<'input>, TextPos),
+    __3: (TextPos, Value<'input>, TextPos),
+    __4: (TextPos, Box<Instruction<'input>>, TextPos),
+    __5: (TextPos, Token<'input>, TextPos),
 ) -> Box<Instruction<'input>>
 {
     let __start0 = __5.2.clone();
@@ -6543,14 +6543,14 @@ fn __action112<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (usize, Token<'input>, usize),
-    __1: (usize, Token<'input>, usize),
-    __2: (usize, Value<'input>, usize),
-    __3: (usize, Value<'input>, usize),
-    __4: (usize, Box<Instruction<'input>>, usize),
-    __5: (usize, Token<'input>, usize),
+    __0: (TextPos, Token<'input>, TextPos),
+    __1: (TextPos, Token<'input>, TextPos),
+    __2: (TextPos, Value<'input>, TextPos),
+    __3: (TextPos, Value<'input>, TextPos),
+    __4: (TextPos, Box<Instruction<'input>>, TextPos),
+    __5: (TextPos, Token<'input>, TextPos),
 ) -> Box<Instruction<'input>>
 {
     let __start0 = __5.2.clone();
@@ -6584,14 +6584,14 @@ fn __action113<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (usize, Token<'input>, usize),
-    __1: (usize, Token<'input>, usize),
-    __2: (usize, Triplet<'input>, usize),
-    __3: (usize, Vec<Value<'input>>, usize),
-    __4: (usize, CallOutputValue<'input>, usize),
-    __5: (usize, Token<'input>, usize),
+    __0: (TextPos, Token<'input>, TextPos),
+    __1: (TextPos, Token<'input>, TextPos),
+    __2: (TextPos, Triplet<'input>, TextPos),
+    __3: (TextPos, Vec<Value<'input>>, TextPos),
+    __4: (TextPos, CallOutputValue<'input>, TextPos),
+    __5: (TextPos, Token<'input>, TextPos),
 ) -> Box<Instruction<'input>>
 {
     let __start0 = __4.0.clone();
@@ -6623,13 +6623,13 @@ fn __action114<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (usize, Token<'input>, usize),
-    __1: (usize, Token<'input>, usize),
-    __2: (usize, Triplet<'input>, usize),
-    __3: (usize, Vec<Value<'input>>, usize),
-    __4: (usize, Token<'input>, usize),
+    __0: (TextPos, Token<'input>, TextPos),
+    __1: (TextPos, Token<'input>, TextPos),
+    __2: (TextPos, Triplet<'input>, TextPos),
+    __3: (TextPos, Vec<Value<'input>>, TextPos),
+    __4: (TextPos, Token<'input>, TextPos),
 ) -> Box<Instruction<'input>>
 {
     let __start0 = __3.2.clone();
@@ -6657,18 +6657,18 @@ fn __action114<
 
 pub trait __ToTriple<'err, 'input, 'v, >
 {
-    fn to_triple(value: Self) -> Result<(usize,Token<'input>,usize), __lalrpop_util::ParseError<usize, Token<'input>, ParserError>>;
+    fn to_triple(value: Self) -> Result<(TextPos,Token<'input>,TextPos), __lalrpop_util::ParseError<TextPos, Token<'input>, ParserError>>;
 }
 
-impl<'err, 'input, 'v, > __ToTriple<'err, 'input, 'v, > for (usize, Token<'input>, usize)
+impl<'err, 'input, 'v, > __ToTriple<'err, 'input, 'v, > for (TextPos, Token<'input>, TextPos)
 {
-    fn to_triple(value: Self) -> Result<(usize,Token<'input>,usize), __lalrpop_util::ParseError<usize, Token<'input>, ParserError>> {
+    fn to_triple(value: Self) -> Result<(TextPos,Token<'input>,TextPos), __lalrpop_util::ParseError<TextPos, Token<'input>, ParserError>> {
         Ok(value)
     }
 }
-impl<'err, 'input, 'v, > __ToTriple<'err, 'input, 'v, > for Result<(usize, Token<'input>, usize), ParserError>
+impl<'err, 'input, 'v, > __ToTriple<'err, 'input, 'v, > for Result<(TextPos, Token<'input>, TextPos), ParserError>
 {
-    fn to_triple(value: Self) -> Result<(usize,Token<'input>,usize), __lalrpop_util::ParseError<usize, Token<'input>, ParserError>> {
+    fn to_triple(value: Self) -> Result<(TextPos,Token<'input>,TextPos), __lalrpop_util::ParseError<TextPos, Token<'input>, ParserError>> {
         match value {
             Ok(v) => Ok(v),
             Err(error) => Err(__lalrpop_util::ParseError::User { error }),

--- a/crates/air-lib/air-parser/src/parser/air.rs
+++ b/crates/air-lib/air-parser/src/parser/air.rs
@@ -1,10 +1,10 @@
 // auto-generated: "lalrpop 0.19.8"
-// sha3: 6015184229228a3f428f95fb29c56509f070f983a1754f1cde84c27a9f0a417d
+// sha3: b654ab99b5c3594daec351b78297ab71ffa5ab7ec34a2288c0cf1be8efb20660
 use crate::ast::*;
 use crate::parser::ParserError;
 use crate::parser::VariableValidator;
 use crate::parser::Span;
-use crate::parser::lexer::{TextPos, Token};
+use crate::parser::lexer::{AirPos, Token};
 use air_lambda_parser::LambdaAST;
 use lalrpop_util::ErrorRecovery;
 use std::rc::Rc;
@@ -23,7 +23,7 @@ mod __parse__AIR {
     use crate::parser::ParserError;
     use crate::parser::VariableValidator;
     use crate::parser::Span;
-    use crate::parser::lexer::{TextPos, Token};
+    use crate::parser::lexer::{AirPos, Token};
     use air_lambda_parser::LambdaAST;
     use lalrpop_util::ErrorRecovery;
     use std::rc::Rc;
@@ -39,16 +39,16 @@ mod __parse__AIR {
      {
         Variant0(Token<'input>),
         Variant1(bool),
-        Variant2((&'input str, TextPos)),
-        Variant3((&'input str, LambdaAST<'input>, TextPos)),
+        Variant2((&'input str, AirPos)),
+        Variant3((&'input str, LambdaAST<'input>, AirPos)),
         Variant4(f64),
         Variant5(i64),
         Variant6(LambdaAST<'input>),
         Variant7(&'input str),
-        Variant8(__lalrpop_util::ErrorRecovery<TextPos, Token<'input>, ParserError>),
+        Variant8(__lalrpop_util::ErrorRecovery<AirPos, Token<'input>, ParserError>),
         Variant9(Value<'input>),
         Variant10(alloc::vec::Vec<Value<'input>>),
-        Variant11(TextPos),
+        Variant11(AirPos),
         Variant12(Box<Instruction<'input>>),
         Variant13(ApArgument<'input>),
         Variant14(ApResult<'input>),
@@ -735,14 +735,14 @@ mod __parse__AIR {
     where 'input: 'err, 'input: 'v
     {
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
         __phantom: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     }
     impl<'err, 'input, 'v> __state_machine::ParserDefinition for __StateMachine<'err, 'input, 'v>
     where 'input: 'err, 'input: 'v
     {
-        type Location = TextPos;
+        type Location = AirPos;
         type Error = ParserError;
         type Token = Token<'input>;
         type TokenIndex = usize;
@@ -1499,10 +1499,10 @@ mod __parse__AIR {
         >(
             &self,
             input: &'input str,
-            errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+            errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
             validator: &'v mut VariableValidator<'input>,
             __tokens0: __TOKENS,
-        ) -> Result<Box<Instruction<'input>>, __lalrpop_util::ParseError<TextPos, Token<'input>, ParserError>>
+        ) -> Result<Box<Instruction<'input>>, __lalrpop_util::ParseError<AirPos, Token<'input>, ParserError>>
         {
             let __tokens = __tokens0.into_iter();
             let mut __tokens = __tokens.map(|t| __ToTriple::to_triple(t));
@@ -1523,7 +1523,7 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
         __error_state: i16,
         __states: & [i16],
@@ -1561,14 +1561,14 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
         __action: i16,
-        __lookahead_start: Option<&TextPos>,
+        __lookahead_start: Option<&AirPos>,
         __states: &mut alloc::vec::Vec<i16>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
-    ) -> Option<Result<Box<Instruction<'input>>,__lalrpop_util::ParseError<TextPos, Token<'input>, ParserError>>>
+    ) -> Option<Result<Box<Instruction<'input>>,__lalrpop_util::ParseError<AirPos, Token<'input>, ParserError>>>
     {
         let (__pop_states, __nonterminal) = match __action {
             0 => {
@@ -1862,33 +1862,44 @@ mod __parse__AIR {
     fn __symbol_type_mismatch() -> ! {
         panic!("symbol type mismatch")
     }
-    fn __pop_Variant3<
-      'input,
-    >(
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
-    ) -> (TextPos, (&'input str, LambdaAST<'input>, TextPos), TextPos)
-     {
-        match __symbols.pop() {
-            Some((__l, __Symbol::Variant3(__v), __r)) => (__l, __v, __r),
-            _ => __symbol_type_mismatch()
-        }
-    }
     fn __pop_Variant2<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
-    ) -> (TextPos, (&'input str, TextPos), TextPos)
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>
+    ) -> (AirPos, (&'input str, AirPos), AirPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant2(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
+    fn __pop_Variant3<
+      'input,
+    >(
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>
+    ) -> (AirPos, (&'input str, LambdaAST<'input>, AirPos), AirPos)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant3(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
+    fn __pop_Variant11<
+      'input,
+    >(
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>
+    ) -> (AirPos, AirPos, AirPos)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant11(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
     fn __pop_Variant13<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
-    ) -> (TextPos, ApArgument<'input>, TextPos)
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>
+    ) -> (AirPos, ApArgument<'input>, AirPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant13(__v), __r)) => (__l, __v, __r),
@@ -1898,8 +1909,8 @@ mod __parse__AIR {
     fn __pop_Variant14<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
-    ) -> (TextPos, ApResult<'input>, TextPos)
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>
+    ) -> (AirPos, ApResult<'input>, AirPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant14(__v), __r)) => (__l, __v, __r),
@@ -1909,8 +1920,8 @@ mod __parse__AIR {
     fn __pop_Variant12<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
-    ) -> (TextPos, Box<Instruction<'input>>, TextPos)
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>
+    ) -> (AirPos, Box<Instruction<'input>>, AirPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant12(__v), __r)) => (__l, __v, __r),
@@ -1920,8 +1931,8 @@ mod __parse__AIR {
     fn __pop_Variant16<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
-    ) -> (TextPos, CallInstrValue<'input>, TextPos)
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>
+    ) -> (AirPos, CallInstrValue<'input>, AirPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant16(__v), __r)) => (__l, __v, __r),
@@ -1931,8 +1942,8 @@ mod __parse__AIR {
     fn __pop_Variant17<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
-    ) -> (TextPos, CallOutputValue<'input>, TextPos)
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>
+    ) -> (AirPos, CallOutputValue<'input>, AirPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant17(__v), __r)) => (__l, __v, __r),
@@ -1942,8 +1953,8 @@ mod __parse__AIR {
     fn __pop_Variant19<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
-    ) -> (TextPos, CanonStream<'input>, TextPos)
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>
+    ) -> (AirPos, CanonStream<'input>, AirPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant19(__v), __r)) => (__l, __v, __r),
@@ -1953,8 +1964,8 @@ mod __parse__AIR {
     fn __pop_Variant20<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
-    ) -> (TextPos, Fail<'input>, TextPos)
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>
+    ) -> (AirPos, Fail<'input>, AirPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant20(__v), __r)) => (__l, __v, __r),
@@ -1964,8 +1975,8 @@ mod __parse__AIR {
     fn __pop_Variant21<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
-    ) -> (TextPos, FoldScalarIterable<'input>, TextPos)
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>
+    ) -> (AirPos, FoldScalarIterable<'input>, AirPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant21(__v), __r)) => (__l, __v, __r),
@@ -1975,8 +1986,8 @@ mod __parse__AIR {
     fn __pop_Variant6<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
-    ) -> (TextPos, LambdaAST<'input>, TextPos)
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>
+    ) -> (AirPos, LambdaAST<'input>, AirPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant6(__v), __r)) => (__l, __v, __r),
@@ -1986,8 +1997,8 @@ mod __parse__AIR {
     fn __pop_Variant22<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
-    ) -> (TextPos, NewArgument<'input>, TextPos)
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>
+    ) -> (AirPos, NewArgument<'input>, AirPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant22(__v), __r)) => (__l, __v, __r),
@@ -1997,8 +2008,8 @@ mod __parse__AIR {
     fn __pop_Variant23<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
-    ) -> (TextPos, Number, TextPos)
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>
+    ) -> (AirPos, Number, AirPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant23(__v), __r)) => (__l, __v, __r),
@@ -2008,30 +2019,19 @@ mod __parse__AIR {
     fn __pop_Variant24<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
-    ) -> (TextPos, Stream<'input>, TextPos)
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>
+    ) -> (AirPos, Stream<'input>, AirPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant24(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant11<
-      'input,
-    >(
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
-    ) -> (TextPos, TextPos, TextPos)
-     {
-        match __symbols.pop() {
-            Some((__l, __Symbol::Variant11(__v), __r)) => (__l, __v, __r),
-            _ => __symbol_type_mismatch()
-        }
-    }
     fn __pop_Variant0<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
-    ) -> (TextPos, Token<'input>, TextPos)
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>
+    ) -> (AirPos, Token<'input>, AirPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant0(__v), __r)) => (__l, __v, __r),
@@ -2041,8 +2041,8 @@ mod __parse__AIR {
     fn __pop_Variant25<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
-    ) -> (TextPos, Triplet<'input>, TextPos)
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>
+    ) -> (AirPos, Triplet<'input>, AirPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant25(__v), __r)) => (__l, __v, __r),
@@ -2052,8 +2052,8 @@ mod __parse__AIR {
     fn __pop_Variant9<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
-    ) -> (TextPos, Value<'input>, TextPos)
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>
+    ) -> (AirPos, Value<'input>, AirPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant9(__v), __r)) => (__l, __v, __r),
@@ -2063,8 +2063,8 @@ mod __parse__AIR {
     fn __pop_Variant15<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
-    ) -> (TextPos, Vec<Value<'input>>, TextPos)
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>
+    ) -> (AirPos, Vec<Value<'input>>, AirPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant15(__v), __r)) => (__l, __v, __r),
@@ -2074,8 +2074,8 @@ mod __parse__AIR {
     fn __pop_Variant8<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
-    ) -> (TextPos, __lalrpop_util::ErrorRecovery<TextPos, Token<'input>, ParserError>, TextPos)
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>
+    ) -> (AirPos, __lalrpop_util::ErrorRecovery<AirPos, Token<'input>, ParserError>, AirPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant8(__v), __r)) => (__l, __v, __r),
@@ -2085,8 +2085,8 @@ mod __parse__AIR {
     fn __pop_Variant10<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
-    ) -> (TextPos, alloc::vec::Vec<Value<'input>>, TextPos)
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>
+    ) -> (AirPos, alloc::vec::Vec<Value<'input>>, AirPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant10(__v), __r)) => (__l, __v, __r),
@@ -2096,8 +2096,8 @@ mod __parse__AIR {
     fn __pop_Variant1<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
-    ) -> (TextPos, bool, TextPos)
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>
+    ) -> (AirPos, bool, AirPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant1(__v), __r)) => (__l, __v, __r),
@@ -2107,8 +2107,8 @@ mod __parse__AIR {
     fn __pop_Variant18<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
-    ) -> (TextPos, core::option::Option<CallOutputValue<'input>>, TextPos)
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>
+    ) -> (AirPos, core::option::Option<CallOutputValue<'input>>, AirPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant18(__v), __r)) => (__l, __v, __r),
@@ -2118,8 +2118,8 @@ mod __parse__AIR {
     fn __pop_Variant4<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
-    ) -> (TextPos, f64, TextPos)
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>
+    ) -> (AirPos, f64, AirPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant4(__v), __r)) => (__l, __v, __r),
@@ -2129,8 +2129,8 @@ mod __parse__AIR {
     fn __pop_Variant5<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
-    ) -> (TextPos, i64, TextPos)
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>
+    ) -> (AirPos, i64, AirPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant5(__v), __r)) => (__l, __v, __r),
@@ -2140,8 +2140,8 @@ mod __parse__AIR {
     fn __pop_Variant7<
       'input,
     >(
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>
-    ) -> (TextPos, &'input str, TextPos)
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>
+    ) -> (AirPos, &'input str, AirPos)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant7(__v), __r)) => (__l, __v, __r),
@@ -2154,10 +2154,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2175,10 +2175,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2195,10 +2195,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2216,10 +2216,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2237,10 +2237,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2260,10 +2260,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2280,10 +2280,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2300,10 +2300,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2321,10 +2321,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2342,10 +2342,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2363,10 +2363,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2384,10 +2384,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2405,10 +2405,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2426,10 +2426,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2447,10 +2447,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2468,10 +2468,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2489,10 +2489,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2512,10 +2512,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2533,10 +2533,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2554,10 +2554,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2575,10 +2575,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2596,10 +2596,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2617,10 +2617,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2638,10 +2638,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2659,10 +2659,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2682,10 +2682,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2706,10 +2706,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2727,10 +2727,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2748,10 +2748,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2769,10 +2769,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2790,10 +2790,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2811,10 +2811,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2832,10 +2832,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2853,10 +2853,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2874,10 +2874,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2895,10 +2895,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2916,10 +2916,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2937,10 +2937,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2957,10 +2957,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2978,10 +2978,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -2999,10 +2999,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3020,10 +3020,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3043,10 +3043,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3064,10 +3064,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3085,10 +3085,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3106,10 +3106,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3127,10 +3127,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3148,10 +3148,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3171,10 +3171,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3192,10 +3192,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3219,10 +3219,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3245,10 +3245,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3272,10 +3272,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3298,10 +3298,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3324,10 +3324,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3350,10 +3350,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3374,10 +3374,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3398,10 +3398,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3424,10 +3424,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3449,10 +3449,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3476,10 +3476,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3503,10 +3503,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3528,10 +3528,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3554,10 +3554,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3581,10 +3581,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3608,10 +3608,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3629,10 +3629,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3650,10 +3650,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3671,10 +3671,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3692,10 +3692,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3713,10 +3713,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3734,10 +3734,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3755,10 +3755,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3776,10 +3776,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3797,10 +3797,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3823,10 +3823,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3844,10 +3844,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3865,10 +3865,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3886,10 +3886,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3907,10 +3907,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3928,10 +3928,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3949,10 +3949,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3970,10 +3970,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -3991,10 +3991,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -4014,10 +4014,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -4035,10 +4035,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -4056,10 +4056,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -4077,10 +4077,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -4098,10 +4098,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -4119,10 +4119,10 @@ mod __parse__AIR {
         'v,
     >(
         input: &'input str,
-        errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+        errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
         validator: &'v mut VariableValidator<'input>,
-        __lookahead_start: Option<&TextPos>,
-        __symbols: &mut alloc::vec::Vec<(TextPos,__Symbol<'input>,TextPos)>,
+        __lookahead_start: Option<&AirPos>,
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
     ) -> (usize, usize)
     {
@@ -4144,9 +4144,9 @@ fn __action0<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (TextPos, Box<Instruction<'input>>, TextPos),
+    (_, __0, _): (AirPos, Box<Instruction<'input>>, AirPos),
 ) -> Box<Instruction<'input>>
 {
     __0
@@ -4159,9 +4159,9 @@ fn __action1<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (TextPos, Box<Instruction<'input>>, TextPos),
+    (_, __0, _): (AirPos, Box<Instruction<'input>>, AirPos),
 ) -> Box<Instruction<'input>>
 {
     __0
@@ -4174,16 +4174,16 @@ fn __action2<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, left, _): (TextPos, TextPos, TextPos),
-    (_, _, _): (TextPos, Token<'input>, TextPos),
-    (_, _, _): (TextPos, Token<'input>, TextPos),
-    (_, triplet, _): (TextPos, Triplet<'input>, TextPos),
-    (_, args, _): (TextPos, Vec<Value<'input>>, TextPos),
-    (_, output, _): (TextPos, core::option::Option<CallOutputValue<'input>>, TextPos),
-    (_, _, _): (TextPos, Token<'input>, TextPos),
-    (_, right, _): (TextPos, TextPos, TextPos),
+    (_, left, _): (AirPos, AirPos, AirPos),
+    (_, _, _): (AirPos, Token<'input>, AirPos),
+    (_, _, _): (AirPos, Token<'input>, AirPos),
+    (_, triplet, _): (AirPos, Triplet<'input>, AirPos),
+    (_, args, _): (AirPos, Vec<Value<'input>>, AirPos),
+    (_, output, _): (AirPos, core::option::Option<CallOutputValue<'input>>, AirPos),
+    (_, _, _): (AirPos, Token<'input>, AirPos),
+    (_, right, _): (AirPos, AirPos, AirPos),
 ) -> Box<Instruction<'input>>
 {
     {
@@ -4205,16 +4205,16 @@ fn __action3<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, left, _): (TextPos, TextPos, TextPos),
-    (_, _, _): (TextPos, Token<'input>, TextPos),
-    (_, _, _): (TextPos, Token<'input>, TextPos),
-    (_, peer_pk, _): (TextPos, CallInstrValue<'input>, TextPos),
-    (_, stream, _): (TextPos, Stream<'input>, TextPos),
-    (_, canon_stream, _): (TextPos, CanonStream<'input>, TextPos),
-    (_, _, _): (TextPos, Token<'input>, TextPos),
-    (_, right, _): (TextPos, TextPos, TextPos),
+    (_, left, _): (AirPos, AirPos, AirPos),
+    (_, _, _): (AirPos, Token<'input>, AirPos),
+    (_, _, _): (AirPos, Token<'input>, AirPos),
+    (_, peer_pk, _): (AirPos, CallInstrValue<'input>, AirPos),
+    (_, stream, _): (AirPos, Stream<'input>, AirPos),
+    (_, canon_stream, _): (AirPos, CanonStream<'input>, AirPos),
+    (_, _, _): (AirPos, Token<'input>, AirPos),
+    (_, right, _): (AirPos, AirPos, AirPos),
 ) -> Box<Instruction<'input>>
 {
     {
@@ -4234,15 +4234,15 @@ fn __action4<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, left, _): (TextPos, TextPos, TextPos),
-    (_, _, _): (TextPos, Token<'input>, TextPos),
-    (_, _, _): (TextPos, Token<'input>, TextPos),
-    (_, arg, _): (TextPos, ApArgument<'input>, TextPos),
-    (_, result, _): (TextPos, ApResult<'input>, TextPos),
-    (_, _, _): (TextPos, Token<'input>, TextPos),
-    (_, right, _): (TextPos, TextPos, TextPos),
+    (_, left, _): (AirPos, AirPos, AirPos),
+    (_, _, _): (AirPos, Token<'input>, AirPos),
+    (_, _, _): (AirPos, Token<'input>, AirPos),
+    (_, arg, _): (AirPos, ApArgument<'input>, AirPos),
+    (_, result, _): (AirPos, ApResult<'input>, AirPos),
+    (_, _, _): (AirPos, Token<'input>, AirPos),
+    (_, right, _): (AirPos, AirPos, AirPos),
 ) -> Box<Instruction<'input>>
 {
     {
@@ -4262,13 +4262,13 @@ fn __action5<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, _, _): (TextPos, Token<'input>, TextPos),
-    (_, _, _): (TextPos, Token<'input>, TextPos),
-    (_, l, _): (TextPos, Box<Instruction<'input>>, TextPos),
-    (_, r, _): (TextPos, Box<Instruction<'input>>, TextPos),
-    (_, _, _): (TextPos, Token<'input>, TextPos),
+    (_, _, _): (AirPos, Token<'input>, AirPos),
+    (_, _, _): (AirPos, Token<'input>, AirPos),
+    (_, l, _): (AirPos, Box<Instruction<'input>>, AirPos),
+    (_, r, _): (AirPos, Box<Instruction<'input>>, AirPos),
+    (_, _, _): (AirPos, Token<'input>, AirPos),
 ) -> Box<Instruction<'input>>
 {
     Box::new(Instruction::Seq(Seq::new(l, r)))
@@ -4281,13 +4281,13 @@ fn __action6<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, _, _): (TextPos, Token<'input>, TextPos),
-    (_, _, _): (TextPos, Token<'input>, TextPos),
-    (_, l, _): (TextPos, Box<Instruction<'input>>, TextPos),
-    (_, r, _): (TextPos, Box<Instruction<'input>>, TextPos),
-    (_, _, _): (TextPos, Token<'input>, TextPos),
+    (_, _, _): (AirPos, Token<'input>, AirPos),
+    (_, _, _): (AirPos, Token<'input>, AirPos),
+    (_, l, _): (AirPos, Box<Instruction<'input>>, AirPos),
+    (_, r, _): (AirPos, Box<Instruction<'input>>, AirPos),
+    (_, _, _): (AirPos, Token<'input>, AirPos),
 ) -> Box<Instruction<'input>>
 {
     Box::new(Instruction::Par(Par::new(l, r)))
@@ -4300,11 +4300,11 @@ fn __action7<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (TextPos, Token<'input>, TextPos),
-    (_, __1, _): (TextPos, Token<'input>, TextPos),
-    (_, __2, _): (TextPos, Token<'input>, TextPos),
+    (_, __0, _): (AirPos, Token<'input>, AirPos),
+    (_, __1, _): (AirPos, Token<'input>, AirPos),
+    (_, __2, _): (AirPos, Token<'input>, AirPos),
 ) -> Box<Instruction<'input>>
 {
     Box::new(Instruction::Never(Never))
@@ -4317,11 +4317,11 @@ fn __action8<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (TextPos, Token<'input>, TextPos),
-    (_, __1, _): (TextPos, Token<'input>, TextPos),
-    (_, __2, _): (TextPos, Token<'input>, TextPos),
+    (_, __0, _): (AirPos, Token<'input>, AirPos),
+    (_, __1, _): (AirPos, Token<'input>, AirPos),
+    (_, __2, _): (AirPos, Token<'input>, AirPos),
 ) -> Box<Instruction<'input>>
 {
     Box::new(Instruction::Null(Null))
@@ -4334,15 +4334,15 @@ fn __action9<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, left, _): (TextPos, TextPos, TextPos),
-    (_, _, _): (TextPos, Token<'input>, TextPos),
-    (_, _, _): (TextPos, Token<'input>, TextPos),
-    (_, argument, _): (TextPos, NewArgument<'input>, TextPos),
-    (_, instruction, _): (TextPos, Box<Instruction<'input>>, TextPos),
-    (_, _, _): (TextPos, Token<'input>, TextPos),
-    (_, right, _): (TextPos, TextPos, TextPos),
+    (_, left, _): (AirPos, AirPos, AirPos),
+    (_, _, _): (AirPos, Token<'input>, AirPos),
+    (_, _, _): (AirPos, Token<'input>, AirPos),
+    (_, argument, _): (AirPos, NewArgument<'input>, AirPos),
+    (_, instruction, _): (AirPos, Box<Instruction<'input>>, AirPos),
+    (_, _, _): (AirPos, Token<'input>, AirPos),
+    (_, right, _): (AirPos, AirPos, AirPos),
 ) -> Box<Instruction<'input>>
 {
     {
@@ -4362,12 +4362,12 @@ fn __action10<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, _, _): (TextPos, Token<'input>, TextPos),
-    (_, _, _): (TextPos, Token<'input>, TextPos),
-    (_, fail_body, _): (TextPos, Fail<'input>, TextPos),
-    (_, _, _): (TextPos, Token<'input>, TextPos),
+    (_, _, _): (AirPos, Token<'input>, AirPos),
+    (_, _, _): (AirPos, Token<'input>, AirPos),
+    (_, fail_body, _): (AirPos, Fail<'input>, AirPos),
+    (_, _, _): (AirPos, Token<'input>, AirPos),
 ) -> Box<Instruction<'input>>
 {
     {
@@ -4382,16 +4382,16 @@ fn __action11<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, left, _): (TextPos, TextPos, TextPos),
-    (_, _, _): (TextPos, Token<'input>, TextPos),
-    (_, _, _): (TextPos, Token<'input>, TextPos),
-    (_, iterable, _): (TextPos, FoldScalarIterable<'input>, TextPos),
-    (_, iterator, _): (TextPos, (&'input str, TextPos), TextPos),
-    (_, i, _): (TextPos, Box<Instruction<'input>>, TextPos),
-    (_, _, _): (TextPos, Token<'input>, TextPos),
-    (_, right, _): (TextPos, TextPos, TextPos),
+    (_, left, _): (AirPos, AirPos, AirPos),
+    (_, _, _): (AirPos, Token<'input>, AirPos),
+    (_, _, _): (AirPos, Token<'input>, AirPos),
+    (_, iterable, _): (AirPos, FoldScalarIterable<'input>, AirPos),
+    (_, iterator, _): (AirPos, (&'input str, AirPos), AirPos),
+    (_, i, _): (AirPos, Box<Instruction<'input>>, AirPos),
+    (_, _, _): (AirPos, Token<'input>, AirPos),
+    (_, right, _): (AirPos, AirPos, AirPos),
 ) -> Box<Instruction<'input>>
 {
     {
@@ -4412,16 +4412,16 @@ fn __action12<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, left, _): (TextPos, TextPos, TextPos),
-    (_, _, _): (TextPos, Token<'input>, TextPos),
-    (_, _, _): (TextPos, Token<'input>, TextPos),
-    (_, stream, _): (TextPos, (&'input str, TextPos), TextPos),
-    (_, iterator, _): (TextPos, (&'input str, TextPos), TextPos),
-    (_, i, _): (TextPos, Box<Instruction<'input>>, TextPos),
-    (_, _, _): (TextPos, Token<'input>, TextPos),
-    (_, right, _): (TextPos, TextPos, TextPos),
+    (_, left, _): (AirPos, AirPos, AirPos),
+    (_, _, _): (AirPos, Token<'input>, AirPos),
+    (_, _, _): (AirPos, Token<'input>, AirPos),
+    (_, stream, _): (AirPos, (&'input str, AirPos), AirPos),
+    (_, iterator, _): (AirPos, (&'input str, AirPos), AirPos),
+    (_, i, _): (AirPos, Box<Instruction<'input>>, AirPos),
+    (_, _, _): (AirPos, Token<'input>, AirPos),
+    (_, right, _): (AirPos, AirPos, AirPos),
 ) -> Box<Instruction<'input>>
 {
     {
@@ -4443,14 +4443,14 @@ fn __action13<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, left, _): (TextPos, TextPos, TextPos),
-    (_, _, _): (TextPos, Token<'input>, TextPos),
-    (_, _, _): (TextPos, Token<'input>, TextPos),
-    (_, iterator, _): (TextPos, (&'input str, TextPos), TextPos),
-    (_, _, _): (TextPos, Token<'input>, TextPos),
-    (_, right, _): (TextPos, TextPos, TextPos),
+    (_, left, _): (AirPos, AirPos, AirPos),
+    (_, _, _): (AirPos, Token<'input>, AirPos),
+    (_, _, _): (AirPos, Token<'input>, AirPos),
+    (_, iterator, _): (AirPos, (&'input str, AirPos), AirPos),
+    (_, _, _): (AirPos, Token<'input>, AirPos),
+    (_, right, _): (AirPos, AirPos, AirPos),
 ) -> Box<Instruction<'input>>
 {
     {
@@ -4470,13 +4470,13 @@ fn __action14<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, _, _): (TextPos, Token<'input>, TextPos),
-    (_, _, _): (TextPos, Token<'input>, TextPos),
-    (_, l, _): (TextPos, Box<Instruction<'input>>, TextPos),
-    (_, r, _): (TextPos, Box<Instruction<'input>>, TextPos),
-    (_, _, _): (TextPos, Token<'input>, TextPos),
+    (_, _, _): (AirPos, Token<'input>, AirPos),
+    (_, _, _): (AirPos, Token<'input>, AirPos),
+    (_, l, _): (AirPos, Box<Instruction<'input>>, AirPos),
+    (_, r, _): (AirPos, Box<Instruction<'input>>, AirPos),
+    (_, _, _): (AirPos, Token<'input>, AirPos),
 ) -> Box<Instruction<'input>>
 {
     Box::new(Instruction::Xor(Xor(l, r)))
@@ -4489,16 +4489,16 @@ fn __action15<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, left, _): (TextPos, TextPos, TextPos),
-    (_, _, _): (TextPos, Token<'input>, TextPos),
-    (_, _, _): (TextPos, Token<'input>, TextPos),
-    (_, l, _): (TextPos, Value<'input>, TextPos),
-    (_, r, _): (TextPos, Value<'input>, TextPos),
-    (_, i, _): (TextPos, Box<Instruction<'input>>, TextPos),
-    (_, _, _): (TextPos, Token<'input>, TextPos),
-    (_, right, _): (TextPos, TextPos, TextPos),
+    (_, left, _): (AirPos, AirPos, AirPos),
+    (_, _, _): (AirPos, Token<'input>, AirPos),
+    (_, _, _): (AirPos, Token<'input>, AirPos),
+    (_, l, _): (AirPos, Value<'input>, AirPos),
+    (_, r, _): (AirPos, Value<'input>, AirPos),
+    (_, i, _): (AirPos, Box<Instruction<'input>>, AirPos),
+    (_, _, _): (AirPos, Token<'input>, AirPos),
+    (_, right, _): (AirPos, AirPos, AirPos),
 ) -> Box<Instruction<'input>>
 {
     {
@@ -4517,16 +4517,16 @@ fn __action16<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, left, _): (TextPos, TextPos, TextPos),
-    (_, _, _): (TextPos, Token<'input>, TextPos),
-    (_, _, _): (TextPos, Token<'input>, TextPos),
-    (_, l, _): (TextPos, Value<'input>, TextPos),
-    (_, r, _): (TextPos, Value<'input>, TextPos),
-    (_, i, _): (TextPos, Box<Instruction<'input>>, TextPos),
-    (_, _, _): (TextPos, Token<'input>, TextPos),
-    (_, right, _): (TextPos, TextPos, TextPos),
+    (_, left, _): (AirPos, AirPos, AirPos),
+    (_, _, _): (AirPos, Token<'input>, AirPos),
+    (_, _, _): (AirPos, Token<'input>, AirPos),
+    (_, l, _): (AirPos, Value<'input>, AirPos),
+    (_, r, _): (AirPos, Value<'input>, AirPos),
+    (_, i, _): (AirPos, Box<Instruction<'input>>, AirPos),
+    (_, _, _): (AirPos, Token<'input>, AirPos),
+    (_, right, _): (AirPos, AirPos, AirPos),
 ) -> Box<Instruction<'input>>
 {
     {
@@ -4545,9 +4545,9 @@ fn __action17<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (TextPos, __lalrpop_util::ErrorRecovery<TextPos, Token<'input>, ParserError>, TextPos),
+    (_, __0, _): (AirPos, __lalrpop_util::ErrorRecovery<AirPos, Token<'input>, ParserError>, AirPos),
 ) -> Box<Instruction<'input>>
 {
     { errors.push(__0); Box::new(Instruction::Error) }
@@ -4560,11 +4560,11 @@ fn __action18<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, _, _): (TextPos, Token<'input>, TextPos),
-    (_, args, _): (TextPos, alloc::vec::Vec<Value<'input>>, TextPos),
-    (_, _, _): (TextPos, Token<'input>, TextPos),
+    (_, _, _): (AirPos, Token<'input>, AirPos),
+    (_, args, _): (AirPos, alloc::vec::Vec<Value<'input>>, AirPos),
+    (_, _, _): (AirPos, Token<'input>, AirPos),
 ) -> Vec<Value<'input>>
 {
     args
@@ -4577,13 +4577,13 @@ fn __action19<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, peer_pk, _): (TextPos, CallInstrValue<'input>, TextPos),
-    (_, _, _): (TextPos, Token<'input>, TextPos),
-    (_, service_id, _): (TextPos, CallInstrValue<'input>, TextPos),
-    (_, function_name, _): (TextPos, CallInstrValue<'input>, TextPos),
-    (_, _, _): (TextPos, Token<'input>, TextPos),
+    (_, peer_pk, _): (AirPos, CallInstrValue<'input>, AirPos),
+    (_, _, _): (AirPos, Token<'input>, AirPos),
+    (_, service_id, _): (AirPos, CallInstrValue<'input>, AirPos),
+    (_, function_name, _): (AirPos, CallInstrValue<'input>, AirPos),
+    (_, _, _): (AirPos, Token<'input>, AirPos),
 ) -> Triplet<'input>
 {
     Triplet {
@@ -4600,9 +4600,9 @@ fn __action20<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, scalar, _): (TextPos, (&'input str, TextPos), TextPos),
+    (_, scalar, _): (AirPos, (&'input str, AirPos), AirPos),
 ) -> ApResult<'input>
 {
     ApResult::scalar(scalar.0, scalar.1)
@@ -4615,9 +4615,9 @@ fn __action21<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, stream, _): (TextPos, (&'input str, TextPos), TextPos),
+    (_, stream, _): (AirPos, (&'input str, AirPos), AirPos),
 ) -> ApResult<'input>
 {
     ApResult::stream(stream.0, stream.1)
@@ -4630,9 +4630,9 @@ fn __action22<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, scalar, _): (TextPos, (&'input str, TextPos), TextPos),
+    (_, scalar, _): (AirPos, (&'input str, AirPos), AirPos),
 ) -> CallOutputValue<'input>
 {
     CallOutputValue::scalar(scalar.0, scalar.1)
@@ -4645,9 +4645,9 @@ fn __action23<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, stream, _): (TextPos, (&'input str, TextPos), TextPos),
+    (_, stream, _): (AirPos, (&'input str, AirPos), AirPos),
 ) -> CallOutputValue<'input>
 {
     CallOutputValue::stream(stream.0, stream.1)
@@ -4660,9 +4660,9 @@ fn __action24<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, scalar, _): (TextPos, (&'input str, TextPos), TextPos),
+    (_, scalar, _): (AirPos, (&'input str, AirPos), AirPos),
 ) -> Fail<'input>
 {
     Fail::Scalar(ScalarWithLambda::new(scalar.0, None, scalar.1))
@@ -4675,9 +4675,9 @@ fn __action25<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, scalar, _): (TextPos, (&'input str, LambdaAST<'input>, TextPos), TextPos),
+    (_, scalar, _): (AirPos, (&'input str, LambdaAST<'input>, AirPos), AirPos),
 ) -> Fail<'input>
 {
     Fail::Scalar(ScalarWithLambda::new(scalar.0, Some(scalar.1), scalar.2))
@@ -4690,10 +4690,10 @@ fn __action26<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, ret_code, _): (TextPos, i64, TextPos),
-    (_, error_message, _): (TextPos, &'input str, TextPos),
+    (_, ret_code, _): (AirPos, i64, AirPos),
+    (_, error_message, _): (AirPos, &'input str, AirPos),
 ) -> Fail<'input>
 {
     Fail::Literal {
@@ -4709,9 +4709,9 @@ fn __action27<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, canon_stream, _): (TextPos, (&'input str, LambdaAST<'input>, TextPos), TextPos),
+    (_, canon_stream, _): (AirPos, (&'input str, LambdaAST<'input>, AirPos), AirPos),
 ) -> Fail<'input>
 {
     Fail::CanonStream {
@@ -4727,11 +4727,11 @@ fn __action28<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, left, _): (TextPos, TextPos, TextPos),
-    (_, l, _): (TextPos, Token<'input>, TextPos),
-    (_, right, _): (TextPos, TextPos, TextPos),
+    (_, left, _): (AirPos, AirPos, AirPos),
+    (_, l, _): (AirPos, Token<'input>, AirPos),
+    (_, right, _): (AirPos, AirPos, AirPos),
 ) -> Fail<'input>
 {
     {
@@ -4746,9 +4746,9 @@ fn __action29<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, scalar, _): (TextPos, (&'input str, TextPos), TextPos),
+    (_, scalar, _): (AirPos, (&'input str, AirPos), AirPos),
 ) -> FoldScalarIterable<'input>
 {
     FoldScalarIterable::Scalar(ScalarWithLambda::new(scalar.0, None, scalar.1))
@@ -4761,9 +4761,9 @@ fn __action30<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, scalar, _): (TextPos, (&'input str, LambdaAST<'input>, TextPos), TextPos),
+    (_, scalar, _): (AirPos, (&'input str, LambdaAST<'input>, AirPos), AirPos),
 ) -> FoldScalarIterable<'input>
 {
     FoldScalarIterable::Scalar(ScalarWithLambda::new(scalar.0, Some(scalar.1), scalar.2))
@@ -4776,9 +4776,9 @@ fn __action31<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, canon_stream, _): (TextPos, (&'input str, TextPos), TextPos),
+    (_, canon_stream, _): (AirPos, (&'input str, AirPos), AirPos),
 ) -> FoldScalarIterable<'input>
 {
     FoldScalarIterable::CanonStream(CanonStream::new(canon_stream.0, canon_stream.1))
@@ -4791,10 +4791,10 @@ fn __action32<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (TextPos, Token<'input>, TextPos),
-    (_, __1, _): (TextPos, Token<'input>, TextPos),
+    (_, __0, _): (AirPos, Token<'input>, AirPos),
+    (_, __1, _): (AirPos, Token<'input>, AirPos),
 ) -> FoldScalarIterable<'input>
 {
     FoldScalarIterable::EmptyArray
@@ -4807,9 +4807,9 @@ fn __action33<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (TextPos, CallInstrValue<'input>, TextPos),
+    (_, __0, _): (AirPos, CallInstrValue<'input>, AirPos),
 ) -> CallInstrValue<'input>
 {
     __0
@@ -4822,9 +4822,9 @@ fn __action34<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (TextPos, CallInstrValue<'input>, TextPos),
+    (_, __0, _): (AirPos, CallInstrValue<'input>, AirPos),
 ) -> CallInstrValue<'input>
 {
     __0
@@ -4837,9 +4837,9 @@ fn __action35<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (TextPos, CallInstrValue<'input>, TextPos),
+    (_, __0, _): (AirPos, CallInstrValue<'input>, AirPos),
 ) -> CallInstrValue<'input>
 {
     __0
@@ -4852,9 +4852,9 @@ fn __action36<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (TextPos, Token<'input>, TextPos),
+    (_, __0, _): (AirPos, Token<'input>, AirPos),
 ) -> CallInstrValue<'input>
 {
     CallInstrValue::InitPeerId
@@ -4867,9 +4867,9 @@ fn __action37<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, l, _): (TextPos, &'input str, TextPos),
+    (_, l, _): (AirPos, &'input str, AirPos),
 ) -> CallInstrValue<'input>
 {
     CallInstrValue::Literal(l)
@@ -4882,9 +4882,9 @@ fn __action38<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, scalar, _): (TextPos, (&'input str, TextPos), TextPos),
+    (_, scalar, _): (AirPos, (&'input str, AirPos), AirPos),
 ) -> CallInstrValue<'input>
 {
     CallInstrValue::Variable(VariableWithLambda::scalar(scalar.0, scalar.1))
@@ -4897,9 +4897,9 @@ fn __action39<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, scalar, _): (TextPos, (&'input str, LambdaAST<'input>, TextPos), TextPos),
+    (_, scalar, _): (AirPos, (&'input str, LambdaAST<'input>, AirPos), AirPos),
 ) -> CallInstrValue<'input>
 {
     CallInstrValue::Variable(VariableWithLambda::scalar_wl(scalar.0, scalar.1, scalar.2))
@@ -4912,9 +4912,9 @@ fn __action40<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, stream, _): (TextPos, (&'input str, TextPos), TextPos),
+    (_, stream, _): (AirPos, (&'input str, AirPos), AirPos),
 ) -> CallInstrValue<'input>
 {
     CallInstrValue::Variable(VariableWithLambda::stream(stream.0, stream.1))
@@ -4927,9 +4927,9 @@ fn __action41<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, stream, _): (TextPos, (&'input str, LambdaAST<'input>, TextPos), TextPos),
+    (_, stream, _): (AirPos, (&'input str, LambdaAST<'input>, AirPos), AirPos),
 ) -> CallInstrValue<'input>
 {
     CallInstrValue::Variable(VariableWithLambda::stream_wl(stream.0, stream.1, stream.2))
@@ -4942,9 +4942,9 @@ fn __action42<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, canon_stream, _): (TextPos, (&'input str, TextPos), TextPos),
+    (_, canon_stream, _): (AirPos, (&'input str, AirPos), AirPos),
 ) -> CallInstrValue<'input>
 {
     CallInstrValue::Variable(VariableWithLambda::canon_stream(canon_stream.0, canon_stream.1))
@@ -4957,9 +4957,9 @@ fn __action43<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, canon_stream, _): (TextPos, (&'input str, LambdaAST<'input>, TextPos), TextPos),
+    (_, canon_stream, _): (AirPos, (&'input str, LambdaAST<'input>, AirPos), AirPos),
 ) -> CallInstrValue<'input>
 {
     CallInstrValue::Variable(VariableWithLambda::canon_stream_wl(canon_stream.0, canon_stream.1, canon_stream.2))
@@ -4972,9 +4972,9 @@ fn __action44<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, scalar, _): (TextPos, (&'input str, TextPos), TextPos),
+    (_, scalar, _): (AirPos, (&'input str, AirPos), AirPos),
 ) -> NewArgument<'input>
 {
     NewArgument::Scalar(Scalar::new(scalar.0, scalar.1))
@@ -4987,9 +4987,9 @@ fn __action45<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, stream, _): (TextPos, (&'input str, TextPos), TextPos),
+    (_, stream, _): (AirPos, (&'input str, AirPos), AirPos),
 ) -> NewArgument<'input>
 {
     NewArgument::Stream(Stream::new(stream.0, stream.1))
@@ -5002,9 +5002,9 @@ fn __action46<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, canon_stream, _): (TextPos, (&'input str, TextPos), TextPos),
+    (_, canon_stream, _): (AirPos, (&'input str, AirPos), AirPos),
 ) -> NewArgument<'input>
 {
     NewArgument::CanonStream(CanonStream::new(canon_stream.0, canon_stream.1))
@@ -5017,9 +5017,9 @@ fn __action47<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, integer, _): (TextPos, i64, TextPos),
+    (_, integer, _): (AirPos, i64, AirPos),
 ) -> Number
 {
     Number::Int(integer)
@@ -5032,9 +5032,9 @@ fn __action48<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, float, _): (TextPos, f64, TextPos),
+    (_, float, _): (AirPos, f64, AirPos),
 ) -> Number
 {
     Number::Float(float)
@@ -5047,9 +5047,9 @@ fn __action49<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (TextPos, Value<'input>, TextPos),
+    (_, __0, _): (AirPos, Value<'input>, AirPos),
 ) -> Value<'input>
 {
     __0
@@ -5062,9 +5062,9 @@ fn __action50<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (TextPos, Token<'input>, TextPos),
+    (_, __0, _): (AirPos, Token<'input>, AirPos),
 ) -> Value<'input>
 {
     Value::InitPeerId
@@ -5077,9 +5077,9 @@ fn __action51<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (TextPos, Token<'input>, TextPos),
+    (_, __0, _): (AirPos, Token<'input>, AirPos),
 ) -> Value<'input>
 {
     Value::LastError(None)
@@ -5092,9 +5092,9 @@ fn __action52<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, le, _): (TextPos, LambdaAST<'input>, TextPos),
+    (_, le, _): (AirPos, LambdaAST<'input>, AirPos),
 ) -> Value<'input>
 {
     Value::LastError(Some(le))
@@ -5107,9 +5107,9 @@ fn __action53<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, l, _): (TextPos, &'input str, TextPos),
+    (_, l, _): (AirPos, &'input str, AirPos),
 ) -> Value<'input>
 {
     Value::Literal(l)
@@ -5122,9 +5122,9 @@ fn __action54<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (TextPos, Token<'input>, TextPos),
+    (_, __0, _): (AirPos, Token<'input>, AirPos),
 ) -> Value<'input>
 {
     Value::Timestamp
@@ -5137,9 +5137,9 @@ fn __action55<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (TextPos, Token<'input>, TextPos),
+    (_, __0, _): (AirPos, Token<'input>, AirPos),
 ) -> Value<'input>
 {
     Value::TTL
@@ -5152,9 +5152,9 @@ fn __action56<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, n, _): (TextPos, Number, TextPos),
+    (_, n, _): (AirPos, Number, AirPos),
 ) -> Value<'input>
 {
     Value::Number(n)
@@ -5167,9 +5167,9 @@ fn __action57<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, b, _): (TextPos, bool, TextPos),
+    (_, b, _): (AirPos, bool, AirPos),
 ) -> Value<'input>
 {
     Value::Boolean(b)
@@ -5182,10 +5182,10 @@ fn __action58<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (TextPos, Token<'input>, TextPos),
-    (_, __1, _): (TextPos, Token<'input>, TextPos),
+    (_, __0, _): (AirPos, Token<'input>, AirPos),
+    (_, __1, _): (AirPos, Token<'input>, AirPos),
 ) -> Value<'input>
 {
     Value::EmptyArray
@@ -5198,9 +5198,9 @@ fn __action59<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, scalar, _): (TextPos, (&'input str, TextPos), TextPos),
+    (_, scalar, _): (AirPos, (&'input str, AirPos), AirPos),
 ) -> Value<'input>
 {
     Value::Variable(VariableWithLambda::scalar(scalar.0, scalar.1))
@@ -5213,9 +5213,9 @@ fn __action60<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, scalar, _): (TextPos, (&'input str, LambdaAST<'input>, TextPos), TextPos),
+    (_, scalar, _): (AirPos, (&'input str, LambdaAST<'input>, AirPos), AirPos),
 ) -> Value<'input>
 {
     Value::Variable(VariableWithLambda::scalar_wl(scalar.0, scalar.1, scalar.2))
@@ -5228,9 +5228,9 @@ fn __action61<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, stream, _): (TextPos, (&'input str, TextPos), TextPos),
+    (_, stream, _): (AirPos, (&'input str, AirPos), AirPos),
 ) -> Value<'input>
 {
     Value::Variable(VariableWithLambda::stream(stream.0, stream.1))
@@ -5243,9 +5243,9 @@ fn __action62<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, stream, _): (TextPos, (&'input str, LambdaAST<'input>, TextPos), TextPos),
+    (_, stream, _): (AirPos, (&'input str, LambdaAST<'input>, AirPos), AirPos),
 ) -> Value<'input>
 {
     Value::Variable(VariableWithLambda::stream_wl(stream.0, stream.1, stream.2))
@@ -5258,9 +5258,9 @@ fn __action63<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, canon_stream, _): (TextPos, (&'input str, TextPos), TextPos),
+    (_, canon_stream, _): (AirPos, (&'input str, AirPos), AirPos),
 ) -> Value<'input>
 {
     Value::Variable(VariableWithLambda::canon_stream(canon_stream.0, canon_stream.1))
@@ -5273,9 +5273,9 @@ fn __action64<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, canon_stream, _): (TextPos, (&'input str, LambdaAST<'input>, TextPos), TextPos),
+    (_, canon_stream, _): (AirPos, (&'input str, LambdaAST<'input>, AirPos), AirPos),
 ) -> Value<'input>
 {
     Value::Variable(VariableWithLambda::canon_stream_wl(canon_stream.0, canon_stream.1, canon_stream.2))
@@ -5288,9 +5288,9 @@ fn __action65<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (TextPos, Token<'input>, TextPos),
+    (_, __0, _): (AirPos, Token<'input>, AirPos),
 ) -> ApArgument<'input>
 {
     ApArgument::InitPeerId
@@ -5303,9 +5303,9 @@ fn __action66<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (TextPos, Token<'input>, TextPos),
+    (_, __0, _): (AirPos, Token<'input>, AirPos),
 ) -> ApArgument<'input>
 {
     ApArgument::LastError(None)
@@ -5318,9 +5318,9 @@ fn __action67<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, le, _): (TextPos, LambdaAST<'input>, TextPos),
+    (_, le, _): (AirPos, LambdaAST<'input>, AirPos),
 ) -> ApArgument<'input>
 {
     ApArgument::LastError(Some(le))
@@ -5333,9 +5333,9 @@ fn __action68<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (TextPos, Token<'input>, TextPos),
+    (_, __0, _): (AirPos, Token<'input>, AirPos),
 ) -> ApArgument<'input>
 {
     ApArgument::Timestamp
@@ -5348,9 +5348,9 @@ fn __action69<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (TextPos, Token<'input>, TextPos),
+    (_, __0, _): (AirPos, Token<'input>, AirPos),
 ) -> ApArgument<'input>
 {
     ApArgument::TTL
@@ -5363,9 +5363,9 @@ fn __action70<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, l, _): (TextPos, &'input str, TextPos),
+    (_, l, _): (AirPos, &'input str, AirPos),
 ) -> ApArgument<'input>
 {
     ApArgument::Literal(l)
@@ -5378,9 +5378,9 @@ fn __action71<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, n, _): (TextPos, Number, TextPos),
+    (_, n, _): (AirPos, Number, AirPos),
 ) -> ApArgument<'input>
 {
     ApArgument::Number(n)
@@ -5393,9 +5393,9 @@ fn __action72<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, b, _): (TextPos, bool, TextPos),
+    (_, b, _): (AirPos, bool, AirPos),
 ) -> ApArgument<'input>
 {
     ApArgument::Boolean(b)
@@ -5408,10 +5408,10 @@ fn __action73<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (TextPos, Token<'input>, TextPos),
-    (_, __1, _): (TextPos, Token<'input>, TextPos),
+    (_, __0, _): (AirPos, Token<'input>, AirPos),
+    (_, __1, _): (AirPos, Token<'input>, AirPos),
 ) -> ApArgument<'input>
 {
     ApArgument::EmptyArray
@@ -5424,9 +5424,9 @@ fn __action74<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, scalar, _): (TextPos, (&'input str, TextPos), TextPos),
+    (_, scalar, _): (AirPos, (&'input str, AirPos), AirPos),
 ) -> ApArgument<'input>
 {
     ApArgument::Scalar(ScalarWithLambda::new(scalar.0, None, scalar.1))
@@ -5439,9 +5439,9 @@ fn __action75<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, scalar, _): (TextPos, (&'input str, LambdaAST<'input>, TextPos), TextPos),
+    (_, scalar, _): (AirPos, (&'input str, LambdaAST<'input>, AirPos), AirPos),
 ) -> ApArgument<'input>
 {
     ApArgument::Scalar(ScalarWithLambda::new(scalar.0, Some(scalar.1), scalar.2))
@@ -5454,9 +5454,9 @@ fn __action76<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, canon_stream, _): (TextPos, (&'input str, TextPos), TextPos),
+    (_, canon_stream, _): (AirPos, (&'input str, AirPos), AirPos),
 ) -> ApArgument<'input>
 {
     ApArgument::CanonStream(CanonStreamWithLambda::new(canon_stream.0, None, canon_stream.1))
@@ -5469,9 +5469,9 @@ fn __action77<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, canon_stream, _): (TextPos, (&'input str, LambdaAST<'input>, TextPos), TextPos),
+    (_, canon_stream, _): (AirPos, (&'input str, LambdaAST<'input>, AirPos), AirPos),
 ) -> ApArgument<'input>
 {
     ApArgument::CanonStream(CanonStreamWithLambda::new(canon_stream.0, Some(canon_stream.1), canon_stream.2))
@@ -5484,9 +5484,9 @@ fn __action78<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, stream, _): (TextPos, (&'input str, TextPos), TextPos),
+    (_, stream, _): (AirPos, (&'input str, AirPos), AirPos),
 ) -> Stream<'input>
 {
     Stream::new(stream.0, stream.1)
@@ -5499,9 +5499,9 @@ fn __action79<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, canon_stream, _): (TextPos, (&'input str, TextPos), TextPos),
+    (_, canon_stream, _): (AirPos, (&'input str, AirPos), AirPos),
 ) -> CanonStream<'input>
 {
     CanonStream::new(canon_stream.0, canon_stream.1)
@@ -5514,10 +5514,10 @@ fn __action80<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __lookbehind: &TextPos,
-    __lookahead: &TextPos,
+    __lookbehind: &AirPos,
+    __lookahead: &AirPos,
 ) -> alloc::vec::Vec<Value<'input>>
 {
     alloc::vec![]
@@ -5530,9 +5530,9 @@ fn __action81<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, v, _): (TextPos, alloc::vec::Vec<Value<'input>>, TextPos),
+    (_, v, _): (AirPos, alloc::vec::Vec<Value<'input>>, AirPos),
 ) -> alloc::vec::Vec<Value<'input>>
 {
     v
@@ -5545,9 +5545,9 @@ fn __action82<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (TextPos, Value<'input>, TextPos),
+    (_, __0, _): (AirPos, Value<'input>, AirPos),
 ) -> Value<'input>
 {
     __0
@@ -5560,11 +5560,11 @@ fn __action83<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __lookbehind: &TextPos,
-    __lookahead: &TextPos,
-) -> TextPos
+    __lookbehind: &AirPos,
+    __lookahead: &AirPos,
+) -> AirPos
 {
     __lookbehind.clone()
 }
@@ -5576,9 +5576,9 @@ fn __action84<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (TextPos, CallOutputValue<'input>, TextPos),
+    (_, __0, _): (AirPos, CallOutputValue<'input>, AirPos),
 ) -> core::option::Option<CallOutputValue<'input>>
 {
     Some(__0)
@@ -5591,10 +5591,10 @@ fn __action85<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __lookbehind: &TextPos,
-    __lookahead: &TextPos,
+    __lookbehind: &AirPos,
+    __lookahead: &AirPos,
 ) -> core::option::Option<CallOutputValue<'input>>
 {
     None
@@ -5607,11 +5607,11 @@ fn __action86<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __lookbehind: &TextPos,
-    __lookahead: &TextPos,
-) -> TextPos
+    __lookbehind: &AirPos,
+    __lookahead: &AirPos,
+) -> AirPos
 {
     __lookahead.clone()
 }
@@ -5623,9 +5623,9 @@ fn __action87<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (TextPos, Value<'input>, TextPos),
+    (_, __0, _): (AirPos, Value<'input>, AirPos),
 ) -> alloc::vec::Vec<Value<'input>>
 {
     alloc::vec![__0]
@@ -5638,10 +5638,10 @@ fn __action88<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, v, _): (TextPos, alloc::vec::Vec<Value<'input>>, TextPos),
-    (_, e, _): (TextPos, Value<'input>, TextPos),
+    (_, v, _): (AirPos, alloc::vec::Vec<Value<'input>>, AirPos),
+    (_, e, _): (AirPos, Value<'input>, AirPos),
 ) -> alloc::vec::Vec<Value<'input>>
 {
     { let mut v = v; v.push(e); v }
@@ -5654,9 +5654,9 @@ fn __action89<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (TextPos, Value<'input>, TextPos),
+    __0: (AirPos, Value<'input>, AirPos),
 ) -> alloc::vec::Vec<Value<'input>>
 {
     let __start0 = __0.0.clone();
@@ -5683,10 +5683,10 @@ fn __action90<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (TextPos, alloc::vec::Vec<Value<'input>>, TextPos),
-    __1: (TextPos, Value<'input>, TextPos),
+    __0: (AirPos, alloc::vec::Vec<Value<'input>>, AirPos),
+    __1: (AirPos, Value<'input>, AirPos),
 ) -> alloc::vec::Vec<Value<'input>>
 {
     let __start0 = __1.0.clone();
@@ -5714,10 +5714,10 @@ fn __action91<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (TextPos, Token<'input>, TextPos),
-    __1: (TextPos, Token<'input>, TextPos),
+    __0: (AirPos, Token<'input>, AirPos),
+    __1: (AirPos, Token<'input>, AirPos),
 ) -> Vec<Value<'input>>
 {
     let __start0 = __0.2.clone();
@@ -5747,11 +5747,11 @@ fn __action92<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (TextPos, Token<'input>, TextPos),
-    __1: (TextPos, alloc::vec::Vec<Value<'input>>, TextPos),
-    __2: (TextPos, Token<'input>, TextPos),
+    __0: (AirPos, Token<'input>, AirPos),
+    __1: (AirPos, alloc::vec::Vec<Value<'input>>, AirPos),
+    __2: (AirPos, Token<'input>, AirPos),
 ) -> Vec<Value<'input>>
 {
     let __start0 = __1.0.clone();
@@ -5780,10 +5780,10 @@ fn __action93<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (TextPos, Token<'input>, TextPos),
-    __1: (TextPos, TextPos, TextPos),
+    __0: (AirPos, Token<'input>, AirPos),
+    __1: (AirPos, AirPos, AirPos),
 ) -> Fail<'input>
 {
     let __start0 = __0.0.clone();
@@ -5813,15 +5813,15 @@ fn __action94<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (TextPos, Token<'input>, TextPos),
-    __1: (TextPos, Token<'input>, TextPos),
-    __2: (TextPos, Triplet<'input>, TextPos),
-    __3: (TextPos, Vec<Value<'input>>, TextPos),
-    __4: (TextPos, core::option::Option<CallOutputValue<'input>>, TextPos),
-    __5: (TextPos, Token<'input>, TextPos),
-    __6: (TextPos, TextPos, TextPos),
+    __0: (AirPos, Token<'input>, AirPos),
+    __1: (AirPos, Token<'input>, AirPos),
+    __2: (AirPos, Triplet<'input>, AirPos),
+    __3: (AirPos, Vec<Value<'input>>, AirPos),
+    __4: (AirPos, core::option::Option<CallOutputValue<'input>>, AirPos),
+    __5: (AirPos, Token<'input>, AirPos),
+    __6: (AirPos, AirPos, AirPos),
 ) -> Box<Instruction<'input>>
 {
     let __start0 = __0.0.clone();
@@ -5856,15 +5856,15 @@ fn __action95<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (TextPos, Token<'input>, TextPos),
-    __1: (TextPos, Token<'input>, TextPos),
-    __2: (TextPos, CallInstrValue<'input>, TextPos),
-    __3: (TextPos, Stream<'input>, TextPos),
-    __4: (TextPos, CanonStream<'input>, TextPos),
-    __5: (TextPos, Token<'input>, TextPos),
-    __6: (TextPos, TextPos, TextPos),
+    __0: (AirPos, Token<'input>, AirPos),
+    __1: (AirPos, Token<'input>, AirPos),
+    __2: (AirPos, CallInstrValue<'input>, AirPos),
+    __3: (AirPos, Stream<'input>, AirPos),
+    __4: (AirPos, CanonStream<'input>, AirPos),
+    __5: (AirPos, Token<'input>, AirPos),
+    __6: (AirPos, AirPos, AirPos),
 ) -> Box<Instruction<'input>>
 {
     let __start0 = __0.0.clone();
@@ -5899,14 +5899,14 @@ fn __action96<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (TextPos, Token<'input>, TextPos),
-    __1: (TextPos, Token<'input>, TextPos),
-    __2: (TextPos, ApArgument<'input>, TextPos),
-    __3: (TextPos, ApResult<'input>, TextPos),
-    __4: (TextPos, Token<'input>, TextPos),
-    __5: (TextPos, TextPos, TextPos),
+    __0: (AirPos, Token<'input>, AirPos),
+    __1: (AirPos, Token<'input>, AirPos),
+    __2: (AirPos, ApArgument<'input>, AirPos),
+    __3: (AirPos, ApResult<'input>, AirPos),
+    __4: (AirPos, Token<'input>, AirPos),
+    __5: (AirPos, AirPos, AirPos),
 ) -> Box<Instruction<'input>>
 {
     let __start0 = __0.0.clone();
@@ -5940,14 +5940,14 @@ fn __action97<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (TextPos, Token<'input>, TextPos),
-    __1: (TextPos, Token<'input>, TextPos),
-    __2: (TextPos, NewArgument<'input>, TextPos),
-    __3: (TextPos, Box<Instruction<'input>>, TextPos),
-    __4: (TextPos, Token<'input>, TextPos),
-    __5: (TextPos, TextPos, TextPos),
+    __0: (AirPos, Token<'input>, AirPos),
+    __1: (AirPos, Token<'input>, AirPos),
+    __2: (AirPos, NewArgument<'input>, AirPos),
+    __3: (AirPos, Box<Instruction<'input>>, AirPos),
+    __4: (AirPos, Token<'input>, AirPos),
+    __5: (AirPos, AirPos, AirPos),
 ) -> Box<Instruction<'input>>
 {
     let __start0 = __0.0.clone();
@@ -5981,15 +5981,15 @@ fn __action98<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (TextPos, Token<'input>, TextPos),
-    __1: (TextPos, Token<'input>, TextPos),
-    __2: (TextPos, FoldScalarIterable<'input>, TextPos),
-    __3: (TextPos, (&'input str, TextPos), TextPos),
-    __4: (TextPos, Box<Instruction<'input>>, TextPos),
-    __5: (TextPos, Token<'input>, TextPos),
-    __6: (TextPos, TextPos, TextPos),
+    __0: (AirPos, Token<'input>, AirPos),
+    __1: (AirPos, Token<'input>, AirPos),
+    __2: (AirPos, FoldScalarIterable<'input>, AirPos),
+    __3: (AirPos, (&'input str, AirPos), AirPos),
+    __4: (AirPos, Box<Instruction<'input>>, AirPos),
+    __5: (AirPos, Token<'input>, AirPos),
+    __6: (AirPos, AirPos, AirPos),
 ) -> Box<Instruction<'input>>
 {
     let __start0 = __0.0.clone();
@@ -6024,15 +6024,15 @@ fn __action99<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (TextPos, Token<'input>, TextPos),
-    __1: (TextPos, Token<'input>, TextPos),
-    __2: (TextPos, (&'input str, TextPos), TextPos),
-    __3: (TextPos, (&'input str, TextPos), TextPos),
-    __4: (TextPos, Box<Instruction<'input>>, TextPos),
-    __5: (TextPos, Token<'input>, TextPos),
-    __6: (TextPos, TextPos, TextPos),
+    __0: (AirPos, Token<'input>, AirPos),
+    __1: (AirPos, Token<'input>, AirPos),
+    __2: (AirPos, (&'input str, AirPos), AirPos),
+    __3: (AirPos, (&'input str, AirPos), AirPos),
+    __4: (AirPos, Box<Instruction<'input>>, AirPos),
+    __5: (AirPos, Token<'input>, AirPos),
+    __6: (AirPos, AirPos, AirPos),
 ) -> Box<Instruction<'input>>
 {
     let __start0 = __0.0.clone();
@@ -6067,13 +6067,13 @@ fn __action100<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (TextPos, Token<'input>, TextPos),
-    __1: (TextPos, Token<'input>, TextPos),
-    __2: (TextPos, (&'input str, TextPos), TextPos),
-    __3: (TextPos, Token<'input>, TextPos),
-    __4: (TextPos, TextPos, TextPos),
+    __0: (AirPos, Token<'input>, AirPos),
+    __1: (AirPos, Token<'input>, AirPos),
+    __2: (AirPos, (&'input str, AirPos), AirPos),
+    __3: (AirPos, Token<'input>, AirPos),
+    __4: (AirPos, AirPos, AirPos),
 ) -> Box<Instruction<'input>>
 {
     let __start0 = __0.0.clone();
@@ -6106,15 +6106,15 @@ fn __action101<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (TextPos, Token<'input>, TextPos),
-    __1: (TextPos, Token<'input>, TextPos),
-    __2: (TextPos, Value<'input>, TextPos),
-    __3: (TextPos, Value<'input>, TextPos),
-    __4: (TextPos, Box<Instruction<'input>>, TextPos),
-    __5: (TextPos, Token<'input>, TextPos),
-    __6: (TextPos, TextPos, TextPos),
+    __0: (AirPos, Token<'input>, AirPos),
+    __1: (AirPos, Token<'input>, AirPos),
+    __2: (AirPos, Value<'input>, AirPos),
+    __3: (AirPos, Value<'input>, AirPos),
+    __4: (AirPos, Box<Instruction<'input>>, AirPos),
+    __5: (AirPos, Token<'input>, AirPos),
+    __6: (AirPos, AirPos, AirPos),
 ) -> Box<Instruction<'input>>
 {
     let __start0 = __0.0.clone();
@@ -6149,15 +6149,15 @@ fn __action102<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (TextPos, Token<'input>, TextPos),
-    __1: (TextPos, Token<'input>, TextPos),
-    __2: (TextPos, Value<'input>, TextPos),
-    __3: (TextPos, Value<'input>, TextPos),
-    __4: (TextPos, Box<Instruction<'input>>, TextPos),
-    __5: (TextPos, Token<'input>, TextPos),
-    __6: (TextPos, TextPos, TextPos),
+    __0: (AirPos, Token<'input>, AirPos),
+    __1: (AirPos, Token<'input>, AirPos),
+    __2: (AirPos, Value<'input>, AirPos),
+    __3: (AirPos, Value<'input>, AirPos),
+    __4: (AirPos, Box<Instruction<'input>>, AirPos),
+    __5: (AirPos, Token<'input>, AirPos),
+    __6: (AirPos, AirPos, AirPos),
 ) -> Box<Instruction<'input>>
 {
     let __start0 = __0.0.clone();
@@ -6192,9 +6192,9 @@ fn __action103<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (TextPos, Token<'input>, TextPos),
+    __0: (AirPos, Token<'input>, AirPos),
 ) -> Fail<'input>
 {
     let __start0 = __0.2.clone();
@@ -6223,14 +6223,14 @@ fn __action104<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (TextPos, Token<'input>, TextPos),
-    __1: (TextPos, Token<'input>, TextPos),
-    __2: (TextPos, Triplet<'input>, TextPos),
-    __3: (TextPos, Vec<Value<'input>>, TextPos),
-    __4: (TextPos, core::option::Option<CallOutputValue<'input>>, TextPos),
-    __5: (TextPos, Token<'input>, TextPos),
+    __0: (AirPos, Token<'input>, AirPos),
+    __1: (AirPos, Token<'input>, AirPos),
+    __2: (AirPos, Triplet<'input>, AirPos),
+    __3: (AirPos, Vec<Value<'input>>, AirPos),
+    __4: (AirPos, core::option::Option<CallOutputValue<'input>>, AirPos),
+    __5: (AirPos, Token<'input>, AirPos),
 ) -> Box<Instruction<'input>>
 {
     let __start0 = __5.2.clone();
@@ -6264,14 +6264,14 @@ fn __action105<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (TextPos, Token<'input>, TextPos),
-    __1: (TextPos, Token<'input>, TextPos),
-    __2: (TextPos, CallInstrValue<'input>, TextPos),
-    __3: (TextPos, Stream<'input>, TextPos),
-    __4: (TextPos, CanonStream<'input>, TextPos),
-    __5: (TextPos, Token<'input>, TextPos),
+    __0: (AirPos, Token<'input>, AirPos),
+    __1: (AirPos, Token<'input>, AirPos),
+    __2: (AirPos, CallInstrValue<'input>, AirPos),
+    __3: (AirPos, Stream<'input>, AirPos),
+    __4: (AirPos, CanonStream<'input>, AirPos),
+    __5: (AirPos, Token<'input>, AirPos),
 ) -> Box<Instruction<'input>>
 {
     let __start0 = __5.2.clone();
@@ -6305,13 +6305,13 @@ fn __action106<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (TextPos, Token<'input>, TextPos),
-    __1: (TextPos, Token<'input>, TextPos),
-    __2: (TextPos, ApArgument<'input>, TextPos),
-    __3: (TextPos, ApResult<'input>, TextPos),
-    __4: (TextPos, Token<'input>, TextPos),
+    __0: (AirPos, Token<'input>, AirPos),
+    __1: (AirPos, Token<'input>, AirPos),
+    __2: (AirPos, ApArgument<'input>, AirPos),
+    __3: (AirPos, ApResult<'input>, AirPos),
+    __4: (AirPos, Token<'input>, AirPos),
 ) -> Box<Instruction<'input>>
 {
     let __start0 = __4.2.clone();
@@ -6344,13 +6344,13 @@ fn __action107<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (TextPos, Token<'input>, TextPos),
-    __1: (TextPos, Token<'input>, TextPos),
-    __2: (TextPos, NewArgument<'input>, TextPos),
-    __3: (TextPos, Box<Instruction<'input>>, TextPos),
-    __4: (TextPos, Token<'input>, TextPos),
+    __0: (AirPos, Token<'input>, AirPos),
+    __1: (AirPos, Token<'input>, AirPos),
+    __2: (AirPos, NewArgument<'input>, AirPos),
+    __3: (AirPos, Box<Instruction<'input>>, AirPos),
+    __4: (AirPos, Token<'input>, AirPos),
 ) -> Box<Instruction<'input>>
 {
     let __start0 = __4.2.clone();
@@ -6383,14 +6383,14 @@ fn __action108<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (TextPos, Token<'input>, TextPos),
-    __1: (TextPos, Token<'input>, TextPos),
-    __2: (TextPos, FoldScalarIterable<'input>, TextPos),
-    __3: (TextPos, (&'input str, TextPos), TextPos),
-    __4: (TextPos, Box<Instruction<'input>>, TextPos),
-    __5: (TextPos, Token<'input>, TextPos),
+    __0: (AirPos, Token<'input>, AirPos),
+    __1: (AirPos, Token<'input>, AirPos),
+    __2: (AirPos, FoldScalarIterable<'input>, AirPos),
+    __3: (AirPos, (&'input str, AirPos), AirPos),
+    __4: (AirPos, Box<Instruction<'input>>, AirPos),
+    __5: (AirPos, Token<'input>, AirPos),
 ) -> Box<Instruction<'input>>
 {
     let __start0 = __5.2.clone();
@@ -6424,14 +6424,14 @@ fn __action109<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (TextPos, Token<'input>, TextPos),
-    __1: (TextPos, Token<'input>, TextPos),
-    __2: (TextPos, (&'input str, TextPos), TextPos),
-    __3: (TextPos, (&'input str, TextPos), TextPos),
-    __4: (TextPos, Box<Instruction<'input>>, TextPos),
-    __5: (TextPos, Token<'input>, TextPos),
+    __0: (AirPos, Token<'input>, AirPos),
+    __1: (AirPos, Token<'input>, AirPos),
+    __2: (AirPos, (&'input str, AirPos), AirPos),
+    __3: (AirPos, (&'input str, AirPos), AirPos),
+    __4: (AirPos, Box<Instruction<'input>>, AirPos),
+    __5: (AirPos, Token<'input>, AirPos),
 ) -> Box<Instruction<'input>>
 {
     let __start0 = __5.2.clone();
@@ -6465,12 +6465,12 @@ fn __action110<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (TextPos, Token<'input>, TextPos),
-    __1: (TextPos, Token<'input>, TextPos),
-    __2: (TextPos, (&'input str, TextPos), TextPos),
-    __3: (TextPos, Token<'input>, TextPos),
+    __0: (AirPos, Token<'input>, AirPos),
+    __1: (AirPos, Token<'input>, AirPos),
+    __2: (AirPos, (&'input str, AirPos), AirPos),
+    __3: (AirPos, Token<'input>, AirPos),
 ) -> Box<Instruction<'input>>
 {
     let __start0 = __3.2.clone();
@@ -6502,14 +6502,14 @@ fn __action111<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (TextPos, Token<'input>, TextPos),
-    __1: (TextPos, Token<'input>, TextPos),
-    __2: (TextPos, Value<'input>, TextPos),
-    __3: (TextPos, Value<'input>, TextPos),
-    __4: (TextPos, Box<Instruction<'input>>, TextPos),
-    __5: (TextPos, Token<'input>, TextPos),
+    __0: (AirPos, Token<'input>, AirPos),
+    __1: (AirPos, Token<'input>, AirPos),
+    __2: (AirPos, Value<'input>, AirPos),
+    __3: (AirPos, Value<'input>, AirPos),
+    __4: (AirPos, Box<Instruction<'input>>, AirPos),
+    __5: (AirPos, Token<'input>, AirPos),
 ) -> Box<Instruction<'input>>
 {
     let __start0 = __5.2.clone();
@@ -6543,14 +6543,14 @@ fn __action112<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (TextPos, Token<'input>, TextPos),
-    __1: (TextPos, Token<'input>, TextPos),
-    __2: (TextPos, Value<'input>, TextPos),
-    __3: (TextPos, Value<'input>, TextPos),
-    __4: (TextPos, Box<Instruction<'input>>, TextPos),
-    __5: (TextPos, Token<'input>, TextPos),
+    __0: (AirPos, Token<'input>, AirPos),
+    __1: (AirPos, Token<'input>, AirPos),
+    __2: (AirPos, Value<'input>, AirPos),
+    __3: (AirPos, Value<'input>, AirPos),
+    __4: (AirPos, Box<Instruction<'input>>, AirPos),
+    __5: (AirPos, Token<'input>, AirPos),
 ) -> Box<Instruction<'input>>
 {
     let __start0 = __5.2.clone();
@@ -6584,14 +6584,14 @@ fn __action113<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (TextPos, Token<'input>, TextPos),
-    __1: (TextPos, Token<'input>, TextPos),
-    __2: (TextPos, Triplet<'input>, TextPos),
-    __3: (TextPos, Vec<Value<'input>>, TextPos),
-    __4: (TextPos, CallOutputValue<'input>, TextPos),
-    __5: (TextPos, Token<'input>, TextPos),
+    __0: (AirPos, Token<'input>, AirPos),
+    __1: (AirPos, Token<'input>, AirPos),
+    __2: (AirPos, Triplet<'input>, AirPos),
+    __3: (AirPos, Vec<Value<'input>>, AirPos),
+    __4: (AirPos, CallOutputValue<'input>, AirPos),
+    __5: (AirPos, Token<'input>, AirPos),
 ) -> Box<Instruction<'input>>
 {
     let __start0 = __4.0.clone();
@@ -6623,13 +6623,13 @@ fn __action114<
     'v,
 >(
     input: &'input str,
-    errors: &'err mut Vec<ErrorRecovery<TextPos, Token<'input>, ParserError>>,
+    errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    __0: (TextPos, Token<'input>, TextPos),
-    __1: (TextPos, Token<'input>, TextPos),
-    __2: (TextPos, Triplet<'input>, TextPos),
-    __3: (TextPos, Vec<Value<'input>>, TextPos),
-    __4: (TextPos, Token<'input>, TextPos),
+    __0: (AirPos, Token<'input>, AirPos),
+    __1: (AirPos, Token<'input>, AirPos),
+    __2: (AirPos, Triplet<'input>, AirPos),
+    __3: (AirPos, Vec<Value<'input>>, AirPos),
+    __4: (AirPos, Token<'input>, AirPos),
 ) -> Box<Instruction<'input>>
 {
     let __start0 = __3.2.clone();
@@ -6657,18 +6657,18 @@ fn __action114<
 
 pub trait __ToTriple<'err, 'input, 'v, >
 {
-    fn to_triple(value: Self) -> Result<(TextPos,Token<'input>,TextPos), __lalrpop_util::ParseError<TextPos, Token<'input>, ParserError>>;
+    fn to_triple(value: Self) -> Result<(AirPos,Token<'input>,AirPos), __lalrpop_util::ParseError<AirPos, Token<'input>, ParserError>>;
 }
 
-impl<'err, 'input, 'v, > __ToTriple<'err, 'input, 'v, > for (TextPos, Token<'input>, TextPos)
+impl<'err, 'input, 'v, > __ToTriple<'err, 'input, 'v, > for (AirPos, Token<'input>, AirPos)
 {
-    fn to_triple(value: Self) -> Result<(TextPos,Token<'input>,TextPos), __lalrpop_util::ParseError<TextPos, Token<'input>, ParserError>> {
+    fn to_triple(value: Self) -> Result<(AirPos,Token<'input>,AirPos), __lalrpop_util::ParseError<AirPos, Token<'input>, ParserError>> {
         Ok(value)
     }
 }
-impl<'err, 'input, 'v, > __ToTriple<'err, 'input, 'v, > for Result<(TextPos, Token<'input>, TextPos), ParserError>
+impl<'err, 'input, 'v, > __ToTriple<'err, 'input, 'v, > for Result<(AirPos, Token<'input>, AirPos), ParserError>
 {
-    fn to_triple(value: Self) -> Result<(TextPos,Token<'input>,TextPos), __lalrpop_util::ParseError<TextPos, Token<'input>, ParserError>> {
+    fn to_triple(value: Self) -> Result<(AirPos,Token<'input>,AirPos), __lalrpop_util::ParseError<AirPos, Token<'input>, ParserError>> {
         match value {
             Ok(v) => Ok(v),
             Err(error) => Err(__lalrpop_util::ParseError::User { error }),

--- a/crates/air-lib/air-parser/src/parser/air_parser.rs
+++ b/crates/air-lib/air-parser/src/parser/air_parser.rs
@@ -16,6 +16,7 @@
 
 use super::air;
 use super::lexer::AIRLexer;
+use super::lexer::TextPos;
 use super::lexer::Token;
 use super::ParserError;
 use crate::ast::Instruction;
@@ -39,7 +40,7 @@ pub fn parse(air_script: &str) -> Result<Box<Instruction<'_>>, String> {
     let file_id = files.add("script.air", air_script);
 
     PARSER.with(|parser| {
-        let mut errors = Vec::new();
+        let mut errors: Vec<ErrorRecovery<TextPos, Token<'_>, ParserError>> = Vec::new();
         let lexer = AIRLexer::new(air_script);
         let mut validator = VariableValidator::new();
         let result = parser.parse(air_script, &mut errors, &mut validator, lexer);
@@ -65,7 +66,7 @@ pub fn parse(air_script: &str) -> Result<Box<Instruction<'_>>, String> {
 fn report_errors(
     file_id: usize,
     files: SimpleFiles<&str, &str>,
-    errors: Vec<ErrorRecovery<usize, Token<'_>, ParserError>>,
+    errors: Vec<ErrorRecovery<TextPos, Token<'_>, ParserError>>,
 ) -> String {
     let labels = errors_to_labels(file_id, errors);
     let diagnostic = Diagnostic::error().with_labels(labels);
@@ -85,7 +86,7 @@ fn report_errors(
 
 fn errors_to_labels(
     file_id: usize,
-    errors: Vec<ErrorRecovery<usize, Token<'_>, ParserError>>,
+    errors: Vec<ErrorRecovery<TextPos, Token<'_>, ParserError>>,
 ) -> Vec<Label<usize>> {
     errors
         .into_iter()
@@ -93,16 +94,17 @@ fn errors_to_labels(
             ParseError::UnrecognizedToken {
                 token: (start, _, end),
                 expected,
-            } => Label::primary(file_id, start..end)
+            } => Label::primary(file_id, start.into()..end.into())
                 .with_message(format!("expected {}", pretty_expected(expected))),
             ParseError::InvalidToken { location } => {
-                Label::primary(file_id, location..(location + 1)).with_message("unexpected token")
+                Label::primary(file_id, location.into()..(location + 1).into())
+                    .with_message("unexpected token")
             }
             ParseError::ExtraToken {
                 token: (start, _, end),
-            } => Label::primary(file_id, start..end).with_message("extra token"),
+            } => Label::primary(file_id, start.into()..end.into()).with_message("extra token"),
             ParseError::UnrecognizedEOF { location, expected } => {
-                Label::primary(file_id, location..(location + 1))
+                Label::primary(file_id, location.into()..(location + 1).into())
                     .with_message(format!("expected {}", pretty_expected(expected)))
             }
             ParseError::User { error } => parser_error_to_label(file_id, error),
@@ -120,5 +122,5 @@ fn pretty_expected(expected: Vec<String>) -> String {
 
 fn parser_error_to_label(file_id: usize, error: ParserError) -> Label<usize> {
     let span = error.span();
-    Label::primary(file_id, span.left..span.right).with_message(error.to_string())
+    Label::primary(file_id, span.left.into()..span.right.into()).with_message(error.to_string())
 }

--- a/crates/air-lib/air-parser/src/parser/air_parser.rs
+++ b/crates/air-lib/air-parser/src/parser/air_parser.rs
@@ -16,7 +16,7 @@
 
 use super::air;
 use super::lexer::AIRLexer;
-use super::lexer::TextPos;
+use super::lexer::AirPos;
 use super::lexer::Token;
 use super::ParserError;
 use crate::ast::Instruction;
@@ -40,7 +40,7 @@ pub fn parse(air_script: &str) -> Result<Box<Instruction<'_>>, String> {
     let file_id = files.add("script.air", air_script);
 
     PARSER.with(|parser| {
-        let mut errors: Vec<ErrorRecovery<TextPos, Token<'_>, ParserError>> = Vec::new();
+        let mut errors: Vec<ErrorRecovery<AirPos, Token<'_>, ParserError>> = Vec::new();
         let lexer = AIRLexer::new(air_script);
         let mut validator = VariableValidator::new();
         let result = parser.parse(air_script, &mut errors, &mut validator, lexer);
@@ -66,7 +66,7 @@ pub fn parse(air_script: &str) -> Result<Box<Instruction<'_>>, String> {
 fn report_errors(
     file_id: usize,
     files: SimpleFiles<&str, &str>,
-    errors: Vec<ErrorRecovery<TextPos, Token<'_>, ParserError>>,
+    errors: Vec<ErrorRecovery<AirPos, Token<'_>, ParserError>>,
 ) -> String {
     let labels = errors_to_labels(file_id, errors);
     let diagnostic = Diagnostic::error().with_labels(labels);
@@ -86,7 +86,7 @@ fn report_errors(
 
 fn errors_to_labels(
     file_id: usize,
-    errors: Vec<ErrorRecovery<TextPos, Token<'_>, ParserError>>,
+    errors: Vec<ErrorRecovery<AirPos, Token<'_>, ParserError>>,
 ) -> Vec<Label<usize>> {
     errors
         .into_iter()

--- a/crates/air-lib/air-parser/src/parser/lexer/air_lexer.rs
+++ b/crates/air-lib/air-parser/src/parser/lexer/air_lexer.rs
@@ -16,7 +16,7 @@
 
 use super::errors::LexerError;
 use super::token::Token;
-use super::LexerResult;
+use super::{LexerResult, TextPos};
 
 use std::iter::Peekable;
 use std::str::CharIndices;
@@ -29,7 +29,7 @@ pub struct AIRLexer<'input> {
 }
 
 impl<'input> Iterator for AIRLexer<'input> {
-    type Item = Spanned<Token<'input>, usize, LexerError>;
+    type Item = Spanned<Token<'input>, TextPos, LexerError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.next_token()
@@ -44,8 +44,9 @@ impl<'input> AIRLexer<'input> {
         }
     }
 
-    pub fn next_token(&mut self) -> Option<Spanned<Token<'input>, usize, LexerError>> {
+    pub fn next_token(&mut self) -> Option<Spanned<Token<'input>, TextPos, LexerError>> {
         while let Some((start_pos, ch)) = self.chars.next() {
+            let start_pos = TextPos::from(start_pos);
             match ch {
                 '(' => return Some(Ok((start_pos, Token::OpenRoundBracket, start_pos + 1))),
                 ')' => return Some(Ok((start_pos, Token::CloseRoundBracket, start_pos + 1))),
@@ -79,34 +80,37 @@ impl<'input> AIRLexer<'input> {
     #[allow(clippy::unnecessary_wraps)]
     fn tokenize_string_literal(
         &mut self,
-        start_pos: usize,
-    ) -> Option<Spanned<Token<'input>, usize, LexerError>> {
+        start_pos: TextPos,
+    ) -> Option<Spanned<Token<'input>, TextPos, LexerError>> {
         for (pos, ch) in &mut self.chars {
+            let pos = TextPos::from(pos);
             if ch == '"' {
                 // + 1 to count an open double quote
                 let string_size = pos - start_pos + 1;
 
                 return Some(Ok((
                     start_pos,
-                    Token::StringLiteral(&self.input[start_pos + 1..pos]),
+                    Token::StringLiteral(&self.input[(start_pos + 1).into()..pos.into()]),
                     start_pos + string_size,
                 )));
             }
         }
 
-        Some(Err(LexerError::unclosed_quote(start_pos..self.input.len())))
+        Some(Err(LexerError::unclosed_quote(
+            start_pos..self.input.len().into(),
+        )))
     }
 
     #[allow(clippy::unnecessary_wraps)]
     fn tokenize_string(
         &mut self,
-        start_pos: usize,
+        start_pos: TextPos,
         open_square_bracket_met: bool,
-    ) -> Option<Spanned<Token<'input>, usize, LexerError>> {
+    ) -> Option<Spanned<Token<'input>, TextPos, LexerError>> {
         let end_pos = self.advance_to_token_end(start_pos, open_square_bracket_met);
 
         // this slicing is safe here because borders come from the chars iterator
-        let token_str = &self.input[start_pos..end_pos];
+        let token_str = &self.input[start_pos.into()..end_pos.into()];
 
         let token = match string_to_token(token_str, start_pos) {
             Ok(token) => token,
@@ -117,13 +121,13 @@ impl<'input> AIRLexer<'input> {
         Some(Ok((start_pos, token, start_pos + token_str_len)))
     }
 
-    fn advance_to_token_end(&mut self, start_pos: usize, square_met: bool) -> usize {
+    fn advance_to_token_end(&mut self, start_pos: TextPos, square_met: bool) -> TextPos {
         let mut end_pos = start_pos;
         let mut round_brackets_balance: i64 = 0;
         let mut square_brackets_balance = i64::from(square_met);
 
         while let Some((pos, ch)) = self.chars.peek() {
-            end_pos = *pos;
+            end_pos = (*pos).into();
             let ch = *ch;
 
             update_brackets_count(
@@ -144,9 +148,9 @@ impl<'input> AIRLexer<'input> {
     }
 
     // if it was the last char, advance the end position.
-    fn advance_end_pos(&mut self, end_pos: &mut usize) {
+    fn advance_end_pos(&mut self, end_pos: &mut TextPos) {
         if self.chars.peek().is_none() {
-            *end_pos = self.input.len();
+            *end_pos = self.input.len().into();
         }
     }
 }
@@ -171,7 +175,7 @@ fn should_stop(ch: char, round_brackets_balance: i64, open_square_brackets_balan
     ch.is_whitespace() || round_brackets_balance < 0 || open_square_brackets_balance < 0
 }
 
-fn string_to_token(input: &str, start_pos: usize) -> LexerResult<Token> {
+fn string_to_token(input: &str, start_pos: TextPos) -> LexerResult<Token> {
     match input {
         "" => Err(LexerError::empty_string(start_pos..start_pos)),
 
@@ -202,7 +206,7 @@ fn string_to_token(input: &str, start_pos: usize) -> LexerResult<Token> {
     }
 }
 
-fn parse_last_error(input: &str, start_pos: usize) -> LexerResult<Token<'_>> {
+fn parse_last_error(input: &str, start_pos: TextPos) -> LexerResult<Token<'_>> {
     let last_error_size = LAST_ERROR.len();
     if input.len() == last_error_size {
         return Ok(Token::LastError);

--- a/crates/air-lib/air-parser/src/parser/lexer/call_variable_parser.rs
+++ b/crates/air-lib/air-parser/src/parser/lexer/call_variable_parser.rs
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
+use super::AirPos;
 use super::LexerError;
 use super::LexerResult;
-use super::TextPos;
 use super::Token;
 use crate::LambdaAST;
 
@@ -25,7 +25,7 @@ use std::str::CharIndices;
 
 pub(super) fn try_parse_call_variable(
     string_to_parse: &str,
-    start_pos: TextPos,
+    start_pos: AirPos,
 ) -> LexerResult<Token<'_>> {
     CallVariableParser::try_parse(string_to_parse, start_pos)
 }
@@ -52,12 +52,12 @@ struct ParserState {
 struct CallVariableParser<'input> {
     string_to_parse_iter: Peekable<CharIndices<'input>>,
     string_to_parse: &'input str,
-    start_pos: TextPos,
+    start_pos: AirPos,
     state: ParserState,
 }
 
 impl<'input> CallVariableParser<'input> {
-    fn new(string_to_parse: &'input str, start_pos: TextPos) -> LexerResult<Self> {
+    fn new(string_to_parse: &'input str, start_pos: AirPos) -> LexerResult<Self> {
         let mut string_to_parse_iter = string_to_parse.char_indices().peekable();
         let (current_offset, current_char) = match string_to_parse_iter.next() {
             Some(pos_and_ch) => pos_and_ch,
@@ -87,7 +87,7 @@ impl<'input> CallVariableParser<'input> {
 
     pub(self) fn try_parse(
         string_to_parse: &'input str,
-        start_pos: TextPos,
+        start_pos: AirPos,
     ) -> LexerResult<Token<'input>> {
         let mut parser = Self::new(string_to_parse, start_pos)?;
 
@@ -261,7 +261,7 @@ impl<'input> CallVariableParser<'input> {
         super::is_json_path_allowed_char(self.current_char())
     }
 
-    fn pos_in_string_to_parse(&self) -> TextPos {
+    fn pos_in_string_to_parse(&self) -> AirPos {
         self.start_pos + self.current_offset()
     }
 

--- a/crates/air-lib/air-parser/src/parser/lexer/call_variable_parser.rs
+++ b/crates/air-lib/air-parser/src/parser/lexer/call_variable_parser.rs
@@ -16,6 +16,7 @@
 
 use super::LexerError;
 use super::LexerResult;
+use super::TextPos;
 use super::Token;
 use crate::LambdaAST;
 
@@ -24,7 +25,7 @@ use std::str::CharIndices;
 
 pub(super) fn try_parse_call_variable(
     string_to_parse: &str,
-    start_pos: usize,
+    start_pos: TextPos,
 ) -> LexerResult<Token<'_>> {
     CallVariableParser::try_parse(string_to_parse, start_pos)
 }
@@ -45,18 +46,18 @@ struct ParserState {
     pub(self) met_tag: MetTag,
     pub(self) is_first_char: bool,
     pub(self) current_char: char,
-    pub(self) current_pos: usize,
+    pub(self) current_offset: usize,
 }
 
 struct CallVariableParser<'input> {
     string_to_parse_iter: Peekable<CharIndices<'input>>,
     string_to_parse: &'input str,
-    start_pos: usize,
+    start_pos: TextPos,
     state: ParserState,
 }
 
 impl<'input> CallVariableParser<'input> {
-    fn new(string_to_parse: &'input str, start_pos: usize) -> LexerResult<Self> {
+    fn new(string_to_parse: &'input str, start_pos: TextPos) -> LexerResult<Self> {
         let mut string_to_parse_iter = string_to_parse.char_indices().peekable();
         let (current_pos, current_char) = match string_to_parse_iter.next() {
             Some(pos_and_ch) => pos_and_ch,
@@ -71,7 +72,7 @@ impl<'input> CallVariableParser<'input> {
             is_first_char: true,
             met_tag: MetTag::None,
             current_char,
-            current_pos,
+            current_offset: current_pos,
         };
 
         let parser = Self {
@@ -86,7 +87,7 @@ impl<'input> CallVariableParser<'input> {
 
     pub(self) fn try_parse(
         string_to_parse: &'input str,
-        start_pos: usize,
+        start_pos: TextPos,
     ) -> LexerResult<Token<'input>> {
         let mut parser = Self::new(string_to_parse, start_pos)?;
 
@@ -112,7 +113,7 @@ impl<'input> CallVariableParser<'input> {
         };
 
         self.state.current_char = ch;
-        self.state.current_pos = pos;
+        self.state.current_offset = pos;
         self.state.is_first_char = false;
 
         true
@@ -186,7 +187,7 @@ impl<'input> CallVariableParser<'input> {
 
     fn try_parse_as_stream_start(&mut self) -> LexerResult<bool> {
         let stream_tag = MetTag::from_tag(self.current_char());
-        if self.current_pos() == 0 && stream_tag.is_tag() {
+        if self.current_offset() == 0 && stream_tag.is_tag() {
             if self.string_to_parse.len() == 1 {
                 let error_pos = self.pos_in_string_to_parse();
                 return Err(LexerError::empty_stream_name(error_pos..error_pos));
@@ -232,12 +233,12 @@ impl<'input> CallVariableParser<'input> {
 
     fn try_parse_first_met_dot(&mut self) -> LexerResult<bool> {
         if !self.dot_met() && self.current_char() == '.' {
-            if self.current_pos() == 0 {
+            if self.current_offset() == 0 {
                 return Err(LexerError::leading_dot(
                     self.start_pos..self.pos_in_string_to_parse(),
                 ));
             }
-            self.state.first_dot_met_pos = Some(self.current_pos());
+            self.state.first_dot_met_pos = Some(self.current_offset());
             return Ok(true);
         }
 
@@ -260,12 +261,12 @@ impl<'input> CallVariableParser<'input> {
         super::is_json_path_allowed_char(self.current_char())
     }
 
-    fn pos_in_string_to_parse(&self) -> usize {
-        self.start_pos + self.current_pos()
+    fn pos_in_string_to_parse(&self) -> TextPos {
+        self.start_pos + self.current_offset()
     }
 
-    fn current_pos(&self) -> usize {
-        self.state.current_pos
+    fn current_offset(&self) -> usize {
+        self.state.current_offset
     }
 
     fn current_char(&self) -> char {
@@ -273,7 +274,7 @@ impl<'input> CallVariableParser<'input> {
     }
 
     fn is_last_char(&self) -> bool {
-        self.current_pos() == self.string_to_parse.len() - 1
+        self.current_offset() == self.string_to_parse.len() - 1
     }
 
     fn to_variable_token<'v>(&self, name: &'v str) -> Token<'v> {

--- a/crates/air-lib/air-parser/src/parser/lexer/errors.rs
+++ b/crates/air-lib/air-parser/src/parser/lexer/errors.rs
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
+use super::TextPos;
 use crate::parser::Span;
+
 use thiserror::Error as ThisError;
 
 use std::num::ParseFloatError;
@@ -88,44 +90,44 @@ impl LexerError {
         *span
     }
 
-    pub fn unclosed_quote(range: Range<usize>) -> Self {
+    pub fn unclosed_quote(range: Range<TextPos>) -> Self {
         Self::UnclosedQuote(range.into())
     }
 
-    pub fn empty_string(range: Range<usize>) -> Self {
+    pub fn empty_string(range: Range<TextPos>) -> Self {
         Self::EmptyString(range.into())
     }
 
-    pub fn is_not_alphanumeric(range: Range<usize>) -> Self {
+    pub fn is_not_alphanumeric(range: Range<TextPos>) -> Self {
         Self::IsNotAlphanumeric(range.into())
     }
 
-    pub fn empty_stream_name(range: Range<usize>) -> Self {
+    pub fn empty_stream_name(range: Range<TextPos>) -> Self {
         Self::EmptyStreamName(range.into())
     }
 
-    pub fn empty_variable_or_const(range: Range<usize>) -> Self {
+    pub fn empty_variable_or_const(range: Range<TextPos>) -> Self {
         Self::EmptyVariableOrConst(range.into())
     }
 
-    pub fn invalid_lambda(range: Range<usize>) -> Self {
+    pub fn invalid_lambda(range: Range<TextPos>) -> Self {
         Self::InvalidLambda(range.into())
     }
 
-    pub fn unallowed_char_in_number(range: Range<usize>) -> Self {
+    pub fn unallowed_char_in_number(range: Range<TextPos>) -> Self {
         Self::UnallowedCharInNumber(range.into())
     }
 
-    pub fn parse_int_error(range: Range<usize>, parse_int_error: ParseIntError) -> Self {
+    pub fn parse_int_error(range: Range<TextPos>, parse_int_error: ParseIntError) -> Self {
         Self::ParseIntError(range.into(), parse_int_error)
     }
 
-    pub fn parse_float_error(range: Range<usize>, parse_float_error: ParseFloatError) -> Self {
+    pub fn parse_float_error(range: Range<TextPos>, parse_float_error: ParseFloatError) -> Self {
         Self::ParseFloatError(range.into(), parse_float_error)
     }
 
     pub fn lambda_parser_error(
-        range: Range<usize>,
+        range: Range<TextPos>,
         se_lambda_parser_error: impl Into<String>,
     ) -> Self {
         Self::LambdaParserError {
@@ -134,18 +136,18 @@ impl LexerError {
         }
     }
 
-    pub fn last_error_path_error(range: Range<usize>, error_path: String) -> Self {
+    pub fn last_error_path_error(range: Range<TextPos>, error_path: String) -> Self {
         Self::LastErrorPathError {
             span: range.into(),
             error_path,
         }
     }
 
-    pub fn too_big_float(range: Range<usize>) -> Self {
+    pub fn too_big_float(range: Range<TextPos>) -> Self {
         Self::TooBigFloat(range.into())
     }
 
-    pub fn leading_dot(range: Range<usize>) -> Self {
+    pub fn leading_dot(range: Range<TextPos>) -> Self {
         Self::LeadingDot(range.into())
     }
 }
@@ -155,14 +157,14 @@ use crate::parser::air::__ToTriple;
 use crate::parser::ParserError;
 
 impl<'err, 'input, 'i> __ToTriple<'err, 'input, 'i>
-    for Result<(usize, Token<'input>, usize), LexerError>
+    for Result<(TextPos, Token<'input>, TextPos), LexerError>
 {
     #[allow(clippy::wrong_self_convention)]
     fn to_triple(
         value: Self,
     ) -> Result<
-        (usize, Token<'input>, usize),
-        lalrpop_util::ParseError<usize, Token<'input>, ParserError>,
+        (TextPos, Token<'input>, TextPos),
+        lalrpop_util::ParseError<TextPos, Token<'input>, ParserError>,
     > {
         match value {
             Ok(v) => Ok(v),

--- a/crates/air-lib/air-parser/src/parser/lexer/errors.rs
+++ b/crates/air-lib/air-parser/src/parser/lexer/errors.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use super::TextPos;
+use super::AirPos;
 use crate::parser::Span;
 
 use thiserror::Error as ThisError;
@@ -90,44 +90,44 @@ impl LexerError {
         *span
     }
 
-    pub fn unclosed_quote(range: Range<TextPos>) -> Self {
+    pub fn unclosed_quote(range: Range<AirPos>) -> Self {
         Self::UnclosedQuote(range.into())
     }
 
-    pub fn empty_string(range: Range<TextPos>) -> Self {
+    pub fn empty_string(range: Range<AirPos>) -> Self {
         Self::EmptyString(range.into())
     }
 
-    pub fn is_not_alphanumeric(range: Range<TextPos>) -> Self {
+    pub fn is_not_alphanumeric(range: Range<AirPos>) -> Self {
         Self::IsNotAlphanumeric(range.into())
     }
 
-    pub fn empty_stream_name(range: Range<TextPos>) -> Self {
+    pub fn empty_stream_name(range: Range<AirPos>) -> Self {
         Self::EmptyStreamName(range.into())
     }
 
-    pub fn empty_variable_or_const(range: Range<TextPos>) -> Self {
+    pub fn empty_variable_or_const(range: Range<AirPos>) -> Self {
         Self::EmptyVariableOrConst(range.into())
     }
 
-    pub fn invalid_lambda(range: Range<TextPos>) -> Self {
+    pub fn invalid_lambda(range: Range<AirPos>) -> Self {
         Self::InvalidLambda(range.into())
     }
 
-    pub fn unallowed_char_in_number(range: Range<TextPos>) -> Self {
+    pub fn unallowed_char_in_number(range: Range<AirPos>) -> Self {
         Self::UnallowedCharInNumber(range.into())
     }
 
-    pub fn parse_int_error(range: Range<TextPos>, parse_int_error: ParseIntError) -> Self {
+    pub fn parse_int_error(range: Range<AirPos>, parse_int_error: ParseIntError) -> Self {
         Self::ParseIntError(range.into(), parse_int_error)
     }
 
-    pub fn parse_float_error(range: Range<TextPos>, parse_float_error: ParseFloatError) -> Self {
+    pub fn parse_float_error(range: Range<AirPos>, parse_float_error: ParseFloatError) -> Self {
         Self::ParseFloatError(range.into(), parse_float_error)
     }
 
     pub fn lambda_parser_error(
-        range: Range<TextPos>,
+        range: Range<AirPos>,
         se_lambda_parser_error: impl Into<String>,
     ) -> Self {
         Self::LambdaParserError {
@@ -136,18 +136,18 @@ impl LexerError {
         }
     }
 
-    pub fn last_error_path_error(range: Range<TextPos>, error_path: String) -> Self {
+    pub fn last_error_path_error(range: Range<AirPos>, error_path: String) -> Self {
         Self::LastErrorPathError {
             span: range.into(),
             error_path,
         }
     }
 
-    pub fn too_big_float(range: Range<TextPos>) -> Self {
+    pub fn too_big_float(range: Range<AirPos>) -> Self {
         Self::TooBigFloat(range.into())
     }
 
-    pub fn leading_dot(range: Range<TextPos>) -> Self {
+    pub fn leading_dot(range: Range<AirPos>) -> Self {
         Self::LeadingDot(range.into())
     }
 }
@@ -157,14 +157,14 @@ use crate::parser::air::__ToTriple;
 use crate::parser::ParserError;
 
 impl<'err, 'input, 'i> __ToTriple<'err, 'input, 'i>
-    for Result<(TextPos, Token<'input>, TextPos), LexerError>
+    for Result<(AirPos, Token<'input>, AirPos), LexerError>
 {
     #[allow(clippy::wrong_self_convention)]
     fn to_triple(
         value: Self,
     ) -> Result<
-        (TextPos, Token<'input>, TextPos),
-        lalrpop_util::ParseError<TextPos, Token<'input>, ParserError>,
+        (AirPos, Token<'input>, AirPos),
+        lalrpop_util::ParseError<AirPos, Token<'input>, ParserError>,
     > {
         match value {
             Ok(v) => Ok(v),

--- a/crates/air-lib/air-parser/src/parser/lexer/mod.rs
+++ b/crates/air-lib/air-parser/src/parser/lexer/mod.rs
@@ -26,7 +26,7 @@ pub mod text_pos;
 
 pub use air_lexer::AIRLexer;
 pub use errors::LexerError;
-pub use text_pos::TextPos;
+pub use text_pos::AirPos;
 pub use token::Token;
 
 pub(super) type LexerResult<T> = std::result::Result<T, LexerError>;

--- a/crates/air-lib/air-parser/src/parser/lexer/mod.rs
+++ b/crates/air-lib/air-parser/src/parser/lexer/mod.rs
@@ -22,9 +22,11 @@ mod utils;
 
 #[cfg(test)]
 mod tests;
+pub mod text_pos;
 
 pub use air_lexer::AIRLexer;
 pub use errors::LexerError;
+pub use text_pos::TextPos;
 pub use token::Token;
 
 pub(super) type LexerResult<T> = std::result::Result<T, LexerError>;

--- a/crates/air-lib/air-parser/src/parser/lexer/tests.rs
+++ b/crates/air-lib/air-parser/src/parser/lexer/tests.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use crate::TextPos;
+use crate::AirPos;
 
 use super::air_lexer::Spanned;
 use super::AIRLexer;
@@ -28,17 +28,17 @@ use air_lambda_ast::Functor;
 use fstrings::f;
 use fstrings::format_args_f;
 
-fn run_lexer(input: &str) -> Vec<Spanned<Token<'_>, TextPos, LexerError>> {
+fn run_lexer(input: &str) -> Vec<Spanned<Token<'_>, AirPos, LexerError>> {
     let lexer = AIRLexer::new(input);
     lexer.collect()
 }
 
 #[allow(dead_code)]
 enum TokenCompareStrategy<'token> {
-    All(Vec<Spanned<Token<'token>, TextPos, LexerError>>),
-    Some(Vec<usize>, Vec<Spanned<Token<'token>, TextPos, LexerError>>),
-    One(usize, Spanned<Token<'token>, TextPos, LexerError>),
-    Single(Spanned<Token<'token>, TextPos, LexerError>),
+    All(Vec<Spanned<Token<'token>, AirPos, LexerError>>),
+    Some(Vec<usize>, Vec<Spanned<Token<'token>, AirPos, LexerError>>),
+    One(usize, Spanned<Token<'token>, AirPos, LexerError>),
+    Single(Spanned<Token<'token>, AirPos, LexerError>),
 }
 
 use TokenCompareStrategy::*;

--- a/crates/air-lib/air-parser/src/parser/lexer/tests.rs
+++ b/crates/air-lib/air-parser/src/parser/lexer/tests.rs
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+use crate::TextPos;
+
 use super::air_lexer::Spanned;
 use super::AIRLexer;
 use super::LexerError;
@@ -26,17 +28,17 @@ use air_lambda_ast::Functor;
 use fstrings::f;
 use fstrings::format_args_f;
 
-fn run_lexer(input: &str) -> Vec<Spanned<Token<'_>, usize, LexerError>> {
+fn run_lexer(input: &str) -> Vec<Spanned<Token<'_>, TextPos, LexerError>> {
     let lexer = AIRLexer::new(input);
     lexer.collect()
 }
 
 #[allow(dead_code)]
 enum TokenCompareStrategy<'token> {
-    All(Vec<Spanned<Token<'token>, usize, LexerError>>),
-    Some(Vec<usize>, Vec<Spanned<Token<'token>, usize, LexerError>>),
-    One(usize, Spanned<Token<'token>, usize, LexerError>),
-    Single(Spanned<Token<'token>, usize, LexerError>),
+    All(Vec<Spanned<Token<'token>, TextPos, LexerError>>),
+    Some(Vec<usize>, Vec<Spanned<Token<'token>, TextPos, LexerError>>),
+    One(usize, Spanned<Token<'token>, TextPos, LexerError>),
+    Single(Spanned<Token<'token>, TextPos, LexerError>),
 }
 
 use TokenCompareStrategy::*;
@@ -58,93 +60,96 @@ fn lexer_test(input: &str, expected_tokens: TokenCompareStrategy) {
 
 #[test]
 fn air_instructions() {
-    lexer_test("call", Single(Ok((0, Token::Call, 4))));
+    lexer_test("call", Single(Ok((0.into(), Token::Call, 4.into()))));
 
     lexer_test(
         "(call)",
         All(vec![
-            Ok((0, Token::OpenRoundBracket, 1)),
-            Ok((1, Token::Call, 5)),
-            Ok((5, Token::CloseRoundBracket, 6)),
+            Ok((0.into(), Token::OpenRoundBracket, 1.into())),
+            Ok((1.into(), Token::Call, 5.into())),
+            Ok((5.into(), Token::CloseRoundBracket, 6.into())),
         ]),
     );
 
-    lexer_test("par", Single(Ok((0, Token::Par, 3))));
+    lexer_test("par", Single(Ok((0.into(), Token::Par, 3.into()))));
 
     lexer_test(
         "(par)",
         All(vec![
-            Ok((0, Token::OpenRoundBracket, 1)),
-            Ok((1, Token::Par, 4)),
-            Ok((4, Token::CloseRoundBracket, 5)),
+            Ok((0.into(), Token::OpenRoundBracket, 1.into())),
+            Ok((1.into(), Token::Par, 4.into())),
+            Ok((4.into(), Token::CloseRoundBracket, 5.into())),
         ]),
     );
 
-    lexer_test("seq", Single(Ok((0, Token::Seq, 3))));
+    lexer_test("seq", Single(Ok((0.into(), Token::Seq, 3.into()))));
 
     lexer_test(
         "(seq)",
         All(vec![
-            Ok((0, Token::OpenRoundBracket, 1)),
-            Ok((1, Token::Seq, 4)),
-            Ok((4, Token::CloseRoundBracket, 5)),
+            Ok((0.into(), Token::OpenRoundBracket, 1.into())),
+            Ok((1.into(), Token::Seq, 4.into())),
+            Ok((4.into(), Token::CloseRoundBracket, 5.into())),
         ]),
     );
 
-    lexer_test("null", Single(Ok((0, Token::Null, 4))));
+    lexer_test("null", Single(Ok((0.into(), Token::Null, 4.into()))));
 
     lexer_test(
         "(null)",
         All(vec![
-            Ok((0, Token::OpenRoundBracket, 1)),
-            Ok((1, Token::Null, 5)),
-            Ok((5, Token::CloseRoundBracket, 6)),
+            Ok((0.into(), Token::OpenRoundBracket, 1.into())),
+            Ok((1.into(), Token::Null, 5.into())),
+            Ok((5.into(), Token::CloseRoundBracket, 6.into())),
         ]),
     );
 
-    lexer_test("fail", Single(Ok((0, Token::Fail, 4))));
+    lexer_test("fail", Single(Ok((0.into(), Token::Fail, 4.into()))));
 
-    lexer_test("fold", Single(Ok((0, Token::Fold, 4))));
+    lexer_test("fold", Single(Ok((0.into(), Token::Fold, 4.into()))));
 
     lexer_test(
         "(fold)",
         All(vec![
-            Ok((0, Token::OpenRoundBracket, 1)),
-            Ok((1, Token::Fold, 5)),
-            Ok((5, Token::CloseRoundBracket, 6)),
+            Ok((0.into(), Token::OpenRoundBracket, 1.into())),
+            Ok((1.into(), Token::Fold, 5.into())),
+            Ok((5.into(), Token::CloseRoundBracket, 6.into())),
         ]),
     );
 
-    lexer_test("next", Single(Ok((0, Token::Next, 4))));
+    lexer_test("next", Single(Ok((0.into(), Token::Next, 4.into()))));
 
     lexer_test(
         "(next)",
         All(vec![
-            Ok((0, Token::OpenRoundBracket, 1)),
-            Ok((1, Token::Next, 5)),
-            Ok((5, Token::CloseRoundBracket, 6)),
+            Ok((0.into(), Token::OpenRoundBracket, 1.into())),
+            Ok((1.into(), Token::Next, 5.into())),
+            Ok((5.into(), Token::CloseRoundBracket, 6.into())),
         ]),
     );
 
-    lexer_test("match", Single(Ok((0, Token::Match, 5))));
+    lexer_test("match", Single(Ok((0.into(), Token::Match, 5.into()))));
 
     lexer_test(
         "(match)",
         All(vec![
-            Ok((0, Token::OpenRoundBracket, 1)),
-            Ok((1, Token::Match, 6)),
-            Ok((6, Token::CloseRoundBracket, 7)),
+            Ok((0.into(), Token::OpenRoundBracket, 1.into())),
+            Ok((1.into(), Token::Match, 6.into())),
+            Ok((6.into(), Token::CloseRoundBracket, 7.into())),
         ]),
     );
 
-    lexer_test("mismatch", Single(Ok((0, Token::MisMatch, 8))));
+    lexer_test(
+        "mismatch",
+        Single(Ok((0.into(), Token::MisMatch, 8.into()))),
+    );
 
     lexer_test(
         "(mismatch)",
         All(vec![
-            Ok((0, Token::OpenRoundBracket, 1)),
-            Ok((1, Token::MisMatch, 9)),
-            Ok((9, Token::CloseRoundBracket, 10)),
+            Ok((0.into(), Token::OpenRoundBracket, 1.into())),
+            Ok((1.into(), Token::MisMatch, 9.into())),
+            Ok((9.into(), Token::CloseRoundBracket, 10.into())),
         ]),
     );
 }
@@ -155,7 +160,7 @@ fn init_peer_id() {
 
     lexer_test(
         INIT_PEER_ID,
-        Single(Ok((0, Token::InitPeerId, INIT_PEER_ID.len()))),
+        Single(Ok((0.into(), Token::InitPeerId, INIT_PEER_ID.len().into()))),
     );
 }
 
@@ -165,7 +170,7 @@ fn timestamp() {
 
     lexer_test(
         TIMESTAMP,
-        Single(Ok((0, Token::Timestamp, TIMESTAMP.len()))),
+        Single(Ok((0.into(), Token::Timestamp, TIMESTAMP.len().into()))),
     );
 }
 
@@ -173,7 +178,7 @@ fn timestamp() {
 fn ttl() {
     const TTL: &str = "%ttl%";
 
-    lexer_test(TTL, Single(Ok((0, Token::TTL, TTL.len()))));
+    lexer_test(TTL, Single(Ok((0.into(), Token::TTL, TTL.len().into()))));
 }
 
 #[test]
@@ -183,12 +188,12 @@ fn stream() {
     lexer_test(
         STREAM,
         Single(Ok((
-            0,
+            0.into(),
             Token::Stream {
                 name: STREAM,
-                position: 0,
+                position: 0.into(),
             },
-            STREAM.len(),
+            STREAM.len().into(),
         ))),
     );
 }
@@ -200,12 +205,12 @@ fn canon_stream() {
     lexer_test(
         CANON_STREAM,
         Single(Ok((
-            0,
+            0.into(),
             Token::CanonStream {
                 name: CANON_STREAM,
-                position: 0,
+                position: 0.into(),
             },
-            CANON_STREAM.len(),
+            CANON_STREAM.len().into(),
         ))),
     );
 }
@@ -218,13 +223,13 @@ fn stream_with_functor() {
     lexer_test(
         &stream_with_functor,
         Single(Ok((
-            0,
+            0.into(),
             Token::StreamWithLambda {
                 name: stream_name,
                 lambda: LambdaAST::Functor(Functor::Length),
-                position: 0,
+                position: 0.into(),
             },
-            stream_with_functor.len(),
+            stream_with_functor.len().into(),
         ))),
     );
 }
@@ -237,13 +242,13 @@ fn canon_stream_with_functor() {
     lexer_test(
         &canon_stream_with_functor,
         Single(Ok((
-            0,
+            0.into(),
             Token::CanonStreamWithLambda {
                 name: canon_stream_name,
                 lambda: LambdaAST::Functor(Functor::Length),
-                position: 0,
+                position: 0.into(),
             },
-            canon_stream_with_functor.len(),
+            canon_stream_with_functor.len().into(),
         ))),
     );
 }
@@ -256,13 +261,13 @@ fn scalar_with_functor() {
     lexer_test(
         &scalar_with_functor,
         Single(Ok((
-            0,
+            0.into(),
             Token::ScalarWithLambda {
                 name: scalar_name,
                 lambda: LambdaAST::Functor(Functor::Length),
-                position: 0,
+                position: 0.into(),
             },
-            scalar_with_functor.len(),
+            scalar_with_functor.len().into(),
         ))),
     );
 }
@@ -274,9 +279,9 @@ fn string_literal() {
     lexer_test(
         STRING_LITERAL,
         Single(Ok((
-            0,
+            0.into(),
             Token::StringLiteral(&STRING_LITERAL[1..STRING_LITERAL.len() - 1]),
-            STRING_LITERAL.len(),
+            STRING_LITERAL.len().into(),
         ))),
     );
 }
@@ -289,9 +294,9 @@ fn integer_numbers() {
     lexer_test(
         &number_with_plus_sign,
         Single(Ok((
-            0,
+            0.into(),
             Token::I64(test_integer),
-            number_with_plus_sign.len(),
+            number_with_plus_sign.len().into(),
         ))),
     );
 
@@ -299,7 +304,11 @@ fn integer_numbers() {
 
     lexer_test(
         &number,
-        Single(Ok((0, Token::I64(test_integer), number.len()))),
+        Single(Ok((
+            0.into(),
+            Token::I64(test_integer),
+            number.len().into(),
+        ))),
     );
 
     let number_with_minus_sign = f!("-{test_integer}");
@@ -307,9 +316,9 @@ fn integer_numbers() {
     lexer_test(
         &number_with_minus_sign,
         Single(Ok((
-            0,
+            0.into(),
             Token::I64(-test_integer),
-            number_with_minus_sign.len(),
+            number_with_minus_sign.len().into(),
         ))),
     );
 }
@@ -322,9 +331,9 @@ fn float_number() {
     lexer_test(
         &float_number_with_plus_sign,
         Single(Ok((
-            0,
+            0.into(),
             Token::F64(test_float),
-            float_number_with_plus_sign.len(),
+            float_number_with_plus_sign.len().into(),
         ))),
     );
 
@@ -332,7 +341,11 @@ fn float_number() {
 
     lexer_test(
         &float_number,
-        Single(Ok((0, Token::F64(test_float), float_number.len()))),
+        Single(Ok((
+            0.into(),
+            Token::F64(test_float),
+            float_number.len().into(),
+        ))),
     );
 
     let float_number_with_minus_sign = f!("-{test_float}");
@@ -340,9 +353,9 @@ fn float_number() {
     lexer_test(
         &float_number_with_minus_sign,
         Single(Ok((
-            0,
+            0.into(),
             Token::F64(-test_float),
-            float_number_with_minus_sign.len(),
+            float_number_with_minus_sign.len().into(),
         ))),
     );
 }
@@ -366,7 +379,9 @@ fn too_big_float_number() {
 
     lexer_test(
         FNUMBER,
-        Single(Err(LexerError::too_big_float(0..FNUMBER.len()))),
+        Single(Err(LexerError::too_big_float(
+            0.into()..FNUMBER.len().into(),
+        ))),
     );
 }
 
@@ -378,7 +393,7 @@ fn lambda() {
     lexer_test(
         LAMBDA,
         Single(Ok((
-            0,
+            0.into(),
             Token::ScalarWithLambda {
                 name: "value",
                 lambda: LambdaAST::try_from_accessors(vec![
@@ -388,9 +403,9 @@ fn lambda() {
                     ValueAccessor::ArrayAccess { idx: 1 },
                 ])
                 .unwrap(),
-                position: 0,
+                position: 0.into(),
             },
-            LAMBDA.len(),
+            LAMBDA.len().into(),
         ))),
     );
 }
@@ -401,14 +416,18 @@ fn lambda_path_numbers() {
 
     lexer_test(
         LAMBDA,
-        Single(Err(LexerError::unallowed_char_in_number(6..6))),
+        Single(Err(LexerError::unallowed_char_in_number(
+            6.into()..6.into(),
+        ))),
     );
 
     const LAMBDA1: &str = r#"+12345.$[$@[]():?.*,"]"#;
 
     lexer_test(
         LAMBDA1,
-        Single(Err(LexerError::unallowed_char_in_number(7..7))),
+        Single(Err(LexerError::unallowed_char_in_number(
+            7.into()..7.into(),
+        ))),
     );
 }
 
@@ -416,13 +435,16 @@ fn lambda_path_numbers() {
 fn leading_dot() {
     const LEADING_DOT: &str = ".111";
 
-    lexer_test(LEADING_DOT, Single(Err(LexerError::leading_dot(0..0))));
+    lexer_test(
+        LEADING_DOT,
+        Single(Err(LexerError::leading_dot(0.into()..0.into()))),
+    );
 
     const LEADING_DOT_AFTER_SIGN: &str = "+.1111";
 
     lexer_test(
         LEADING_DOT_AFTER_SIGN,
-        Single(Err(LexerError::leading_dot(1..1))),
+        Single(Err(LexerError::leading_dot(1.into()..1.into()))),
     );
 }
 
@@ -432,7 +454,10 @@ fn unclosed_quote() {
 
     lexer_test(
         UNCLOSED_QUOTE_AIR,
-        One(4, Err(LexerError::is_not_alphanumeric(33..33))),
+        One(
+            4,
+            Err(LexerError::is_not_alphanumeric(33.into()..33.into())),
+        ),
     );
 }
 
@@ -443,7 +468,7 @@ fn bad_value() {
 
     lexer_test(
         INVALID_VALUE,
-        Single(Err(LexerError::is_not_alphanumeric(3..3))),
+        Single(Err(LexerError::is_not_alphanumeric(3.into()..3.into()))),
     );
 
     // value contains ! that only allowed at the end of a lambda expression
@@ -451,7 +476,7 @@ fn bad_value() {
 
     lexer_test(
         INVALID_VALUE2,
-        Single(Err(LexerError::invalid_lambda(7..7))),
+        Single(Err(LexerError::invalid_lambda(7.into()..7.into()))),
     );
 }
 
@@ -461,7 +486,7 @@ fn invalid_lambda() {
 
     lexer_test(
         INVALID_LAMBDA,
-        Single(Err(LexerError::invalid_lambda(7..7))),
+        Single(Err(LexerError::invalid_lambda(7.into()..7.into()))),
     );
 }
 
@@ -470,7 +495,10 @@ fn invalid_lambda_numbers() {
     // this lambda contains all allowed in lambda characters
     const LAMBDA: &str = r#"+12345$[$@[]():?.*,"!]"#;
 
-    lexer_test(LAMBDA, Single(Err(LexerError::is_not_alphanumeric(6..6))));
+    lexer_test(
+        LAMBDA,
+        Single(Err(LexerError::is_not_alphanumeric(6.into()..6.into()))),
+    );
 }
 
 #[test]
@@ -479,7 +507,7 @@ fn last_error() {
 
     lexer_test(
         LAST_ERROR,
-        Single(Ok((0, Token::LastError, LAST_ERROR.len()))),
+        Single(Ok((0.into(), Token::LastError, LAST_ERROR.len().into()))),
     );
 }
 
@@ -494,7 +522,10 @@ fn last_error_instruction() {
         .unwrap(),
     );
 
-    lexer_test(LAST_ERROR, Single(Ok((0, token, LAST_ERROR.len()))));
+    lexer_test(
+        LAST_ERROR,
+        Single(Ok((0.into(), token, LAST_ERROR.len().into()))),
+    );
 }
 
 #[test]
@@ -507,7 +538,10 @@ fn last_error_message() {
         }])
         .unwrap(),
     );
-    lexer_test(LAST_ERROR, Single(Ok((0, token, LAST_ERROR.len()))));
+    lexer_test(
+        LAST_ERROR,
+        Single(Ok((0.into(), token, LAST_ERROR.len().into()))),
+    );
 }
 
 #[test]
@@ -520,7 +554,10 @@ fn last_error_peer_id() {
         }])
         .unwrap(),
     );
-    lexer_test(LAST_ERROR, Single(Ok((0, token, LAST_ERROR.len()))));
+    lexer_test(
+        LAST_ERROR,
+        Single(Ok((0.into(), token, LAST_ERROR.len().into()))),
+    );
 }
 
 #[test]
@@ -533,7 +570,10 @@ fn last_error_non_standard_field() {
         }])
         .unwrap(),
     );
-    lexer_test(LAST_ERROR, Single(Ok((0, token, LAST_ERROR.len()))));
+    lexer_test(
+        LAST_ERROR,
+        Single(Ok((0.into(), token, LAST_ERROR.len().into()))),
+    );
 }
 
 #[test]
@@ -542,14 +582,22 @@ fn booleans() {
 
     lexer_test(
         TRUE_BOOL_CONST,
-        Single(Ok((0, Token::Boolean(true), TRUE_BOOL_CONST.len()))),
+        Single(Ok((
+            0.into(),
+            Token::Boolean(true),
+            TRUE_BOOL_CONST.len().into(),
+        ))),
     );
 
     const FALSE_BOOL_CONST: &str = "false";
 
     lexer_test(
         FALSE_BOOL_CONST,
-        Single(Ok((0, Token::Boolean(false), FALSE_BOOL_CONST.len()))),
+        Single(Ok((
+            0.into(),
+            Token::Boolean(false),
+            FALSE_BOOL_CONST.len().into(),
+        ))),
     );
 
     const NON_BOOL_CONST: &str = "true1";
@@ -557,12 +605,12 @@ fn booleans() {
     lexer_test(
         NON_BOOL_CONST,
         Single(Ok((
-            0,
+            0.into(),
             Token::Scalar {
                 name: NON_BOOL_CONST,
-                position: 0,
+                position: 0.into(),
             },
-            NON_BOOL_CONST.len(),
+            NON_BOOL_CONST.len().into(),
         ))),
     );
 }
@@ -578,8 +626,8 @@ fn match_with_empty_array__() {
         Some(
             vec![3, 4],
             vec![
-                Ok((14, Token::OpenSquareBracket, 15)),
-                Ok((15, Token::CloseSquareBracket, 16)),
+                Ok((14.into(), Token::OpenSquareBracket, 15.into())),
+                Ok((15.into(), Token::CloseSquareBracket, 16.into())),
             ],
         ),
     );

--- a/crates/air-lib/air-parser/src/parser/lexer/text_pos.rs
+++ b/crates/air-lib/air-parser/src/parser/lexer/text_pos.rs
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2021 Fluence Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::ops::{Add, Sub};
+
+use serde::{Deserialize, Serialize};
+
+/// Character position in the AIR script text.
+#[derive(
+    Clone, Copy, Debug, Default, Hash, PartialEq, Eq, Serialize, Deserialize, PartialOrd, Ord,
+)]
+#[serde(transparent)]
+#[repr(transparent)]
+pub struct TextPos(usize);
+
+impl From<usize> for TextPos {
+    fn from(value: usize) -> Self {
+        Self(value)
+    }
+}
+
+impl From<TextPos> for usize {
+    fn from(p: TextPos) -> Self {
+        p.0
+    }
+}
+
+impl Add<usize> for TextPos {
+    type Output = Self;
+
+    fn add(self, rhs: usize) -> Self::Output {
+        Self(self.0 + rhs)
+    }
+}
+
+impl Sub<usize> for TextPos {
+    type Output = TextPos;
+
+    fn sub(self, rhs: usize) -> Self::Output {
+        Self(self.0 - rhs)
+    }
+}
+
+impl Sub<TextPos> for TextPos {
+    type Output = usize;
+
+    fn sub(self, rhs: TextPos) -> Self::Output {
+        self.0 - rhs.0
+    }
+}
+
+impl PartialEq<usize> for TextPos {
+    fn eq(&self, other: &usize) -> bool {
+        self.0 == *other
+    }
+}
+
+impl std::fmt::Display for TextPos {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.0, f)
+    }
+}

--- a/crates/air-lib/air-parser/src/parser/lexer/text_pos.rs
+++ b/crates/air-lib/air-parser/src/parser/lexer/text_pos.rs
@@ -24,21 +24,21 @@ use serde::{Deserialize, Serialize};
 )]
 #[serde(transparent)]
 #[repr(transparent)]
-pub struct TextPos(usize);
+pub struct AirPos(usize);
 
-impl From<usize> for TextPos {
+impl From<usize> for AirPos {
     fn from(value: usize) -> Self {
         Self(value)
     }
 }
 
-impl From<TextPos> for usize {
-    fn from(p: TextPos) -> Self {
+impl From<AirPos> for usize {
+    fn from(p: AirPos) -> Self {
         p.0
     }
 }
 
-impl Add<usize> for TextPos {
+impl Add<usize> for AirPos {
     type Output = Self;
 
     fn add(self, rhs: usize) -> Self::Output {
@@ -46,29 +46,29 @@ impl Add<usize> for TextPos {
     }
 }
 
-impl Sub<usize> for TextPos {
-    type Output = TextPos;
+impl Sub<usize> for AirPos {
+    type Output = AirPos;
 
     fn sub(self, rhs: usize) -> Self::Output {
         Self(self.0 - rhs)
     }
 }
 
-impl Sub<TextPos> for TextPos {
+impl Sub<AirPos> for AirPos {
     type Output = usize;
 
-    fn sub(self, rhs: TextPos) -> Self::Output {
+    fn sub(self, rhs: AirPos) -> Self::Output {
         self.0 - rhs.0
     }
 }
 
-impl PartialEq<usize> for TextPos {
+impl PartialEq<usize> for AirPos {
     fn eq(&self, other: &usize) -> bool {
         self.0 == *other
     }
 }
 
-impl std::fmt::Display for TextPos {
+impl std::fmt::Display for AirPos {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(&self.0, f)
     }

--- a/crates/air-lib/air-parser/src/parser/lexer/token.rs
+++ b/crates/air-lib/air-parser/src/parser/lexer/token.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use super::TextPos;
+use super::AirPos;
 use crate::LambdaAST;
 
 use serde::Deserialize;
@@ -30,30 +30,30 @@ pub enum Token<'input> {
 
     Scalar {
         name: &'input str,
-        position: TextPos,
+        position: AirPos,
     },
     ScalarWithLambda {
         name: &'input str,
         lambda: LambdaAST<'input>,
-        position: TextPos,
+        position: AirPos,
     },
     Stream {
         name: &'input str,
-        position: TextPos,
+        position: AirPos,
     },
     StreamWithLambda {
         name: &'input str,
         lambda: LambdaAST<'input>,
-        position: TextPos,
+        position: AirPos,
     },
     CanonStream {
         name: &'input str,
-        position: TextPos,
+        position: AirPos,
     },
     CanonStreamWithLambda {
         name: &'input str,
         lambda: LambdaAST<'input>,
-        position: TextPos,
+        position: AirPos,
     },
 
     StringLiteral(&'input str),

--- a/crates/air-lib/air-parser/src/parser/lexer/token.rs
+++ b/crates/air-lib/air-parser/src/parser/lexer/token.rs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+use super::TextPos;
 use crate::LambdaAST;
 
 use serde::Deserialize;
@@ -29,30 +30,30 @@ pub enum Token<'input> {
 
     Scalar {
         name: &'input str,
-        position: usize,
+        position: TextPos,
     },
     ScalarWithLambda {
         name: &'input str,
         lambda: LambdaAST<'input>,
-        position: usize,
+        position: TextPos,
     },
     Stream {
         name: &'input str,
-        position: usize,
+        position: TextPos,
     },
     StreamWithLambda {
         name: &'input str,
         lambda: LambdaAST<'input>,
-        position: usize,
+        position: TextPos,
     },
     CanonStream {
         name: &'input str,
-        position: usize,
+        position: TextPos,
     },
     CanonStreamWithLambda {
         name: &'input str,
         lambda: LambdaAST<'input>,
-        position: usize,
+        position: TextPos,
     },
 
     StringLiteral(&'input str),

--- a/crates/air-lib/air-parser/src/parser/span.rs
+++ b/crates/air-lib/air-parser/src/parser/span.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use super::lexer::TextPos;
+use super::lexer::AirPos;
 
 use serde::Deserialize;
 use serde::Serialize;
@@ -23,16 +23,16 @@ use std::ops::Range;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Span {
-    pub left: TextPos,
-    pub right: TextPos,
+    pub left: AirPos,
+    pub right: AirPos,
 }
 
 impl Span {
-    pub fn new(left: TextPos, right: TextPos) -> Self {
+    pub fn new(left: AirPos, right: AirPos) -> Self {
         Self { left, right }
     }
 
-    pub fn contains_position(&self, position: TextPos) -> bool {
+    pub fn contains_position(&self, position: AirPos) -> bool {
         self.left < position && position < self.right
     }
 
@@ -41,8 +41,8 @@ impl Span {
     }
 }
 
-impl From<Range<TextPos>> for Span {
-    fn from(range: Range<TextPos>) -> Self {
+impl From<Range<AirPos>> for Span {
+    fn from(range: Range<AirPos>) -> Self {
         Self {
             left: range.start,
             right: range.end,

--- a/crates/air-lib/air-parser/src/parser/span.rs
+++ b/crates/air-lib/air-parser/src/parser/span.rs
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+use super::lexer::TextPos;
+
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -21,16 +23,16 @@ use std::ops::Range;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Span {
-    pub left: usize,
-    pub right: usize,
+    pub left: TextPos,
+    pub right: TextPos,
 }
 
 impl Span {
-    pub fn new(left: usize, right: usize) -> Self {
+    pub fn new(left: TextPos, right: TextPos) -> Self {
         Self { left, right }
     }
 
-    pub fn contains_position(&self, position: usize) -> bool {
+    pub fn contains_position(&self, position: TextPos) -> bool {
         self.left < position && position < self.right
     }
 
@@ -39,8 +41,8 @@ impl Span {
     }
 }
 
-impl From<Range<usize>> for Span {
-    fn from(range: Range<usize>) -> Self {
+impl From<Range<TextPos>> for Span {
+    fn from(range: Range<TextPos>) -> Self {
         Self {
             left: range.start,
             right: range.end,

--- a/crates/air-lib/air-parser/src/parser/tests/ap.rs
+++ b/crates/air-lib/air-parser/src/parser/tests/ap.rs
@@ -31,7 +31,7 @@ fn ap_with_literal() {
     let actual = parse(source_code);
     let expected = ap(
         ApArgument::Literal("some_string"),
-        ApResult::Stream(Stream::new("$stream", 27)),
+        ApResult::Stream(Stream::new("$stream", 27.into())),
     );
 
     assert_eq!(actual, expected);
@@ -46,7 +46,7 @@ fn ap_with_number() {
     let actual = parse(source_code);
     let expected = ap(
         ApArgument::Number(Number::Int(-100)),
-        ApResult::Stream(Stream::new("$stream", 18)),
+        ApResult::Stream(Stream::new("$stream", 18.into())),
     );
 
     assert_eq!(actual, expected);
@@ -61,7 +61,7 @@ fn ap_with_bool() {
     let actual = parse(source_code);
     let expected = ap(
         ApArgument::Boolean(true),
-        ApResult::Stream(Stream::new("$stream", 18)),
+        ApResult::Stream(Stream::new("$stream", 18.into())),
     );
 
     assert_eq!(actual, expected);
@@ -81,7 +81,7 @@ fn ap_with_last_error() {
             }])
             .unwrap(),
         )),
-        ApResult::Stream(Stream::new("$stream", 37)),
+        ApResult::Stream(Stream::new("$stream", 37.into())),
     );
 
     assert_eq!(actual, expected);
@@ -96,7 +96,7 @@ fn ap_with_empty_array() {
     let actual = parse(source_code);
     let expected = ap(
         ApArgument::EmptyArray,
-        ApResult::Stream(Stream::new("$stream", 16)),
+        ApResult::Stream(Stream::new("$stream", 16.into())),
     );
 
     assert_eq!(actual, expected);
@@ -111,7 +111,7 @@ fn ap_with_init_peer_id() {
     let actual = parse(source_code);
     let expected = ap(
         ApArgument::InitPeerId,
-        ApResult::Stream(Stream::new("$stream", 28)),
+        ApResult::Stream(Stream::new("$stream", 28.into())),
     );
 
     assert_eq!(actual, expected);
@@ -126,7 +126,7 @@ fn ap_with_timestamp() {
     let actual = parse(source_code);
     let expected = ap(
         ApArgument::Timestamp,
-        ApResult::Stream(Stream::new("$stream", 25)),
+        ApResult::Stream(Stream::new("$stream", 25.into())),
     );
 
     assert_eq!(actual, expected);
@@ -141,7 +141,7 @@ fn ap_with_ttl() {
     let actual = parse(source_code);
     let expected = ap(
         ApArgument::TTL,
-        ApResult::Stream(Stream::new("$stream", 19)),
+        ApResult::Stream(Stream::new("$stream", 19.into())),
     );
 
     assert_eq!(actual, expected);
@@ -157,8 +157,8 @@ fn ap_with_canon_stream() {
 
     let actual = parse(&source_code);
     let expected = ap(
-        ApArgument::CanonStream(CanonStreamWithLambda::new(canon_stream, None, 13)),
-        ApResult::Scalar(Scalar::new(scalar, 27)),
+        ApArgument::CanonStream(CanonStreamWithLambda::new(canon_stream, None, 13.into())),
+        ApResult::Scalar(Scalar::new(scalar, 27.into())),
     );
 
     assert_eq!(actual, expected);
@@ -179,9 +179,9 @@ fn ap_with_canon_stream_with_lambda() {
             Some(
                 LambdaAST::try_from_accessors(vec![ValueAccessor::ArrayAccess { idx: 0 }]).unwrap(),
             ),
-            13,
+            13.into(),
         )),
-        ApResult::Scalar(Scalar::new(scalar, 33)),
+        ApResult::Scalar(Scalar::new(scalar, 33.into())),
     );
 
     assert_eq!(actual, expected);

--- a/crates/air-lib/air-parser/src/parser/tests/call.rs
+++ b/crates/air-lib/air-parser/src/parser/tests/call.rs
@@ -37,15 +37,15 @@ fn parse_json_path() {
         CallInstrValue::Variable(VariableWithLambda::from_raw_value_path(
             "peer_id",
             vec![ValueAccessor::FieldAccessByName { field_name: "a" }],
-            15,
+            15.into(),
         )),
         CallInstrValue::Literal("service_id"),
         CallInstrValue::Literal("function_name"),
         Rc::new(vec![
             Value::Literal("hello"),
-            Value::Variable(VariableWithLambda::scalar("name", 68)),
+            Value::Variable(VariableWithLambda::scalar("name", 68.into())),
         ]),
-        CallOutputValue::Stream(Stream::new("$void", 74)),
+        CallOutputValue::Stream(Stream::new("$void", 74.into())),
     );
     assert_eq!(instruction, expected);
 }
@@ -58,13 +58,13 @@ fn parse_empty_array() {
 
     let actual = parse(source_code);
     let expected = call(
-        CallInstrValue::Variable(VariableWithLambda::scalar("peer_id", 15)),
-        CallInstrValue::Variable(VariableWithLambda::scalar("service_id", 24)),
+        CallInstrValue::Variable(VariableWithLambda::scalar("peer_id", 15.into())),
+        CallInstrValue::Variable(VariableWithLambda::scalar("service_id", 24.into())),
         CallInstrValue::Literal("function_name"),
         Rc::new(vec![
             Value::Literal(""),
             Value::EmptyArray,
-            Value::Variable(VariableWithLambda::scalar("arg", 59)),
+            Value::Variable(VariableWithLambda::scalar("arg", 59.into())),
         ]),
         CallOutputValue::None,
     );
@@ -80,11 +80,11 @@ fn parse_empty_array_2() {
 
     let actual = parse(source_code);
     let expected = call(
-        CallInstrValue::Variable(VariableWithLambda::scalar("peer_id", 15)),
+        CallInstrValue::Variable(VariableWithLambda::scalar("peer_id", 15.into())),
         CallInstrValue::Literal("service_id"),
         CallInstrValue::Literal("function_name"),
         Rc::new(vec![
-            Value::Variable(VariableWithLambda::scalar("k", 55)),
+            Value::Variable(VariableWithLambda::scalar("k", 55.into())),
             Value::EmptyArray,
             Value::EmptyArray,
         ]),
@@ -190,12 +190,12 @@ fn parse_lambda_complex() {
             CallInstrValue::Variable(VariableWithLambda::from_raw_value_path(
                 "m",
                 vec![ValueAccessor::ArrayAccess { idx: 1 }],
-                32,
+                32.into(),
             )),
             CallInstrValue::Literal("service_id"),
             CallInstrValue::Literal("function_name"),
             Rc::new(vec![]),
-            CallOutputValue::Scalar(Scalar::new("void", 75)),
+            CallOutputValue::Scalar(Scalar::new("void", 75.into())),
         ),
         call(
             CallInstrValue::Variable(VariableWithLambda::from_raw_value_path(
@@ -209,12 +209,12 @@ fn parse_lambda_complex() {
                     ValueAccessor::FieldAccessByName { field_name: "cde" },
                     ValueAccessor::ArrayAccess { idx: 1 },
                 ],
-                99,
+                99.into(),
             )),
             CallInstrValue::Literal("service_id"),
             CallInstrValue::Literal("function_name"),
             Rc::new(vec![]),
-            CallOutputValue::Scalar(Scalar::new("void", 162)),
+            CallOutputValue::Scalar(Scalar::new("void", 162.into())),
         ),
     );
     assert_eq!(instruction, expected);
@@ -242,12 +242,12 @@ fn parse_lambda_with_scalars_complex() {
                         scalar_name: "scalar_2",
                     },
                 ],
-                32,
+                32.into(),
             )),
             CallInstrValue::Literal("service_id"),
             CallInstrValue::Literal("function_name"),
             Rc::new(vec![]),
-            CallOutputValue::Scalar(Scalar::new("void", 97)),
+            CallOutputValue::Scalar(Scalar::new("void", 97.into())),
         ),
         call(
             CallInstrValue::Variable(VariableWithLambda::from_raw_value_path(
@@ -267,12 +267,12 @@ fn parse_lambda_with_scalars_complex() {
                     ValueAccessor::FieldAccessByName { field_name: "cde" },
                     ValueAccessor::ArrayAccess { idx: 1 },
                 ],
-                121,
+                121.into(),
             )),
             CallInstrValue::Literal("service_id"),
             CallInstrValue::Literal("function_name"),
             Rc::new(vec![]),
-            CallOutputValue::Scalar(Scalar::new("void", 205)),
+            CallOutputValue::Scalar(Scalar::new("void", 205.into())),
         ),
     );
     assert_eq!(instruction, expected);
@@ -290,7 +290,7 @@ fn json_path_square_braces() {
             vec![ValueAccessor::FieldAccessByName {
                 field_name: "peer_id",
             }],
-            15,
+            15.into(),
         )),
         CallInstrValue::Literal("return"),
         CallInstrValue::Literal(""),
@@ -304,15 +304,15 @@ fn json_path_square_braces() {
                     ValueAccessor::ArrayAccess { idx: 0 },
                     ValueAccessor::FieldAccessByName { field_name: "abc" },
                 ],
-                43,
+                43.into(),
             )),
             Value::Variable(VariableWithLambda::from_raw_value_path(
                 "u",
                 vec![ValueAccessor::FieldAccessByName { field_name: "name" }],
-                64,
+                64.into(),
             )),
         ]),
-        CallOutputValue::Stream(Stream::new("$void", 74)),
+        CallOutputValue::Stream(Stream::new("$void", 74.into())),
     );
 
     assert_eq!(instruction, expected);
@@ -428,7 +428,7 @@ fn canon_stream_in_args() {
         CallInstrValue::Literal(function_name),
         Rc::new(vec![Value::Variable(VariableWithLambda::canon_stream(
             canon_stream,
-            66,
+            66.into(),
         ))]),
         CallOutputValue::None,
     );
@@ -447,7 +447,7 @@ fn canon_stream_in_triplet() {
 
     let instruction = parse(&source_code);
     let expected = call(
-        CallInstrValue::Variable(VariableWithLambda::canon_stream(canon_stream, 19)),
+        CallInstrValue::Variable(VariableWithLambda::canon_stream(canon_stream, 19.into())),
         CallInstrValue::Literal(service_id),
         CallInstrValue::Literal(function_name),
         Rc::new(vec![]),
@@ -476,7 +476,7 @@ fn canon_stream_with_lambda_in_triplet() {
                 ValueAccessor::FieldAccessByName { field_name: "path" },
             ])
             .unwrap(),
-            19,
+            19.into(),
         )),
         CallInstrValue::Literal(service_id),
         CallInstrValue::Literal(function_name),
@@ -507,14 +507,14 @@ fn seq_par_call() {
                 CallInstrValue::Literal("local_service_id"),
                 CallInstrValue::Literal("local_fn_name"),
                 Rc::new(vec![]),
-                CallOutputValue::Scalar(Scalar::new("result_1", 108)),
+                CallOutputValue::Scalar(Scalar::new("result_1", 108.into())),
             ),
             call(
                 CallInstrValue::Literal(peer_id),
                 CallInstrValue::Literal("service_id"),
                 CallInstrValue::Literal("fn_name"),
                 Rc::new(vec![]),
-                CallOutputValue::Scalar(Scalar::new("g", 183)),
+                CallOutputValue::Scalar(Scalar::new("g", 183.into())),
             ),
         ),
         call(
@@ -522,7 +522,7 @@ fn seq_par_call() {
             CallInstrValue::Literal("local_service_id"),
             CallInstrValue::Literal("local_fn_name"),
             Rc::new(vec![]),
-            CallOutputValue::Scalar(Scalar::new("result_2", 273)),
+            CallOutputValue::Scalar(Scalar::new("result_2", 273.into())),
         ),
     );
 
@@ -562,14 +562,14 @@ fn seq_with_empty_and_dash() {
                     CallInstrValue::Literal(""),
                     CallInstrValue::Literal(""),
                     Rc::new(vec![Value::Literal("module-bytes")]),
-                    CallOutputValue::Scalar(Scalar::new("module-bytes", 119)),
+                    CallOutputValue::Scalar(Scalar::new("module-bytes", 119.into())),
                 ),
                 call(
                     CallInstrValue::Literal("set_variables"),
                     CallInstrValue::Literal(""),
                     CallInstrValue::Literal(""),
                     Rc::new(vec![Value::Literal("module_config")]),
-                    CallOutputValue::Scalar(Scalar::new("module_config", 201)),
+                    CallOutputValue::Scalar(Scalar::new("module_config", 201.into())),
                 ),
             ),
             call(
@@ -577,7 +577,7 @@ fn seq_with_empty_and_dash() {
                 CallInstrValue::Literal(""),
                 CallInstrValue::Literal(""),
                 Rc::new(vec![Value::Literal("blueprint")]),
-                CallOutputValue::Scalar(Scalar::new("blueprint", 294)),
+                CallOutputValue::Scalar(Scalar::new("blueprint", 294.into())),
             ),
         ),
         seq(
@@ -586,10 +586,10 @@ fn seq_with_empty_and_dash() {
                 CallInstrValue::Literal("add_module"),
                 CallInstrValue::Literal(""),
                 Rc::new(vec![
-                    Value::Variable(VariableWithLambda::scalar("module-bytes", 381)),
-                    Value::Variable(VariableWithLambda::scalar("module_config", 394)),
+                    Value::Variable(VariableWithLambda::scalar("module-bytes", 381.into())),
+                    Value::Variable(VariableWithLambda::scalar("module_config", 394.into())),
                 ]),
-                CallOutputValue::Scalar(Scalar::new("module", 409)),
+                CallOutputValue::Scalar(Scalar::new("module", 409.into())),
             ),
             seq(
                 Instruction::Call(Call {
@@ -600,9 +600,9 @@ fn seq_with_empty_and_dash() {
                     },
                     args: Rc::new(vec![Value::Variable(VariableWithLambda::scalar(
                         "blueprint",
-                        490,
+                        490.into(),
                     ))]),
-                    output: CallOutputValue::Scalar(Scalar::new("blueprint_id", 501)),
+                    output: CallOutputValue::Scalar(Scalar::new("blueprint_id", 501.into())),
                 }),
                 seq(
                     call(
@@ -611,9 +611,9 @@ fn seq_with_empty_and_dash() {
                         CallInstrValue::Literal(""),
                         Rc::new(vec![Value::Variable(VariableWithLambda::scalar(
                             "blueprint_id",
-                            589,
+                            589.into(),
                         ))]),
-                        CallOutputValue::Scalar(Scalar::new("service_id", 603)),
+                        CallOutputValue::Scalar(Scalar::new("service_id", 603.into())),
                     ),
                     call(
                         CallInstrValue::Literal("remote_peer_id"),
@@ -621,9 +621,9 @@ fn seq_with_empty_and_dash() {
                         CallInstrValue::Literal(""),
                         Rc::new(vec![Value::Variable(VariableWithLambda::scalar(
                             "service_id",
-                            671,
+                            671.into(),
                         ))]),
-                        CallOutputValue::Scalar(Scalar::new("client_result", 683)),
+                        CallOutputValue::Scalar(Scalar::new("client_result", 683.into())),
                     ),
                 ),
             ),
@@ -642,9 +642,9 @@ fn no_output() {
     let actual = parse(source_code);
 
     let expected = call(
-        CallInstrValue::Variable(VariableWithLambda::scalar("peer", 15)),
-        CallInstrValue::Variable(VariableWithLambda::scalar("service", 21)),
-        CallInstrValue::Variable(VariableWithLambda::scalar("fname", 29)),
+        CallInstrValue::Variable(VariableWithLambda::scalar("peer", 15.into())),
+        CallInstrValue::Variable(VariableWithLambda::scalar("service", 21.into())),
+        CallInstrValue::Variable(VariableWithLambda::scalar("fname", 29.into())),
         Rc::new(vec![]),
         CallOutputValue::None,
     );

--- a/crates/air-lib/air-parser/src/parser/tests/canon.rs
+++ b/crates/air-lib/air-parser/src/parser/tests/canon.rs
@@ -33,8 +33,8 @@ fn canon_with_literal_peer_id() {
     let actual = parse(&source_code);
     let expected = canon(
         CallInstrValue::Literal(peer_id),
-        Stream::new(stream, 26),
-        CanonStream::new(canon_stream, 34),
+        Stream::new(stream, 26.into()),
+        CanonStream::new(canon_stream, 34.into()),
     );
 
     assert_eq!(actual, expected);
@@ -51,9 +51,9 @@ fn canon_with_variable_peer_id() {
 
     let actual = parse(&source_code);
     let expected = canon(
-        CallInstrValue::Variable(VariableWithLambda::scalar(peer_id, 16)),
-        Stream::new(stream, 24),
-        CanonStream::new(canon_stream, 32),
+        CallInstrValue::Variable(VariableWithLambda::scalar(peer_id, 16.into())),
+        Stream::new(stream, 24.into()),
+        CanonStream::new(canon_stream, 32.into()),
     );
 
     assert_eq!(actual, expected);

--- a/crates/air-lib/air-parser/src/parser/tests/fail.rs
+++ b/crates/air-lib/air-parser/src/parser/tests/fail.rs
@@ -47,7 +47,7 @@ fn parse_fail_scalars() {
            (fail scalar)
         "#;
     let instruction = parse(source_code);
-    let expected = fail_scalar(ScalarWithLambda::new("scalar", None, 18));
+    let expected = fail_scalar(ScalarWithLambda::new("scalar", None, 18.into()));
     assert_eq!(instruction, expected)
 }
 
@@ -65,7 +65,7 @@ fn parse_fail_scalar_with_lambda() {
             }])
             .unwrap(),
         ),
-        18,
+        18.into(),
     ));
     assert_eq!(instruction, expected)
 }

--- a/crates/air-lib/air-parser/src/parser/tests/fold.rs
+++ b/crates/air-lib/air-parser/src/parser/tests/fold.rs
@@ -272,10 +272,10 @@ fn parse_fold() {
         "#;
     let instruction = parse(&source_code);
     let expected = fold_scalar_variable(
-        ScalarWithLambda::new("iterable", None, 15),
-        Scalar::new("i", 24),
+        ScalarWithLambda::new("iterable", None, 15.into()),
+        Scalar::new("i", 24.into()),
         null(),
-        Span::new(9, 54),
+        Span::new(9.into(), 54.into()),
     );
     assert_eq!(instruction, expected);
 }
@@ -293,11 +293,11 @@ fn fold_json_path() {
         ScalarWithLambda::from_value_path(
             "members",
             vec![ValueAccessor::ArrayAccess { idx: 123321 }],
-            33,
+            33.into(),
         ),
-        Scalar::new("m", 52),
+        Scalar::new("m", 52.into()),
         null(),
-        Span::new(27, 61),
+        Span::new(27.into(), 61.into()),
     );
     assert_eq!(instruction, expected);
 }
@@ -311,7 +311,11 @@ fn fold_empty_array_iterable() {
     "#;
 
     let instruction = parse(source_code);
-    let expected = fold_scalar_empty_array(Scalar::new("m", 18), null(), Span::new(9, 48));
+    let expected = fold_scalar_empty_array(
+        Scalar::new("m", 18.into()),
+        null(),
+        Span::new(9.into(), 48.into()),
+    );
     assert_eq!(instruction, expected);
 }
 
@@ -323,10 +327,10 @@ fn fold_on_stream() {
 
     let instruction = parse(source_code);
     let expected = fold_stream(
-        Stream::new("$stream", 15),
-        Scalar::new("iterator", 23),
+        Stream::new("$stream", 15.into()),
+        Scalar::new("iterator", 23.into()),
         null(),
-        Span::new(9, 39),
+        Span::new(9.into(), 39.into()),
     );
     assert_eq!(instruction, expected);
 }
@@ -341,10 +345,10 @@ fn fold_on_canon_stream() {
 
     let instruction = parse(&source_code);
     let expected = fold_scalar_canon_stream(
-        CanonStream::new(canon_stream, 15),
-        Scalar::new(iterator, 29),
+        CanonStream::new(canon_stream, 15.into()),
+        Scalar::new(iterator, 29.into()),
         null(),
-        Span::new(9, 45),
+        Span::new(9.into(), 45.into()),
     );
     assert_eq!(instruction, expected);
 }
@@ -366,11 +370,11 @@ fn comments() {
                 },
                 ValueAccessor::ArrayAccess { idx: 1 },
             ],
-            33,
+            33.into(),
         ),
-        Scalar::new("m", 52),
+        Scalar::new("m", 52.into()),
         null(),
-        Span::new(27, 61),
+        Span::new(27.into(), 61.into()),
     );
     assert_eq!(instruction, expected);
 }
@@ -387,10 +391,10 @@ fn parse_fold_with_xor_par_seq() {
         let instruction = parse(&source_code);
         let instr = binary_instruction(*name);
         let expected = fold_scalar_variable(
-            ScalarWithLambda::new("iterable", None, 6),
-            Scalar::new("i", 15),
+            ScalarWithLambda::new("iterable", None, 6.into()),
+            Scalar::new("i", 15.into()),
             instr(null(), null()),
-            Span::new(0, 58),
+            Span::new(0.into(), 58.into()),
         );
         assert_eq!(instruction, expected);
     }

--- a/crates/air-lib/air-parser/src/parser/tests/match_.rs
+++ b/crates/air-lib/air-parser/src/parser/tests/match_.rs
@@ -31,8 +31,8 @@ fn parse_match() {
         "#;
     let instruction = parse(&source_code);
     let expected = match_(
-        Value::Variable(VariableWithLambda::scalar("v1", 16)),
-        Value::Variable(VariableWithLambda::scalar("v2", 19)),
+        Value::Variable(VariableWithLambda::scalar("v1", 16.into())),
+        Value::Variable(VariableWithLambda::scalar("v2", 19.into())),
         null(),
     );
     assert_eq!(instruction, expected);
@@ -53,9 +53,9 @@ fn parse_match_with_canon_stream() {
         Value::Variable(VariableWithLambda::canon_stream_wl(
             canon_stream,
             LambdaAST::try_from_accessors(vec![ValueAccessor::ArrayAccess { idx: 0 }]).unwrap(),
-            16,
+            16.into(),
         )),
-        Value::Variable(VariableWithLambda::scalar("v2", 36)),
+        Value::Variable(VariableWithLambda::scalar("v2", 36.into())),
         null(),
     );
     assert_eq!(instruction, expected);
@@ -70,7 +70,7 @@ fn parse_match_with_init_peer_id() {
         "#;
     let instruction = parse(&source_code);
     let expected = match_(
-        Value::Variable(VariableWithLambda::scalar("v1", 16)),
+        Value::Variable(VariableWithLambda::scalar("v1", 16.into())),
         Value::InitPeerId,
         null(),
     );
@@ -87,7 +87,7 @@ fn parse_match_with_timestamp() {
     let instruction = parse(source_code);
     let expected = match_(
         Value::Timestamp,
-        Value::Variable(VariableWithLambda::scalar("v1", 28)),
+        Value::Variable(VariableWithLambda::scalar("v1", 28.into())),
         null(),
     );
     assert_eq!(instruction, expected);
@@ -103,7 +103,7 @@ fn parse_match_with_ttl() {
     let instruction = parse(source_code);
     let expected = match_(
         Value::TTL,
-        Value::Variable(VariableWithLambda::scalar("v1", 22)),
+        Value::Variable(VariableWithLambda::scalar("v1", 22.into())),
         null(),
     );
     assert_eq!(instruction, expected);
@@ -118,8 +118,8 @@ fn parse_mismatch() {
         "#;
     let instruction = parse(&source_code);
     let expected = mismatch(
-        Value::Variable(VariableWithLambda::scalar("v1", 19)),
-        Value::Variable(VariableWithLambda::scalar("v2", 22)),
+        Value::Variable(VariableWithLambda::scalar("v1", 19.into())),
+        Value::Variable(VariableWithLambda::scalar("v2", 22.into())),
         null(),
     );
     assert_eq!(instruction, expected);
@@ -133,7 +133,7 @@ fn match_with_bool() {
          )
         "#;
 
-    let left_value = Value::Variable(VariableWithLambda::scalar("isOnline", 17));
+    let left_value = Value::Variable(VariableWithLambda::scalar("isOnline", 17.into()));
     let right_value = Value::Boolean(true);
     let null = null();
     let expected = match_(left_value, right_value, null);
@@ -151,7 +151,7 @@ fn mismatch_with_bool() {
         "#;
 
     let left_value = Value::Boolean(true);
-    let right_value = Value::Variable(VariableWithLambda::scalar("isOnline", 25));
+    let right_value = Value::Variable(VariableWithLambda::scalar("isOnline", 25.into()));
     let null = null();
     let expected = mismatch(left_value, right_value, null);
 
@@ -167,7 +167,7 @@ fn match_with_empty_array() {
          )
         "#;
 
-    let left_value = Value::Variable(VariableWithLambda::scalar("variable", 17));
+    let left_value = Value::Variable(VariableWithLambda::scalar("variable", 17.into()));
     let right_value = Value::EmptyArray;
     let instr = null();
     let expected = match_(left_value, right_value, instr);
@@ -182,7 +182,7 @@ fn match_with_empty_array() {
         "#;
 
     let left_value = Value::EmptyArray;
-    let right_value = Value::Variable(VariableWithLambda::scalar("variable", 20));
+    let right_value = Value::Variable(VariableWithLambda::scalar("variable", 20.into()));
     let instr = null();
     let expected = match_(left_value, right_value, instr);
 
@@ -198,7 +198,7 @@ fn mismatch_with_empty_array() {
          )
         "#;
 
-    let left_value = Value::Variable(VariableWithLambda::scalar("variable", 20));
+    let left_value = Value::Variable(VariableWithLambda::scalar("variable", 20.into()));
     let right_value = Value::EmptyArray;
     let instr = null();
     let expected = mismatch(left_value, right_value, instr);
@@ -213,7 +213,7 @@ fn mismatch_with_empty_array() {
         "#;
 
     let left_value = Value::EmptyArray;
-    let right_value = Value::Variable(VariableWithLambda::scalar("variable", 23));
+    let right_value = Value::Variable(VariableWithLambda::scalar("variable", 23.into()));
     let instr = null();
     let expected = mismatch(left_value, right_value, instr);
 

--- a/crates/air-lib/air-parser/src/parser/tests/new.rs
+++ b/crates/air-lib/air-parser/src/parser/tests/new.rs
@@ -30,9 +30,9 @@ fn parse_new_with_scalar() {
 
     let instruction = parse(source_code);
     let expected = new(
-        NewArgument::Scalar(Scalar::new("scalar", 5)),
+        NewArgument::Scalar(Scalar::new("scalar", 5.into())),
         null(),
-        Span::new(0, 40),
+        Span::new(0.into(), 40.into()),
     );
     assert_eq!(instruction, expected);
 }
@@ -46,9 +46,9 @@ fn parse_new_with_stream() {
 
     let instruction = parse(source_code);
     let expected = new(
-        NewArgument::Stream(Stream::new("$stream", 5)),
+        NewArgument::Stream(Stream::new("$stream", 5.into())),
         null(),
-        Span::new(0, 41),
+        Span::new(0.into(), 41.into()),
     );
     assert_eq!(instruction, expected);
 }
@@ -62,9 +62,9 @@ fn parse_new_with_canon_stream() {
 
     let instruction = parse(source_code);
     let expected = new(
-        NewArgument::CanonStream(CanonStream::new("#canon_stream", 5)),
+        NewArgument::CanonStream(CanonStream::new("#canon_stream", 5.into())),
         null(),
-        Span::new(0, 47),
+        Span::new(0.into(), 47.into()),
     );
     assert_eq!(instruction, expected);
 }

--- a/crates/air-lib/air-parser/src/parser/tests/seq.rs
+++ b/crates/air-lib/air-parser/src/parser/tests/seq.rs
@@ -32,11 +32,11 @@ fn parse_seq() {
     let instruction = parse(source_code);
     let expected = seq(
         call(
-            CallInstrValue::Variable(VariableWithLambda::scalar("peer_id", 32)),
-            CallInstrValue::Variable(VariableWithLambda::scalar("service_id", 41)),
-            CallInstrValue::Variable(VariableWithLambda::scalar("function_name", 52)),
+            CallInstrValue::Variable(VariableWithLambda::scalar("peer_id", 32.into())),
+            CallInstrValue::Variable(VariableWithLambda::scalar("service_id", 41.into())),
+            CallInstrValue::Variable(VariableWithLambda::scalar("function_name", 52.into())),
             Rc::new(vec![Value::EmptyArray, Value::EmptyArray]),
-            CallOutputValue::Scalar(Scalar::new("output", 75)),
+            CallOutputValue::Scalar(Scalar::new("output", 75.into())),
         ),
         call(
             CallInstrValue::Literal("peer_id"),
@@ -45,7 +45,7 @@ fn parse_seq() {
             Rc::new(vec![
                 Value::Literal("hello"),
                 Value::EmptyArray,
-                Value::Variable(VariableWithLambda::scalar("name", 154)),
+                Value::Variable(VariableWithLambda::scalar("name", 154.into())),
             ]),
             CallOutputValue::None,
         ),
@@ -68,16 +68,16 @@ fn parse_seq_seq() {
     let expected = seq(
         seq(
             call(
-                CallInstrValue::Variable(VariableWithLambda::scalar("peer_id", 53)),
-                CallInstrValue::Variable(VariableWithLambda::scalar("service_id", 62)),
-                CallInstrValue::Variable(VariableWithLambda::scalar("function_name", 73)),
+                CallInstrValue::Variable(VariableWithLambda::scalar("peer_id", 53.into())),
+                CallInstrValue::Variable(VariableWithLambda::scalar("service_id", 62.into())),
+                CallInstrValue::Variable(VariableWithLambda::scalar("function_name", 73.into())),
                 Rc::new(vec![]),
                 CallOutputValue::None,
             ),
             call(
-                CallInstrValue::Variable(VariableWithLambda::scalar("peer_id", 114)),
+                CallInstrValue::Variable(VariableWithLambda::scalar("peer_id", 114.into())),
                 CallInstrValue::Literal("service_B"),
-                CallInstrValue::Variable(VariableWithLambda::scalar("function_name", 135)),
+                CallInstrValue::Variable(VariableWithLambda::scalar("function_name", 135.into())),
                 Rc::new(vec![]),
                 CallOutputValue::None,
             ),
@@ -88,9 +88,9 @@ fn parse_seq_seq() {
             CallInstrValue::Literal("function_name"),
             Rc::new(vec![
                 Value::Literal("hello"),
-                Value::Variable(VariableWithLambda::scalar("name", 236)),
+                Value::Variable(VariableWithLambda::scalar("name", 236.into())),
             ]),
-            CallOutputValue::Stream(Stream::new("$output", 242)),
+            CallOutputValue::Stream(Stream::new("$output", 242.into())),
         ),
     );
     assert_eq!(instruction, expected);

--- a/crates/air-lib/air-parser/src/parser/validator.rs
+++ b/crates/air-lib/air-parser/src/parser/validator.rs
@@ -16,6 +16,7 @@
 
 use crate::ast::*;
 
+use super::lexer::TextPos;
 use crate::parser::lexer::Token;
 use crate::parser::ParserError;
 use crate::parser::Span;
@@ -152,7 +153,7 @@ impl<'i> VariableValidator<'i> {
         self.met_variable_name_definition(ap.result.name(), span);
     }
 
-    pub(super) fn finalize(self) -> Vec<ErrorRecovery<usize, Token<'i>, ParserError>> {
+    pub(super) fn finalize(self) -> Vec<ErrorRecovery<TextPos, Token<'i>, ParserError>> {
         ValidatorErrorBuilder::new(self)
             .check_undefined_variables()
             .check_undefined_iterables()
@@ -274,7 +275,7 @@ impl<'i> VariableValidator<'i> {
 }
 
 struct ValidatorErrorBuilder<'i> {
-    errors: Vec<ErrorRecovery<usize, Token<'i>, ParserError>>,
+    errors: Vec<ErrorRecovery<TextPos, Token<'i>, ParserError>>,
     validator: VariableValidator<'i>,
 }
 
@@ -384,7 +385,7 @@ impl<'i> ValidatorErrorBuilder<'i> {
         self
     }
 
-    fn build(self) -> Vec<ErrorRecovery<usize, Token<'i>, ParserError>> {
+    fn build(self) -> Vec<ErrorRecovery<TextPos, Token<'i>, ParserError>> {
         self.errors
     }
 
@@ -406,7 +407,7 @@ impl<'i> ValidatorErrorBuilder<'i> {
 }
 
 fn add_to_errors<'i>(
-    errors: &mut Vec<ErrorRecovery<usize, Token<'i>, ParserError>>,
+    errors: &mut Vec<ErrorRecovery<TextPos, Token<'i>, ParserError>>,
     span: Span,
     token: Token<'i>,
     error: ParserError,

--- a/crates/air-lib/air-parser/src/parser/validator.rs
+++ b/crates/air-lib/air-parser/src/parser/validator.rs
@@ -16,7 +16,7 @@
 
 use crate::ast::*;
 
-use super::lexer::TextPos;
+use super::lexer::AirPos;
 use crate::parser::lexer::Token;
 use crate::parser::ParserError;
 use crate::parser::Span;
@@ -153,7 +153,7 @@ impl<'i> VariableValidator<'i> {
         self.met_variable_name_definition(ap.result.name(), span);
     }
 
-    pub(super) fn finalize(self) -> Vec<ErrorRecovery<TextPos, Token<'i>, ParserError>> {
+    pub(super) fn finalize(self) -> Vec<ErrorRecovery<AirPos, Token<'i>, ParserError>> {
         ValidatorErrorBuilder::new(self)
             .check_undefined_variables()
             .check_undefined_iterables()
@@ -275,7 +275,7 @@ impl<'i> VariableValidator<'i> {
 }
 
 struct ValidatorErrorBuilder<'i> {
-    errors: Vec<ErrorRecovery<TextPos, Token<'i>, ParserError>>,
+    errors: Vec<ErrorRecovery<AirPos, Token<'i>, ParserError>>,
     validator: VariableValidator<'i>,
 }
 
@@ -385,7 +385,7 @@ impl<'i> ValidatorErrorBuilder<'i> {
         self
     }
 
-    fn build(self) -> Vec<ErrorRecovery<TextPos, Token<'i>, ParserError>> {
+    fn build(self) -> Vec<ErrorRecovery<AirPos, Token<'i>, ParserError>> {
         self.errors
     }
 
@@ -407,7 +407,7 @@ impl<'i> ValidatorErrorBuilder<'i> {
 }
 
 fn add_to_errors<'i>(
-    errors: &mut Vec<ErrorRecovery<TextPos, Token<'i>, ParserError>>,
+    errors: &mut Vec<ErrorRecovery<AirPos, Token<'i>, ParserError>>,
     span: Span,
     token: Token<'i>,
     error: ParserError,

--- a/crates/air-lib/execution-info-collector/Cargo.toml
+++ b/crates/air-lib/execution-info-collector/Cargo.toml
@@ -12,3 +12,6 @@ categories = ["wasm"]
 [lib]
 name = "air_execution_info_collector"
 path = "src/lib.rs"
+
+[dependencies]
+air-parser = { path = "../air-parser" }

--- a/crates/air-lib/execution-info-collector/src/instructions_tracker.rs
+++ b/crates/air-lib/execution-info-collector/src/instructions_tracker.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use air_parser::TextPos;
+use air_parser::AirPos;
 
 use std::collections::HashMap;
 
@@ -65,7 +65,7 @@ pub struct NewTracker {
     /// Mapping from a new instruction position in a script
     /// to a number of their execution. This is needed to
     /// support private stream generation mappings.
-    pub executed_count: HashMap<TextPos, u32>,
+    pub executed_count: HashMap<AirPos, u32>,
 }
 
 impl InstructionTracker {
@@ -125,7 +125,7 @@ impl InstructionTracker {
         self.xor_count += 1;
     }
 
-    pub fn meet_new(&mut self, position: TextPos) {
+    pub fn meet_new(&mut self, position: AirPos) {
         use std::collections::hash_map::Entry::{Occupied, Vacant};
 
         match self.new_tracker.executed_count.entry(position) {
@@ -138,7 +138,7 @@ impl InstructionTracker {
 }
 
 impl NewTracker {
-    pub fn get_iteration(&self, position: TextPos) -> u32 {
+    pub fn get_iteration(&self, position: AirPos) -> u32 {
         self.executed_count
             .get(&position)
             .copied()

--- a/crates/air-lib/execution-info-collector/src/instructions_tracker.rs
+++ b/crates/air-lib/execution-info-collector/src/instructions_tracker.rs
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+use air_parser::TextPos;
+
 use std::collections::HashMap;
 
 /// Intended to track a number of executed instruction of each type. For instructions that
@@ -63,7 +65,7 @@ pub struct NewTracker {
     /// Mapping from a new instruction position in a script
     /// to a number of their execution. This is needed to
     /// support private stream generation mappings.
-    pub executed_count: HashMap<usize, u32>,
+    pub executed_count: HashMap<TextPos, u32>,
 }
 
 impl InstructionTracker {
@@ -123,7 +125,7 @@ impl InstructionTracker {
         self.xor_count += 1;
     }
 
-    pub fn meet_new(&mut self, position: usize) {
+    pub fn meet_new(&mut self, position: TextPos) {
         use std::collections::hash_map::Entry::{Occupied, Vacant};
 
         match self.new_tracker.executed_count.entry(position) {
@@ -136,7 +138,7 @@ impl InstructionTracker {
 }
 
 impl NewTracker {
-    pub fn get_iteration(&self, position: usize) -> u32 {
+    pub fn get_iteration(&self, position: TextPos) -> u32 {
         self.executed_count
             .get(&position)
             .copied()

--- a/crates/air-lib/interpreter-data/Cargo.toml
+++ b/crates/air-lib/interpreter-data/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/lib.rs"
 
 [dependencies]
 air-utils = { path = "../utils" }
+air-parser = { path = "../air-parser" }
 
 serde = {version = "1.0.144", features = ["derive", "rc"]}
 serde_json = "1.0.85"

--- a/crates/air-lib/interpreter-data/src/stream_generations.rs
+++ b/crates/air-lib/interpreter-data/src/stream_generations.rs
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+use air_parser::TextPos;
+
 use std::collections::HashMap;
 
 /// Mapping from a stream name to it's generation count.
@@ -28,4 +30,4 @@ pub type GlobalStreamGens = HashMap<String, u32>;
 /// so it could be met several times during script execution. This field anchors iteration
 /// where it was met.
 /// Similar to pi-calculus restricted names/channels.
-pub type RestrictedStreamGens = HashMap<String, HashMap<u32, Vec<u32>>>;
+pub type RestrictedStreamGens = HashMap<String, HashMap<TextPos, Vec<u32>>>;

--- a/crates/air-lib/interpreter-data/src/stream_generations.rs
+++ b/crates/air-lib/interpreter-data/src/stream_generations.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use air_parser::TextPos;
+use air_parser::AirPos;
 
 use std::collections::HashMap;
 
@@ -30,4 +30,4 @@ pub type GlobalStreamGens = HashMap<String, u32>;
 /// so it could be met several times during script execution. This field anchors iteration
 /// where it was met.
 /// Similar to pi-calculus restricted names/channels.
-pub type RestrictedStreamGens = HashMap<String, HashMap<TextPos, Vec<u32>>>;
+pub type RestrictedStreamGens = HashMap<String, HashMap<AirPos, Vec<u32>>>;


### PR DESCRIPTION
Use a dedicated wrapper type for better type safety and self-documented code.
