### PR TITLE
feat(testing-framework): prevalidate AIR script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,6 +184,7 @@ dependencies = [
 name = "air-testing-framework"
 version = "0.1.0"
 dependencies = [
+ "air-parser",
  "air-test-utils",
  "itertools",
  "maplit",

--- a/crates/testing-framework/Cargo.toml
+++ b/crates/testing-framework/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/lib.rs"
 
 [dependencies]
 air-test-utils = { path = "../air-lib/test-utils" }
+air-parser = { path = "../air-lib/air-parser" }
 
 itertools = "0.10.4"
 strum = { version="0.24.1", features=["derive"] }

--- a/crates/testing-framework/src/execution/mod.rs
+++ b/crates/testing-framework/src/execution/mod.rs
@@ -510,7 +510,7 @@ mod tests {
 
     #[test]
     fn test_invalid_air() {
-        let err = TestExecutor::new(
+        let res = TestExecutor::new(
             TestRunParameters::from_init_peer_id("init_peer_id"),
             vec![],
             std::iter::empty(),
@@ -520,10 +520,13 @@ mod tests {
 "#,
         );
 
-        assert!(err.is_err());
+        assert!(res.is_err());
         // TestExecutor doesn't implement Debug, so we have to unpack the error this way:
-        if let Err(e) = err {
-            assert_eq!(e, "error: \n  ┌─ script.air:3:1\n  │\n3 │ )\n  │ ^ expected \"(\"\n\n");
+        if let Err(err) = res {
+            assert_eq!(
+                err,
+                "error: \n  ┌─ script.air:3:1\n  │\n3 │ )\n  │ ^ expected \"(\"\n\n"
+            );
         }
     }
 }

--- a/crates/testing-framework/src/execution/mod.rs
+++ b/crates/testing-framework/src/execution/mod.rs
@@ -42,6 +42,9 @@ impl TestExecutor {
         extra_peers: impl IntoIterator<Item = PeerId>,
         annotated_air_script: &str,
     ) -> Result<Self, String> {
+        // validate the AIR script with the standard parser first
+        air_parser::parse(annotated_air_script)?;
+
         let mut sexp = Sexp::from_str(annotated_air_script)?;
         let mut walker = Transformer::new();
         walker.transform(&mut sexp);
@@ -503,5 +506,24 @@ mod tests {
             trace_from_result(outcome1),
             ExecutionTrace::from(vec![scalar_number(1), request_sent_by("peer1"),]),
         )
+    }
+
+    #[test]
+    fn test_invalid_air() {
+        let err = TestExecutor::new(
+            TestRunParameters::from_init_peer_id("init_peer_id"),
+            vec![],
+            std::iter::empty(),
+            r#"(seq
+(call "peer1" ("service" "func") [1 22] arg) ; behaviour=echo
+)
+"#,
+        );
+
+        assert!(err.is_err());
+        // TestExecutor doesn't implement Debug, so we have to unpack the error this way:
+        if let Err(e) = err {
+            assert_eq!(e, "error: \n  ┌─ script.air:3:1\n  │\n3 │ )\n  │ ^ expected \"(\"\n\n");
+        }
     }
 }


### PR DESCRIPTION
Try to parse the annotated AIR script with the standard parser to catch to catch errors early with better error messages.

We do it in the `TestExecutor` only to make testing framwork parser tests simplier.  For user experience, it doesn't matter.