### PR TITLE
ci: Renovate tuning

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,27 +3,5 @@
   "extends": [
     "config:base"
   ],
-  "enabledManagers": ["cargo", "npm"],
-  "packageRules": [
-    {
-      "matchLanguages": ["rust"],
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "groupName": "all non-major Rust dependencies"
-    },
-    {
-      "matchLanguages": ["js"],
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "groupName": "all non-major JS dependencies"
-    },
-    {
-      "matchPackagePatterns": ["^@wasmer", "^wasmer", "^wasm-bindgen"],
-      "enabled": false
-    }
-  ]
+  "enabledManagers": ["cargo", "npm", "github-actions"]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,7 +18,8 @@
       "matchManagers": [
         "github-actions"
       ],
-      "automerge": true
+      "automerge": true,
+      "automergeType": "branch"
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,6 +20,10 @@
       ],
       "automerge": true,
       "automergeType": "branch"
+    },
+    {
+      "matchPackagePatterns": ["^@wasmer", "^wasmer", "^wasm-bindgen"],
+      "enabled": false
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,7 +4,7 @@
     "config:base"
   ],
   "enabledManagers": ["cargo", "npm", "github-actions"],
-  "prConcurrentLimit": 5,
+  "schedule": "every weekend",
   "packageRules": [
     {
       "matchDepTypes": ["devDependencies"],
@@ -15,11 +15,10 @@
       "prConcurrentLimit": 1
     },
     {
-      "matchManagers": [
-        "github-actions"
-      ],
+      "matchManagers": [ "github-actions" ],
       "automerge": true,
-      "automergeType": "branch"
+      "automergeType": "branch",
+      "prPriority": 1
     },
     {
       "matchPackagePatterns": ["^@wasmer", "^wasmer", "^wasm-bindgen"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,5 +3,22 @@
   "extends": [
     "config:base"
   ],
-  "enabledManagers": ["cargo", "npm", "github-actions"]
+  "enabledManagers": ["cargo", "npm", "github-actions"],
+  "prConcurrentLimit": 5,
+  "packageRules": [
+    {
+      "matchDepTypes": ["devDependencies"],
+      "prPriority": -1
+    },
+    {
+      "matchUpdateTypes": ["major"],
+      "prConcurrentLimit": 1
+    },
+    {
+      "matchManagers": [
+        "github-actions"
+      ],
+      "automerge": true
+    }
+  ]
 }


### PR DESCRIPTION
- do not group versions update in one PR (unless grouped by default i.e. `jest`)
- max 10 open PR
- max 1 open major bump PR
- dev dependencies have lowest priority
- runs only on weekends