### PR TITLE
fix(trace-handler): treat `ap` states with different generations as compatible for `canon`

### DIFF
--- a/air/tests/test_module/issues/issue_348.rs
+++ b/air/tests/test_module/issues/issue_348.rs
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 Fluence Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use air_test_utils::prelude::*;
+
+#[test]
+// test for github.com/fluencelabs/aquavm/issues/348
+fn issue_348() {
+    let vm_peer_id_1 = "vm_peer_id_1";
+    let mut peer_vm_1 = create_avm(echo_call_service(), vm_peer_id_1);
+    let vm_peer_id_2 = "vm_peer_id_2";
+    let mut peer_vm_2 = create_avm(echo_call_service(), vm_peer_id_2);
+    let vm_peer_id_3 = "vm_peer_id_3";
+    let mut peer_vm_3 = create_avm(echo_call_service(), vm_peer_id_3);
+
+    let script = f!(r#"
+        (seq
+            (seq
+                (ap 1 $inner)
+                (seq
+                    (call "{vm_peer_id_2}" ("op" "noop") [1])
+                    (ap 2 $inner)
+                )
+            )
+            (seq
+                (canon "{vm_peer_id_2}" $inner #inner)
+                (seq
+                    (call "{vm_peer_id_3}" ("op" "noop") [1])
+                    (call "{vm_peer_id_2}" ("op" "noop") [1])
+                )
+            )
+        )
+    "#);
+
+    let result11 = checked_call_vm!(peer_vm_1, <_>::default(), &script, "", "");
+    let result21 = checked_call_vm!(peer_vm_2, <_>::default(), &script, "", result11.data.clone());
+    let result31 = checked_call_vm!(peer_vm_3, <_>::default(), &script, "", result21.data.clone());
+    let _result22 = checked_call_vm!(
+        peer_vm_2,
+        <_>::default(),
+        &script,
+        result21.data.clone(),
+        result31.data.clone()
+    );
+}

--- a/air/tests/test_module/issues/mod.rs
+++ b/air/tests/test_module/issues/mod.rs
@@ -33,3 +33,4 @@ mod issue_304;
 mod issue_306;
 mod issue_331;
 mod issue_346;
+mod issue_348;

--- a/crates/air-lib/trace-handler/src/merger/canon_merger.rs
+++ b/crates/air-lib/trace-handler/src/merger/canon_merger.rs
@@ -114,9 +114,7 @@ fn check_canon_results(
             {
                 continue;
             }
-            (Some(ExecutedState::Ap(prev_ap_result)), Some(ExecutedState::Ap(current_ap_result)))
-                if prev_ap_result == current_ap_result =>
-            {
+            (Some(ExecutedState::Ap(_)), Some(ExecutedState::Ap(_))) => {
                 continue;
             }
             _ => {


### PR DESCRIPTION
Fixes #348 