### PR TITLE
Revert chore: Fix `needless-borrow` warning(#379)

### DIFF
--- a/air/src/execution_step/boxed_value/utils.rs
+++ b/air/src/execution_step/boxed_value/utils.rs
@@ -26,6 +26,6 @@ pub(crate) fn populate_tetraplet_with_lambda(
             tetraplet.add_lambda(&lambda.to_string());
             tetraplet
         }
-        LambdaAST::Functor(_) => SecurityTetraplet::new("", "", "", lambda.to_string()),
+        LambdaAST::Functor(_) => SecurityTetraplet::new("", "", "", &lambda.to_string()),
     }
 }


### PR DESCRIPTION
This reverts commit 98963065738bec728a829116172a94c2656e4442.

This is not a real PR, but just to test the e2e tests.