### PR TITLE
feat(testing-framework): tetraplet behavior

### DIFF
--- a/crates/testing-framework/src/asserts/mod.rs
+++ b/crates/testing-framework/src/asserts/mod.rs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+mod behavior;
 mod json;
 pub(crate) mod parser;
 

--- a/crates/testing-framework/src/asserts/mod.rs
+++ b/crates/testing-framework/src/asserts/mod.rs
@@ -20,14 +20,13 @@ pub(crate) mod parser;
 
 use crate::services::JValue;
 
-use air_test_utils::{
-    prelude::{echo_call_service, unit_call_service},
-    CallRequestParams, CallServiceResult,
-};
+use air_test_utils::{CallRequestParams, CallServiceResult};
 use serde_json::json;
 use strum::{AsRefStr, EnumDiscriminants, EnumString};
 
 use std::{borrow::Cow, cell::Cell, collections::HashMap};
+
+use self::behavior::Behavior;
 
 /// Service definition in the testing framework comment DSL.
 #[derive(Debug, PartialEq, Eq, Clone, EnumDiscriminants)]
@@ -54,7 +53,7 @@ pub enum ServiceDefinition {
     },
     /// Some known service by name: "echo", "unit" (more to follow).
     #[strum_discriminants(strum(serialize = "behaviour"))]
-    Behaviour(String),
+    Behaviour(Behavior),
     /// Maps first argument to a value
     #[strum_discriminants(strum(serialize = "map"))]
     Map(HashMap<String, JValue>),
@@ -83,8 +82,8 @@ impl ServiceDefinition {
         }
     }
 
-    pub fn behaviour(name: impl Into<String>) -> Self {
-        Self::Behaviour(name.into())
+    pub fn behaviour(name: Behavior) -> Self {
+        Self::Behaviour(name)
     }
 
     pub fn map(map: HashMap<String, JValue>) -> Self {
@@ -103,7 +102,7 @@ impl ServiceDefinition {
                 ref call_number_seq,
                 call_map,
             } => call_seq_error(call_number_seq, call_map),
-            ServiceDefinition::Behaviour(name) => call_named_service(name, params),
+            ServiceDefinition::Behaviour(name) => name.call(params),
             ServiceDefinition::Map(map) => call_map_service(map, params),
         }
     }
@@ -148,14 +147,6 @@ fn call_seq_error(
             )
         })
         .clone()
-}
-
-fn call_named_service(name: &str, params: CallRequestParams) -> CallServiceResult {
-    match name {
-        "echo" => echo_call_service()(params),
-        "unit" => unit_call_service()(params),
-        _ => unreachable!("shoudn't be allowed by a parser"),
-    }
 }
 
 fn call_map_service(

--- a/crates/testing-framework/src/asserts/parser.rs
+++ b/crates/testing-framework/src/asserts/parser.rs
@@ -23,7 +23,7 @@ use nom::{error::VerboseError, IResult};
 
 use std::{collections::HashMap, str::FromStr};
 
-type ParseError<'inp> = VerboseError<&'inp str>;
+pub(crate) type ParseError<'inp> = VerboseError<&'inp str>;
 
 impl FromStr for ServiceDefinition {
     type Err = String;

--- a/crates/testing-framework/src/asserts/parser.rs
+++ b/crates/testing-framework/src/asserts/parser.rs
@@ -15,7 +15,6 @@
  */
 
 use super::{ServiceDefinition, ServiceTagName};
-use crate::services::JValue;
 use crate::transform::parser::delim_ws;
 
 use air_test_utils::CallServiceResult;
@@ -38,12 +37,12 @@ impl FromStr for ServiceDefinition {
 // kw "=" val
 // example: "id=firstcall"
 pub fn parse_kw(inp: &str) -> IResult<&str, ServiceDefinition, ParseError> {
+    use super::behavior::parse_behaviour;
     use nom::branch::alt;
     use nom::bytes::complete::tag;
-    use nom::character::complete::alphanumeric1;
-    use nom::combinator::{cut, map_res, recognize};
+    use nom::combinator::{cut, map, map_res, recognize};
     use nom::error::context;
-    use nom::sequence::separated_pair;
+    use nom::sequence::{pair, preceded};
 
     let equal = || delim_ws(tag("="));
     let json_value = || {
@@ -59,45 +58,56 @@ pub fn parse_kw(inp: &str) -> IResult<&str, ServiceDefinition, ParseError> {
         ))
     };
 
-    delim_ws(map_res(
-        alt((
-            separated_pair(tag(ServiceTagName::Ok.as_ref()), equal(), json_value()),
-            separated_pair(tag(ServiceTagName::Error.as_ref()), equal(), json_map()),
-            separated_pair(tag(ServiceTagName::SeqOk.as_ref()), equal(), json_map()),
-            separated_pair(tag(ServiceTagName::SeqError.as_ref()), equal(), json_map()),
-            separated_pair(
-                tag(ServiceTagName::Behaviour.as_ref()),
-                equal(),
-                cut(alphanumeric1),
+    delim_ws(alt((
+        map_res(
+            preceded(
+                pair(tag(ServiceTagName::Ok.as_ref()), equal()),
+                json_value(),
             ),
-            separated_pair(tag(ServiceTagName::Map.as_ref()), equal(), json_map()),
-        )),
-        |(tag, value): (&str, &str)| {
-            let value = value.trim();
-            match ServiceTagName::from_str(tag) {
-                Ok(ServiceTagName::Ok) => {
-                    serde_json::from_str::<JValue>(value).map(ServiceDefinition::ok)
-                }
-                Ok(ServiceTagName::Error) => {
-                    serde_json::from_str::<CallServiceResult>(value).map(ServiceDefinition::error)
-                }
-                Ok(ServiceTagName::SeqOk) => {
-                    serde_json::from_str(value).map(ServiceDefinition::seq_ok)
-                }
-                Ok(ServiceTagName::SeqError) => {
-                    serde_json::from_str::<HashMap<String, CallServiceResult>>(value)
-                        .map(ServiceDefinition::seq_error)
-                }
-                Ok(ServiceTagName::Behaviour) => Ok(ServiceDefinition::behaviour(value)),
-                Ok(ServiceTagName::Map) => serde_json::from_str(value).map(ServiceDefinition::map),
-                Err(_) => unreachable!("unknown tag {:?}", tag),
-            }
-        },
-    ))(inp)
+            |value| serde_json::from_str(value).map(ServiceDefinition::Ok),
+        ),
+        map_res(
+            preceded(
+                pair(tag(ServiceTagName::Error.as_ref()), equal()),
+                json_map(),
+            ),
+            |value| serde_json::from_str::<CallServiceResult>(value).map(ServiceDefinition::Error),
+        ),
+        map_res(
+            preceded(
+                pair(tag(ServiceTagName::SeqOk.as_ref()), equal()),
+                json_map(),
+            ),
+            |value| serde_json::from_str(value).map(ServiceDefinition::seq_ok),
+        ),
+        map_res(
+            preceded(
+                pair(tag(ServiceTagName::SeqError.as_ref()), equal()),
+                json_map(),
+            ),
+            |value| {
+                serde_json::from_str::<HashMap<String, CallServiceResult>>(value)
+                    .map(ServiceDefinition::seq_error)
+            },
+        ),
+        map(
+            preceded(
+                pair(tag(ServiceTagName::Behaviour.as_ref()), equal()),
+                cut(parse_behaviour),
+            ),
+            ServiceDefinition::Behaviour,
+        ),
+        map_res(
+            preceded(pair(tag(ServiceTagName::Map.as_ref()), equal()), json_map()),
+            |value| serde_json::from_str(value).map(ServiceDefinition::Map),
+        ),
+    )))(inp)
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::asserts::behavior::Behavior;
+
     use super::*;
     use pretty_assertions::assert_eq;
     use serde_json::json;
@@ -217,7 +227,7 @@ mod tests {
     #[test]
     fn test_behaviour() {
         let res = ServiceDefinition::from_str(r#"behaviour=echo"#);
-        assert_eq!(res, Ok(ServiceDefinition::Behaviour("echo".to_owned())),);
+        assert_eq!(res, Ok(ServiceDefinition::Behaviour(Behavior::Echo)),);
     }
 
     #[test]

--- a/crates/testing-framework/src/execution/mod.rs
+++ b/crates/testing-framework/src/execution/mod.rs
@@ -542,10 +542,7 @@ mod tests {
         impl MarineService for Service {
             fn call(&self, _params: CallRequestParams) -> crate::services::FunctionOutcome {
                 let mut cell = self.state.borrow_mut();
-                crate::services::FunctionOutcome::ServiceResult(
-                    CallServiceResult::ok(cell.next().unwrap()),
-                    <_>::default(),
-                )
+                crate::services::FunctionOutcome::from_value(cell.next().unwrap())
             }
         }
         let service = Service {

--- a/crates/testing-framework/src/execution/mod.rs
+++ b/crates/testing-framework/src/execution/mod.rs
@@ -606,4 +606,28 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn test_behaviour_service() {
+        let peer = "peer1";
+        let exec = AirScriptExecutor::new(
+            TestRunParameters::from_init_peer_id(peer),
+            vec![],
+            std::iter::empty(),
+            r#"(call "peer1" ("service" "func") [1 22] arg) ; behaviour=service"#,
+        )
+        .unwrap();
+
+        let result_init: Vec<_> = exec.execution_iter(peer).unwrap().collect();
+
+        assert_eq!(result_init.len(), 1);
+        let outcome = &result_init[0];
+        assert_eq!(outcome.ret_code, 0);
+        assert_eq!(outcome.error_message, "");
+
+        assert_eq!(
+            trace_from_result(outcome),
+            ExecutionTrace::from(vec![scalar_string("service"),]),
+        )
+    }
 }

--- a/crates/testing-framework/src/execution/mod.rs
+++ b/crates/testing-framework/src/execution/mod.rs
@@ -630,4 +630,86 @@ mod tests {
             ExecutionTrace::from(vec![scalar_string("service"),]),
         )
     }
+
+    #[test]
+    fn test_behaviour_function() {
+        let peer = "peer1";
+        let exec = AirScriptExecutor::new(
+            TestRunParameters::from_init_peer_id(peer),
+            vec![],
+            std::iter::empty(),
+            r#"(call "peer1" ("service" "func") [1 22] arg) ; behaviour=function"#,
+        )
+        .unwrap();
+
+        let result_init: Vec<_> = exec.execution_iter(peer).unwrap().collect();
+
+        assert_eq!(result_init.len(), 1);
+        let outcome = &result_init[0];
+        assert_eq!(outcome.ret_code, 0);
+        assert_eq!(outcome.error_message, "");
+
+        assert_eq!(
+            trace_from_result(outcome),
+            ExecutionTrace::from(vec![scalar_string("func"),]),
+        )
+    }
+
+    #[test]
+    fn test_behaviour_arg() {
+        let peer = "peer1";
+        let exec = AirScriptExecutor::new(
+            TestRunParameters::from_init_peer_id(peer),
+            vec![],
+            std::iter::empty(),
+            r#"(call "peer1" ("service" "func") [1 22] arg) ; behaviour=arg.1"#,
+        )
+        .unwrap();
+
+        let result_init: Vec<_> = exec.execution_iter(peer).unwrap().collect();
+
+        assert_eq!(result_init.len(), 1);
+        let outcome = &result_init[0];
+        assert_eq!(outcome.ret_code, 0);
+        assert_eq!(outcome.error_message, "");
+
+        assert_eq!(
+            trace_from_result(outcome),
+            ExecutionTrace::from(vec![scalar_number(22),]),
+        )
+    }
+
+    #[test]
+    fn test_behaviour_tetraplet() {
+        let peer = "peer1";
+        let exec = AirScriptExecutor::new(
+            TestRunParameters::from_init_peer_id(peer),
+            vec![],
+            std::iter::empty(),
+            r#"(call "peer1" ("service" "func") [1 22] arg) ; behaviour=tetraplet"#,
+        )
+        .unwrap();
+
+        let result_init: Vec<_> = exec.execution_iter(peer).unwrap().collect();
+
+        assert_eq!(result_init.len(), 1);
+        let outcome = &result_init[0];
+        assert_eq!(outcome.ret_code, 0);
+        assert_eq!(outcome.error_message, "");
+
+        assert_eq!(
+            trace_from_result(outcome),
+            ExecutionTrace::from(vec![scalar(json!([[{
+                "function_name": "",
+                "json_path": "",
+                "peer_pk": "peer1",
+                "service_id": "",
+            }], [{
+                "function_name": "",
+                "json_path": "",
+                "peer_pk": "peer1",
+                "service_id": "",
+            }]]))]),
+        )
+    }
 }

--- a/crates/testing-framework/src/services/mod.rs
+++ b/crates/testing-framework/src/services/mod.rs
@@ -33,6 +33,16 @@ pub enum FunctionOutcome {
     Empty,
 }
 
+impl FunctionOutcome {
+    pub fn from_service_result(service_result: CallServiceResult) -> Self {
+        FunctionOutcome::ServiceResult(service_result, Duration::ZERO)
+    }
+
+    pub fn from_value(value: JValue) -> Self {
+        Self::from_service_result(CallServiceResult::ok(value))
+    }
+}
+
 /// A mocked Marine service.
 pub trait MarineService {
     fn call(&self, params: CallRequestParams) -> FunctionOutcome;

--- a/crates/testing-framework/src/services/results.rs
+++ b/crates/testing-framework/src/services/results.rs
@@ -19,7 +19,7 @@ use crate::asserts::ServiceDefinition;
 
 use air_test_utils::CallRequestParams;
 
-use std::{cell::RefCell, collections::HashMap, rc::Rc, time::Duration};
+use std::{cell::RefCell, collections::HashMap, rc::Rc};
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub(crate) struct ResultStore {
@@ -45,7 +45,7 @@ impl MarineService for ResultStore {
                 });
                 // hide the artificial service_id
                 params.service_id = real_service_id.to_owned();
-                FunctionOutcome::ServiceResult(service_desc.call(params), Duration::ZERO)
+                FunctionOutcome::from_service_result(service_desc.call(params))
             } else {
                 // Pass malformed service names further in a chain
                 FunctionOutcome::NotDefined


### PR DESCRIPTION
Add `behavior=tetraplet` for testing framework annotation to return call's tetraplet.