### PR TITLE
Make unstable clippy happy with `clippy --fix`

### DIFF
--- a/air/benches/call_benchmark.rs
+++ b/air/benches/call_benchmark.rs
@@ -20,7 +20,7 @@ fn current_peer_id_call() -> Result<RawAVMOutcome, String> {
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
-    c.bench_function("current_peer_id_call", move |b| b.iter(move || current_peer_id_call()));
+    c.bench_function("current_peer_id_call", move |b| b.iter(current_peer_id_call));
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/air/benches/chat_benchmark.rs
+++ b/air/benches/chat_benchmark.rs
@@ -65,9 +65,7 @@ fn chat_sent_message_benchmark() -> Result<RawAVMOutcome, String> {
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
-    c.bench_function("chat_send_message", move |b| {
-        b.iter(move || chat_sent_message_benchmark())
-    });
+    c.bench_function("chat_send_message", move |b| b.iter(chat_sent_message_benchmark));
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/air/benches/create_service_benchmark.rs
+++ b/air/benches/create_service_benchmark.rs
@@ -85,7 +85,7 @@ fn create_service_benchmark() -> Result<RawAVMOutcome, String> {
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
-    c.bench_function("create_service", move |b| b.iter(move || create_service_benchmark()));
+    c.bench_function("create_service", move |b| b.iter(create_service_benchmark));
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/air/src/execution_step/boxed_value/canon_stream.rs
+++ b/air/src/execution_step/boxed_value/canon_stream.rs
@@ -80,7 +80,7 @@ impl fmt::Display for CanonStream {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "[")?;
         for value in self.values.iter() {
-            write!(f, "{}, ", value)?;
+            write!(f, "{value}, ")?;
         }
         write!(f, "]")
     }

--- a/air/src/execution_step/boxed_value/scalar.rs
+++ b/air/src/execution_step/boxed_value/scalar.rs
@@ -75,7 +75,7 @@ impl fmt::Display for ValueAggregate {
 impl<'i> fmt::Display for ScalarRef<'i> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ScalarRef::Value(value) => write!(f, "{:?}", value)?,
+            ScalarRef::Value(value) => write!(f, "{value:?}")?,
             ScalarRef::IterableValue(cursor) => {
                 let iterable = &cursor.iterable;
                 write!(f, "cursor, current value: {:?}", iterable.peek())?;

--- a/air/src/execution_step/boxed_value/stream.rs
+++ b/air/src/execution_step/boxed_value/stream.rs
@@ -316,9 +316,9 @@ impl fmt::Display for Stream {
 
         writeln!(f, "[")?;
         for (id, generation) in self.values.iter().enumerate() {
-            write!(f, " -- {}: ", id)?;
+            write!(f, " -- {id}: ")?;
             for value in generation.iter() {
-                write!(f, "{:?}, ", value)?;
+                write!(f, "{value:?}, ")?;
             }
             writeln!(f)?;
         }

--- a/air/src/execution_step/execution_context/scalar_variables.rs
+++ b/air/src/execution_step/execution_context/scalar_variables.rs
@@ -226,7 +226,7 @@ impl<'i> fmt::Display for Scalars<'i> {
 
         for (name, _) in self.iterable_variables.iter() {
             // it's impossible to print an iterable value for now
-            writeln!(f, "{} => iterable", name)?;
+            writeln!(f, "{name} => iterable")?;
         }
 
         Ok(())

--- a/air/src/execution_step/execution_context/scalar_variables/values_sparse_matrix.rs
+++ b/air/src/execution_step/execution_context/scalar_variables/values_sparse_matrix.rs
@@ -252,7 +252,7 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.value {
-            Some(value) => write!(f, "{}", value),
+            Some(value) => write!(f, "{value}"),
             None => write!(f, "none"),
         }
     }
@@ -266,10 +266,10 @@ where
         writeln!(f, "current_depth: {}", self.current_depth)?;
 
         for (name, values) in self.cells.iter() {
-            write!(f, "{}: ", name)?;
+            write!(f, "{name}: ")?;
 
             for value in values.iter() {
-                write!(f, "{} ", value)?;
+                write!(f, "{value} ")?;
             }
             writeln!(f)?;
         }
@@ -305,7 +305,7 @@ mod test {
         scalars.meet_fold_start();
         scalars.set_value(value_2_name, value_aggregate.clone()).unwrap();
         scalars.meet_fold_start();
-        scalars.set_value(value_2_name, value_aggregate.clone()).unwrap();
+        scalars.set_value(value_2_name, value_aggregate).unwrap();
 
         let expected_values_count = scalars.cells.get(value_2_name).unwrap().len();
         assert_eq!(expected_values_count, NonZeroUsize::new(2).unwrap());

--- a/air/src/execution_step/execution_context/streams_variables.rs
+++ b/air/src/execution_step/execution_context/streams_variables.rs
@@ -218,7 +218,7 @@ impl fmt::Display for Streams {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for (name, descriptors) in self.streams.iter() {
             if let Some(last_descriptor) = descriptors.last() {
-                writeln!(f, "{} => {}", name, last_descriptor)?;
+                writeln!(f, "{name} => {last_descriptor}")?;
             }
         }
         Ok(())

--- a/air/tests/test_module/features/data_merging/data_merge.rs
+++ b/air/tests/test_module/features/data_merging/data_merge.rs
@@ -244,21 +244,21 @@ fn fold_merge() {
         local_vm,
         <_>::default(),
         &script,
-        result_1.data.clone(),
+        result_1.data,
         local_vms_results[3].data.clone()
     );
     let result_3 = checked_call_vm!(
         local_vm,
         <_>::default(),
         &script,
-        result_2.data.clone(),
+        result_2.data,
         local_vms_results[4].data.clone()
     );
     let result_4 = checked_call_vm!(
         local_vm,
         <_>::default(),
         &script,
-        result_3.data.clone(),
+        result_3.data,
         local_vms_results[5].data.clone()
     );
 
@@ -266,7 +266,7 @@ fn fold_merge() {
         local_vm,
         <_>::default(),
         &script,
-        result_4.data.clone(),
+        result_4.data,
         local_vms_results[1].data.clone()
     );
 
@@ -274,7 +274,7 @@ fn fold_merge() {
         local_vm,
         <_>::default(),
         &script,
-        result_5.data.clone(),
+        result_5.data,
         local_vms_results[2].data.clone()
     );
 
@@ -282,7 +282,7 @@ fn fold_merge() {
         local_vm,
         <_>::default(),
         &script,
-        result_6.data.clone(),
+        result_6.data,
         local_vms_results[6].data.clone()
     );
 
@@ -318,7 +318,7 @@ fn fold_merge() {
                     };
 
                     if let JValue::String(var_name) = value.deref() {
-                        let current_count: usize = calls_count.get(var_name).map(|v| *v).unwrap_or_default();
+                        let current_count: usize = calls_count.get(var_name).copied().unwrap_or_default();
                         calls_count.insert(var_name, current_count + 1);
                     }
                 }

--- a/air/tests/test_module/features/data_merging/executed_trace_basic.rs
+++ b/air/tests/test_module/features/data_merging/executed_trace_basic.rs
@@ -123,10 +123,10 @@ fn executed_trace_seq_seq() {
         "#);
 
     let result = checked_call_vm!(vm2, <_>::default(), &script, "", "");
-    assert_eq!(result.next_peer_pks, vec![peer_id_1.clone()]);
+    assert_eq!(result.next_peer_pks, vec![peer_id_1]);
 
     let result = checked_call_vm!(vm1, <_>::default(), &script, "", result.data);
-    assert_eq!(result.next_peer_pks, vec![peer_id_2.clone()]);
+    assert_eq!(result.next_peer_pks, vec![peer_id_2]);
 
     let result = checked_call_vm!(vm2, <_>::default(), script, "", result.data);
 

--- a/air/tests/test_module/features/errors/last_error.rs
+++ b/air/tests/test_module/features/errors/last_error.rs
@@ -96,10 +96,7 @@ fn not_clear_last_error_in_match() {
 
     let args = Rc::new(RefCell::new(None));
     let tetraplets = Rc::new(RefCell::new(None));
-    let mut local_vm = create_avm(
-        create_check_service_closure(args.clone(), tetraplets.clone()),
-        local_peer_id,
-    );
+    let mut local_vm = create_avm(create_check_service_closure(args.clone(), tetraplets), local_peer_id);
 
     let script = f!(r#"
         (seq
@@ -132,10 +129,7 @@ fn not_clear_last_error_in_mismatch() {
 
     let args = Rc::new(RefCell::new(None));
     let tetraplets = Rc::new(RefCell::new(None));
-    let mut local_vm = create_avm(
-        create_check_service_closure(args.clone(), tetraplets.clone()),
-        local_peer_id,
-    );
+    let mut local_vm = create_avm(create_check_service_closure(args.clone(), tetraplets), local_peer_id);
 
     let script = f!(r#"
         (seq
@@ -168,10 +162,7 @@ fn track_current_peer_id() {
 
     let args = Rc::new(RefCell::new(None));
     let tetraplets = Rc::new(RefCell::new(None));
-    let mut local_vm = create_avm(
-        create_check_service_closure(args.clone(), tetraplets.clone()),
-        local_peer_id,
-    );
+    let mut local_vm = create_avm(create_check_service_closure(args.clone(), tetraplets), local_peer_id);
 
     let script = f!(r#"
         (xor
@@ -288,10 +279,7 @@ fn last_error_with_par_one_subgraph_failed() {
     let vm_peer_id = "local_peer_id";
     let args = Rc::new(RefCell::new(None));
     let tetraplets = Rc::new(RefCell::new(None));
-    let mut vm = create_avm(
-        create_check_service_closure(args.clone(), tetraplets.clone()),
-        vm_peer_id,
-    );
+    let mut vm = create_avm(create_check_service_closure(args.clone(), tetraplets), vm_peer_id);
     let script = f!(r#"
         (seq
             (par
@@ -454,7 +442,7 @@ fn fail_with_scalar_from_call_field_not_right_type() {
     let result = call_vm!(vm, <_>::default(), &script, "", "");
 
     let expected_error = CatchableError::InvalidLastErrorObjectError(LastErrorObjectError::ScalarFieldIsWrongType {
-        scalar: service_result.clone(),
+        scalar: service_result,
         field_name: "error_code",
         expected_type: "integer",
     });

--- a/air/tests/test_module/features/join_behaviour/join_behaviour.rs
+++ b/air/tests/test_module/features/join_behaviour/join_behaviour.rs
@@ -61,7 +61,7 @@ fn dont_wait_on_json_path() {
     let result = checked_call_vm!(set_variable_vm, test_params.clone(), &script, "", "");
     let result = checked_call_vm!(local_vm, test_params.clone(), script, "", result.data);
 
-    assert_eq!(result.next_peer_pks, vec![test_params.init_peer_id.to_string()]);
+    assert_eq!(result.next_peer_pks, vec![test_params.init_peer_id]);
 }
 
 #[test]
@@ -127,7 +127,7 @@ fn dont_wait_on_json_path_on_scalars() {
     "#);
 
     let result = call_vm!(set_variable_vm, <_>::default(), &script, "", "");
-    let array_result = call_vm!(array_consumer, <_>::default(), &script, "", result.data.clone());
+    let array_result = call_vm!(array_consumer, <_>::default(), &script, "", result.data);
 
     let expected_error =
         CatchableError::LambdaApplierError(LambdaError::ValueNotContainSuchArrayIdx { value: array, idx: 5 });

--- a/air/tests/test_module/features/lambda/flattening.rs
+++ b/air/tests/test_module/features/lambda/flattening.rs
@@ -71,7 +71,7 @@ fn flattening_scalar_arrays() {
         "#);
 
     let result = checked_call_vm!(set_variable_vm, <_>::default(), script.clone(), "", "");
-    let result = call_vm!(local_vm, <_>::default(), script.clone(), "", result.data);
+    let result = call_vm!(local_vm, <_>::default(), script, "", result.data);
 
     assert!(is_interpreter_succeded(&result));
     assert_eq!(
@@ -118,7 +118,7 @@ fn flattening_streams() {
         "#);
 
     let result = checked_call_vm!(set_variable_vm, <_>::default(), script.clone(), "", "");
-    let result = call_vm!(local_vm, <_>::default(), script.clone(), "", result.data);
+    let result = call_vm!(local_vm, <_>::default(), script, "", result.data);
 
     assert!(is_interpreter_succeded(&result));
     assert_eq!(
@@ -156,7 +156,7 @@ fn flattening_empty_values() {
         "#);
 
     let result = checked_call_vm!(set_variable_vm, <_>::default(), script.clone(), "", "");
-    let result = checked_call_vm!(local_vm, <_>::default(), script.clone(), "", result.data);
+    let result = checked_call_vm!(local_vm, <_>::default(), script, "", result.data);
 
     assert!(is_interpreter_succeded(&result));
     assert_eq!(closure_call_args.args_var, Rc::new(RefCell::new(vec![])));
@@ -174,7 +174,7 @@ fn test_handling_non_flattening_values() {
 
     let closure_call_args = ClosureCallArgs::default();
     let local_peer_id = "local_peer_id";
-    let mut local_vm = create_avm(create_check_service_closure(closure_call_args.clone()), local_peer_id);
+    let mut local_vm = create_avm(create_check_service_closure(closure_call_args), local_peer_id);
 
     let script = f!(r#"
         (seq

--- a/air/tests/test_module/features/lambda/functors.rs
+++ b/air/tests/test_module/features/lambda/functors.rs
@@ -30,7 +30,7 @@ fn length_functor_for_array_scalar() {
         "#;
 
     let init_peer_id = "init_peer_id";
-    let executor = AirScriptExecutor::simple(TestRunParameters::from_init_peer_id(init_peer_id), &script)
+    let executor = AirScriptExecutor::simple(TestRunParameters::from_init_peer_id(init_peer_id), script)
         .expect("invalid test AIR script");
 
     let result = executor.execute_one(init_peer_id).unwrap();
@@ -79,7 +79,7 @@ fn length_functor_for_stream() {
         "#;
 
     let init_peer_id = "init_peer_id";
-    let executor = AirScriptExecutor::simple(TestRunParameters::from_init_peer_id(init_peer_id), &script)
+    let executor = AirScriptExecutor::simple(TestRunParameters::from_init_peer_id(init_peer_id), script)
         .expect("invalid test AIR script");
 
     let result = executor.execute_one(init_peer_id).unwrap();
@@ -120,7 +120,7 @@ fn length_functor_for_empty_stream() {
         "#;
 
     let init_peer_id = "init_peer_id";
-    let executor = AirScriptExecutor::simple(TestRunParameters::from_init_peer_id(init_peer_id), &script)
+    let executor = AirScriptExecutor::simple(TestRunParameters::from_init_peer_id(init_peer_id), script)
         .expect("invalid test AIR script");
 
     let result = executor.execute_one(init_peer_id).unwrap();
@@ -151,7 +151,7 @@ fn length_functor_for_canon_stream() {
         "#;
 
     let init_peer_id = "init_peer_id";
-    let executor = AirScriptExecutor::simple(TestRunParameters::from_init_peer_id(init_peer_id), &script)
+    let executor = AirScriptExecutor::simple(TestRunParameters::from_init_peer_id(init_peer_id), script)
         .expect("invalid test AIR script");
 
     let result = executor.execute_one(init_peer_id).unwrap();
@@ -183,7 +183,7 @@ fn length_functor_for_empty_canon_stream() {
         "#;
 
     let init_peer_id = "init_peer_id";
-    let executor = AirScriptExecutor::simple(TestRunParameters::from_init_peer_id(init_peer_id), &script)
+    let executor = AirScriptExecutor::simple(TestRunParameters::from_init_peer_id(init_peer_id), script)
         .expect("invalid test AIR script");
 
     let result = executor.execute_one(init_peer_id).unwrap();

--- a/air/tests/test_module/features/misc/version_check.rs
+++ b/air/tests/test_module/features/misc/version_check.rs
@@ -42,7 +42,7 @@ fn publish_version_check() {
 
     let actual_version =
         semver::Version::parse("0.36.2-feat-VM-173-add-interpreter-version-in-data-a2d575b-205-1.0").unwrap();
-    let current_data = InterpreterData::new(actual_version.clone());
+    let current_data = InterpreterData::new(actual_version);
     let current_data = serde_json::to_vec(&current_data).expect("default serializer shouldn't fail");
     let result = call_vm!(vm, <_>::default(), script, "", current_data);
 

--- a/air/tests/test_module/features/scopes/scalars_scope.rs
+++ b/air/tests/test_module/features/scopes/scalars_scope.rs
@@ -191,7 +191,7 @@ fn local_and_global_scalars() {
 
     let expected_trace = vec![
         executed_state::scalar(iterable_content.clone()),
-        executed_state::scalar(iterable_content.clone()),
+        executed_state::scalar(iterable_content),
         executed_state::scalar_number(0),
         executed_state::scalar_number(1),
         executed_state::scalar_number(2),

--- a/air/tests/test_module/features/streams/ap_with_fold.rs
+++ b/air/tests/test_module/features/streams/ap_with_fold.rs
@@ -19,7 +19,7 @@ use air_test_utils::prelude::*;
 #[test]
 fn ap_with_fold() {
     let nums: Vec<String> = (1..10).map(|i| i.to_string()).collect();
-    let vec = vec![nums.clone(), nums.clone(), nums.clone()];
+    let vec = vec![nums.clone(), nums.clone(), nums];
     let elems: Vec<(String, Vec<Vec<String>>)> = vec![
         ("a".into(), vec.clone()),
         ("a".into(), vec.clone()),

--- a/air/tests/test_module/features/streams/merging.rs
+++ b/air/tests/test_module/features/streams/merging.rs
@@ -86,7 +86,7 @@ fn merging_fold_iterations_extensively() {
         TestRunParameters::from_init_peer_id("client"),
         vec![],
         vec!["relay", "p1", "p2", "p3"].into_iter().map(Into::into),
-        &script,
+        script,
     )
     .unwrap();
 
@@ -97,7 +97,7 @@ fn merging_fold_iterations_extensively() {
         let peer = queue.pop_front().unwrap();
         if let Some(outcomes) = engine.execution_iter(peer.as_str()) {
             for outcome in outcomes {
-                assert_eq!(outcome.ret_code, 0, "{:?}", outcome);
+                assert_eq!(outcome.ret_code, 0, "{outcome:?}");
 
                 for peer in &outcome.next_peer_pks {
                     queue.push_back(peer.clone());
@@ -108,7 +108,7 @@ fn merging_fold_iterations_extensively() {
                 }
             }
         } else {
-            println!("peer: {}, no executions", peer);
+            println!("peer: {peer}, no executions");
         }
     }
 
@@ -223,7 +223,7 @@ fn merging_fold_iterations_extensively_2() {
         TestRunParameters::from_init_peer_id("client"),
         vec![],
         vec!["relay", "p1", "p2", "p3"].into_iter().map(Into::into),
-        &script,
+        script,
     )
     .unwrap();
 
@@ -235,7 +235,7 @@ fn merging_fold_iterations_extensively_2() {
         let peer = queue.pop_front().unwrap();
         if let Some(outcomes) = engine.execution_iter(peer.as_str()) {
             for outcome in outcomes {
-                assert_eq!(outcome.ret_code, 0, "{:?}", outcome);
+                assert_eq!(outcome.ret_code, 0, "{outcome:?}");
 
                 for peer in &outcome.next_peer_pks {
                     if !queue.contains(peer) {
@@ -248,7 +248,7 @@ fn merging_fold_iterations_extensively_2() {
                 }
             }
         } else {
-            println!("peer: {}, no executions", peer);
+            println!("peer: {peer}, no executions");
         }
     }
 

--- a/air/tests/test_module/features/streams/streams.rs
+++ b/air/tests/test_module/features/streams/streams.rs
@@ -113,7 +113,7 @@ fn stream_merging_v0() {
         executor,
         <_>::default(),
         &script,
-        executor_result_1.data.clone(),
+        executor_result_1.data,
         setter_2_res.data
     );
     let actual_trace_2 = trace_from_result(&executor_result_2);
@@ -157,7 +157,7 @@ fn stream_merging_v0() {
         executor,
         <_>::default(),
         &script,
-        executor_result_2.data.clone(),
+        executor_result_2.data,
         setter_3_res.data
     );
     let actual_trace_3 = trace_from_result(&executor_result_3);
@@ -268,7 +268,7 @@ fn stream_merging_v1() {
         executor,
         <_>::default(),
         &script,
-        executor_result_1.data.clone(),
+        executor_result_1.data,
         setter_2_res.data
     );
     let actual_trace_2 = trace_from_result(&executor_result_2);
@@ -317,7 +317,7 @@ fn stream_merging_v1() {
         executor,
         <_>::default(),
         &script,
-        executor_result_2.data.clone(),
+        executor_result_2.data,
         setter_3_res.data
     );
     let actual_trace_3 = trace_from_result(&executor_result_3);
@@ -433,7 +433,7 @@ fn stream_merging_v2() {
         executor,
         <_>::default(),
         &script,
-        executor_result_1.data.clone(),
+        executor_result_1.data,
         setter_2_res.data
     );
     let actual_trace_2 = trace_from_result(&executor_result_2);
@@ -477,7 +477,7 @@ fn stream_merging_v2() {
         executor,
         <_>::default(),
         &script,
-        executor_result_2.data.clone(),
+        executor_result_2.data,
         setter_3_res.data
     );
     let actual_trace_3 = trace_from_result(&executor_result_3);

--- a/air/tests/test_module/features/streams/streams_early_exit.rs
+++ b/air/tests/test_module/features/streams/streams_early_exit.rs
@@ -67,21 +67,21 @@ fn par_early_exit() {
         setter_3,
         <_>::default(),
         &script,
-        setter_3_res_1.data.clone(),
-        setter_1_res.data.clone()
+        setter_3_res_1.data,
+        setter_1_res.data
     );
     let setter_3_res_3 = checked_call_vm!(
         setter_3,
         <_>::default(),
         &script,
-        setter_3_res_2.data.clone(),
-        setter_2_res.data.clone()
+        setter_3_res_2.data,
+        setter_2_res.data
     );
     let init_result_2 = checked_call_vm!(
         init,
         <_>::default(),
         &script,
-        init_result_1.data.clone(),
+        init_result_1.data,
         setter_3_res_3.data.clone()
     );
     let actual_trace_2 = trace_from_result(&setter_3_res_3);

--- a/air/tests/test_module/features/tetraplets/security_tetraplets.rs
+++ b/air/tests/test_module/features/tetraplets/security_tetraplets.rs
@@ -184,7 +184,7 @@ fn check_tetraplet_works_correctly() {
     };
 
     let second_arg_tetraplet = SecurityTetraplet {
-        peer_pk: set_variable_vm_peer_id.clone(),
+        peer_pk: set_variable_vm_peer_id,
         service_id,
         function_name,
         json_path: String::from(".$.args.[0]"),
@@ -206,7 +206,7 @@ use std::path::PathBuf;
 
 fn construct_service_config(module_name: impl Into<String>) -> AppServiceConfig {
     let module_name = module_name.into();
-    let module_path = format!("./tests/security_tetraplets/{}/target/wasm32-wasi/debug/", module_name);
+    let module_path = format!("./tests/security_tetraplets/{module_name}/target/wasm32-wasi/debug/");
 
     let module_descriptor = ModuleDescriptor {
         file_name: module_name.clone() + ".wasm",
@@ -222,12 +222,10 @@ fn construct_service_config(module_name: impl Into<String>) -> AppServiceConfig 
 
     let service_base_dir = std::env::temp_dir();
 
-    let config = AppServiceConfig {
+    AppServiceConfig {
         service_base_dir,
         marine_config,
-    };
-
-    config
+    }
 }
 
 #[test]
@@ -238,11 +236,11 @@ fn tetraplet_with_wasm_modules() {
 
     let auth_module_name = String::from("auth_module");
     let auth_service_config = construct_service_config(auth_module_name.clone());
-    let auth_service = AppService::new(auth_service_config, auth_module_name.clone(), <_>::default()).unwrap();
+    let auth_service = AppService::new(auth_service_config, auth_module_name, <_>::default()).unwrap();
 
     let log_module_name = String::from("log_storage");
     let log_service_config = construct_service_config(log_module_name.clone());
-    let log_service = AppService::new(log_service_config, log_module_name.clone(), <_>::default()).unwrap();
+    let log_service = AppService::new(log_service_config, log_module_name, <_>::default()).unwrap();
 
     let services = maplit::hashmap!(
       "auth" => auth_service,

--- a/air/tests/test_module/instructions/fail.rs
+++ b/air/tests/test_module/instructions/fail.rs
@@ -136,7 +136,7 @@ fn fail_with_canon_stream() {
             )"#);
 
     let test_params = TestRunParameters::from_init_peer_id("init_peer_id");
-    let result = call_vm!(vm, test_params.clone(), script, "", "");
+    let result = call_vm!(vm, test_params, script, "", "");
 
     let expected_error = CatchableError::UserError {
         error: rc!(json!( {

--- a/air/tests/test_module/instructions/fold.rs
+++ b/air/tests/test_module/instructions/fold.rs
@@ -47,7 +47,7 @@ fn lfold() {
     assert_eq!(actual_trace[0.into()], expected_state);
 
     for i in 1..=5 {
-        let expected_state = executed_state::stream_string(format!("{}", i), i as u32 - 1);
+        let expected_state = executed_state::stream_string(format!("{i}"), i as u32 - 1);
         assert_eq!(actual_trace[i.into()], expected_state);
     }
 }
@@ -289,7 +289,7 @@ fn lambda() {
     assert_eq!(actual_trace[0.into()], expected_state);
 
     for i in 1..=5 {
-        let expected_state = executed_state::stream_string(format!("{}", i), i as u32 - 1);
+        let expected_state = executed_state::stream_string(format!("{i}"), i as u32 - 1);
         assert_eq!(actual_trace[i.into()], expected_state);
     }
 }
@@ -619,7 +619,7 @@ fn fold_scalar_seq_next_not_completes_with_never() {
     let actual_trace = trace_from_result(&result);
 
     let expected_trace = vec![
-        executed_state::scalar(service_result.clone()),
+        executed_state::scalar(service_result),
         executed_state::par(1, 2),
         executed_state::request_sent_by(vm_peer_id),
         executed_state::par(1, 0),

--- a/air/tests/test_module/instructions/match_.rs
+++ b/air/tests/test_module/instructions/match_.rs
@@ -131,7 +131,7 @@ fn match_with_init_peer_id() {
 
     let test_params = TestRunParameters::from_init_peer_id(local_peer_id);
     let result = checked_call_vm!(set_variable_vm, test_params.clone(), &script, "", "");
-    let result = checked_call_vm!(vm, test_params.clone(), script, "", result.data);
+    let result = checked_call_vm!(vm, test_params, script, "", result.data);
 
     let actual_trace = trace_from_result(&result);
     let expected_executed_call_result = executed_state::scalar_string("result_1");
@@ -162,7 +162,7 @@ fn match_with_timestamp() {
 
     let test_params = TestRunParameters::from_timestamp(timestamp);
     let result = checked_call_vm!(set_variable_vm, test_params.clone(), &script, "", "");
-    let result = checked_call_vm!(vm, test_params.clone(), script, "", result.data);
+    let result = checked_call_vm!(vm, test_params, script, "", result.data);
 
     let actual_trace = trace_from_result(&result);
     let expected_executed_call_result = executed_state::scalar_string("result_1");
@@ -193,7 +193,7 @@ fn match_with_ttl() {
 
     let test_params = TestRunParameters::from_ttl(ttl);
     let result = checked_call_vm!(set_variable_vm, test_params.clone(), &script, "", "");
-    let result = checked_call_vm!(vm, test_params.clone(), script, "", result.data);
+    let result = checked_call_vm!(vm, test_params, script, "", result.data);
 
     let actual_trace = trace_from_result(&result);
     let expected_executed_call_result = executed_state::scalar_string("result_1");

--- a/air/tests/test_module/instructions/new.rs
+++ b/air/tests/test_module/instructions/new.rs
@@ -491,10 +491,10 @@ fn new_with_global_scalars() {
     assert_eq!(actual_trace, expected_trace);
 }
 
-const GET_ITERABLE_ACTION_NAME: &'static str = "get_iterable_action_name";
-const OUTSIDE_ACTION_NAME: &'static str = "outside_new";
-const INSIDE_ACTION_NAME: &'static str = "inside_new";
-const OUTPUT_ACTION_NAME: &'static str = "output";
+const GET_ITERABLE_ACTION_NAME: &str = "get_iterable_action_name";
+const OUTSIDE_ACTION_NAME: &str = "outside_new";
+const INSIDE_ACTION_NAME: &str = "inside_new";
+const OUTPUT_ACTION_NAME: &str = "output";
 
 fn prepare_new_test_call_service() -> CallServiceClosure {
     let outside_new_id = std::cell::Cell::new(0u32);
@@ -520,7 +520,7 @@ fn prepare_new_test_call_service() -> CallServiceClosure {
                 CallServiceResult::ok(second_argument)
             }
             action_name => {
-                println!("unknown action: {:?}", action_name);
+                println!("unknown action: {action_name:?}");
                 CallServiceResult::err(1, json!("no such action"))
             }
         }

--- a/air/tests/test_module/instructions/xor.rs
+++ b/air/tests/test_module/instructions/xor.rs
@@ -105,7 +105,7 @@ fn xor_par() {
 
     let fallible_service_id = String::from("service_id_1");
     let local_peer_id = "local_peer_id";
-    let mut vm = create_avm(fallible_call_service(fallible_service_id.clone()), local_peer_id);
+    let mut vm = create_avm(fallible_call_service(fallible_service_id), local_peer_id);
 
     let script = f!(r#"
             (xor

--- a/air/tests/test_module/integration/chat_join.rs
+++ b/air/tests/test_module/integration/chat_join.rs
@@ -320,7 +320,7 @@ fn init_peer_id() {
     assert_eq!(client_1_actual_trace, client_1_expected_trace);
     assert_eq!(client_1_result.next_peer_pks, vec![initiator_peer_id.to_string()]);
 
-    let initiator_1_result = checked_call_vm!(initiator, test_params.clone(), script, client_1_result.data, "");
+    let initiator_1_result = checked_call_vm!(initiator, test_params, script, client_1_result.data, "");
 
     let initiator_1_actual_trace = trace_from_result(&initiator_1_result);
 

--- a/air/tests/test_module/integration/create_service.rs
+++ b/air/tests/test_module/integration/create_service.rs
@@ -67,7 +67,7 @@ fn create_service() {
 
     let test_params = TestRunParameters::from_init_peer_id("init_peer_id");
     let result = checked_call_vm!(set_variables_vm, test_params.clone(), script, "", "");
-    let result = checked_call_vm!(vm, test_params.clone(), script, "", result.data);
+    let result = checked_call_vm!(vm, test_params, script, "", result.data);
 
     let add_module_response = "add_module response";
     let add_blueprint_response = "add_blueprint response";

--- a/air/tests/test_module/integration/dashboard.rs
+++ b/air/tests/test_module/integration/dashboard.rs
@@ -37,7 +37,7 @@ fn parse_peers() -> Vec<String> {
         result.push(record.as_slice().to_string());
     }
 
-    return result;
+    result
 }
 
 fn into_hashset(peers: Vec<String>) -> HashSet<String> {
@@ -56,7 +56,7 @@ fn client_host_function(
 
     let to_ret_value = Box::new(
         move |service_name: &str, function_name: &str, arguments: Vec<String>| -> JValue {
-            if service_name != "" || function_name != "load" || arguments.len() != 1 {
+            if !service_name.is_empty() || function_name != "load" || arguments.len() != 1 {
                 return JValue::Null;
             }
 
@@ -181,7 +181,7 @@ fn dashboard() {
     // -> client 1
     let client_1_result = checked_call_vm!(client, test_params.clone(), script, "", "");
     let next_peer_pks = into_hashset(client_1_result.next_peer_pks);
-    let mut all_peer_pks = into_hashset(known_peer_ids.clone());
+    let mut all_peer_pks = into_hashset(known_peer_ids);
     all_peer_pks.insert(relay_id.clone());
     assert_eq!(next_peer_pks, all_peer_pks);
 
@@ -209,11 +209,11 @@ fn dashboard() {
     );
 
     let mut relay_2_result = relay_1_result.clone();
-    let mut client_3_result = client_2_result.clone();
+    let mut client_3_result = client_2_result;
 
     // peers 1 -> relay 2 -> client 3
     for avm in known_peers.iter_mut() {
-        let prev_result = std::mem::replace(&mut avm.prev_result, vec![]);
+        let prev_result = std::mem::take(&mut avm.prev_result);
         let known_peer_result = checked_call_vm!(
             avm.vm,
             test_params.clone(),
@@ -254,12 +254,12 @@ fn dashboard() {
     all_peer_pks.remove(&client_id);
     all_peer_pks.insert(relay_id.to_string());
 
-    let mut relay_3_result = relay_2_result.clone();
-    let mut client_4_result = client_3_result.clone();
+    let mut relay_3_result = relay_2_result;
+    let mut client_4_result = client_3_result;
 
     // peers 2 -> relay 3 -> client 4
     for avm in known_peers.iter_mut() {
-        let prev_result = std::mem::replace(&mut avm.prev_result, vec![]);
+        let prev_result = std::mem::take(&mut avm.prev_result);
         let known_peer_result = checked_call_vm!(
             avm.vm,
             test_params.clone(),
@@ -302,8 +302,8 @@ fn dashboard() {
         )
     }
 
-    let mut relay_4_result = relay_3_result.clone();
-    let mut client_5_result = client_4_result.clone();
+    let mut relay_4_result = relay_3_result;
+    let mut client_5_result = client_4_result;
 
     // peers 2 -> peers 3 -> relay 4 -> client 5
     for i in 0..known_peers.len() {

--- a/air/tests/test_module/issues/issue_177.rs
+++ b/air/tests/test_module/issues/issue_177.rs
@@ -124,7 +124,7 @@ fn issue_177() {
         .runner
         .call(
             script,
-            relay_result_1.data.clone(),
+            relay_result_1.data,
             "",
             client_peer_id,
             0,
@@ -143,7 +143,7 @@ fn issue_177() {
         .runner
         .call(
             script,
-            relay_result_2.data.clone(),
+            relay_result_2.data,
             "",
             client_peer_id,
             0,
@@ -162,7 +162,7 @@ fn issue_177() {
         .runner
         .call(
             script,
-            relay_result_3.data.clone(),
+            relay_result_3.data,
             "",
             client_peer_id,
             0,
@@ -179,7 +179,7 @@ fn issue_177() {
         .call(
             script,
             client_result_2.data,
-            relay_result_4.data.clone(),
+            relay_result_4.data,
             client_peer_id,
             0,
             0,

--- a/air/tests/test_module/issues/issue_300.rs
+++ b/air/tests/test_module/issues/issue_300.rs
@@ -34,7 +34,7 @@ fn issue_300() {
     "#);
 
     let result_1 = checked_call_vm!(peer_vm_2, <_>::default(), &script, "", "");
-    let result_2 = checked_call_vm!(peer_vm_1, <_>::default(), &script, "", result_1.data.clone());
+    let result_2 = checked_call_vm!(peer_vm_1, <_>::default(), &script, "", result_1.data);
     let actual_trace = trace_from_result(&result_2);
 
     let expected_trace = vec![

--- a/air/tests/test_module/issues/issue_304.rs
+++ b/air/tests/test_module/issues/issue_304.rs
@@ -33,7 +33,7 @@ fn issue_304() {
     "#;
 
     let init_peer_id = "init_peer_id";
-    let executor = AirScriptExecutor::simple(TestRunParameters::from_init_peer_id(init_peer_id), &script)
+    let executor = AirScriptExecutor::simple(TestRunParameters::from_init_peer_id(init_peer_id), script)
         .expect("invalid test AIR script");
 
     let res = executor.execute_one(init_peer_id).unwrap();

--- a/air/tests/test_module/issues/issue_348.rs
+++ b/air/tests/test_module/issues/issue_348.rs
@@ -46,13 +46,7 @@ fn issue_348() {
     "#);
 
     let result11 = checked_call_vm!(peer_vm_1, <_>::default(), &script, "", "");
-    let result21 = checked_call_vm!(peer_vm_2, <_>::default(), &script, "", result11.data.clone());
+    let result21 = checked_call_vm!(peer_vm_2, <_>::default(), &script, "", result11.data);
     let result31 = checked_call_vm!(peer_vm_3, <_>::default(), &script, "", result21.data.clone());
-    let _result22 = checked_call_vm!(
-        peer_vm_2,
-        <_>::default(),
-        &script,
-        result21.data.clone(),
-        result31.data.clone()
-    );
+    let _result22 = checked_call_vm!(peer_vm_2, <_>::default(), &script, result21.data, result31.data);
 }

--- a/air/tests/test_module/issues/issue_356.rs
+++ b/air/tests/test_module/issues/issue_356.rs
@@ -55,14 +55,14 @@ fn issue_356() {
         TestRunParameters::from_init_peer_id("client"),
         vec![],
         vec!["p1", "p2", "p3"].into_iter().map(Into::into),
-        &script,
+        script,
     )
     .unwrap();
 
     for _ in 0..7 {
         for peer in ["client", "relay", "p1", "p2"] {
             for outcome in engine.execution_iter(peer).unwrap() {
-                assert_eq!(outcome.ret_code, 0, "{:?}", outcome);
+                assert_eq!(outcome.ret_code, 0, "{outcome:?}");
             }
         }
     }

--- a/air/tests/test_module/issues/issue_363.rs
+++ b/air/tests/test_module/issues/issue_363.rs
@@ -75,7 +75,7 @@ fn issue_363() {
         "#;
 
     let client_result = checked_call_vm!(client_vm, <_>::default(), script, "", "");
-    let p1_result_1 = checked_call_vm!(p1_vm, <_>::default(), script, "", client_result.data.clone());
+    let p1_result_1 = checked_call_vm!(p1_vm, <_>::default(), script, "", client_result.data);
     let p2_result_1 = checked_call_vm!(p2_vm, <_>::default(), script, "", p1_result_1.data.clone());
 
     let p2_trace_1 = trace_from_result(&p2_result_1);
@@ -91,13 +91,7 @@ fn issue_363() {
         panic!("expected fold at pos 9")
     }
 
-    let p1_result_2 = checked_call_vm!(
-        p1_vm,
-        <_>::default(),
-        script,
-        p1_result_1.data.clone(),
-        p2_result_1.data.clone()
-    );
+    let p1_result_2 = checked_call_vm!(p1_vm, <_>::default(), script, p1_result_1.data, p2_result_1.data);
     let p1_trace_2 = trace_from_result(&p1_result_2);
     let fold_p1 = p1_trace_2.get(fold_position).unwrap();
     if let ExecutedState::Fold(fold) = fold_p1 {

--- a/crates/air-lib/air-parser/benches/parser.rs
+++ b/crates/air-lib/air-parser/benches/parser.rs
@@ -27,7 +27,7 @@ use air_parser::AIRLexer;
 use air_parser::AIRParser;
 use air_parser::VariableValidator;
 
-const SOURCE_CODE_BAD: &'static str = r#"(seq
+const SOURCE_CODE_BAD: &str = r#"(seq
         (seq
             (call node ("identity" "") [] $void)
             (call provider (service_id "{fname}") {arg_list} result)
@@ -38,7 +38,7 @@ const SOURCE_CODE_BAD: &'static str = r#"(seq
         )
     )"#;
 
-const SOURCE_CODE_GOOD: &'static str = r#"
+const SOURCE_CODE_GOOD: &str = r#"
     (seq
         (seq
             (call node ("identity" "") [] $void)
@@ -73,7 +73,7 @@ mod gen {
 }
 
 fn create_parser(c: &mut Criterion) {
-    c.bench_function("create_parser", move |b| b.iter(move || AIRParser::new()));
+    c.bench_function("create_parser", move |b| b.iter(AIRParser::new));
 }
 
 fn parse(c: &mut Criterion) {

--- a/crates/air-lib/air-parser/src/ast/instruction_arguments/traits.rs
+++ b/crates/air-lib/air-parser/src/ast/instruction_arguments/traits.rs
@@ -23,8 +23,8 @@ impl fmt::Display for ApResult<'_> {
         use ApResult::*;
 
         match self {
-            Scalar(scalar) => write!(f, "{}", scalar),
-            Stream(stream) => write!(f, "{}", stream),
+            Scalar(scalar) => write!(f, "{scalar}"),
+            Stream(stream) => write!(f, "{stream}"),
         }
     }
 }
@@ -36,14 +36,14 @@ impl fmt::Display for ImmutableValue<'_> {
         match self {
             InitPeerId => write!(f, "%init_peer_id%"),
             LastError(error_accessor) => display_last_error(f, error_accessor),
-            Literal(literal) => write!(f, r#""{}""#, literal),
+            Literal(literal) => write!(f, r#""{literal}""#),
             Timestamp => write!(f, "%timestamp%"),
             TTL => write!(f, "%ttl%"),
-            Number(number) => write!(f, "{}", number),
-            Boolean(bool) => write!(f, "{}", bool),
+            Number(number) => write!(f, "{number}"),
+            Boolean(bool) => write!(f, "{bool}"),
             EmptyArray => write!(f, "[]"),
-            Variable(variable) => write!(f, "{}", variable),
-            VariableWithLambda(variable) => write!(f, "{}", variable),
+            Variable(variable) => write!(f, "{variable}"),
+            VariableWithLambda(variable) => write!(f, "{variable}"),
         }
     }
 }
@@ -54,10 +54,10 @@ impl fmt::Display for ResolvableToPeerIdVariable<'_> {
 
         match self {
             InitPeerId => write!(f, "%init_peer_id%"),
-            Literal(literal) => write!(f, r#""{}""#, literal),
-            Scalar(scalar) => write!(f, "{}", scalar),
-            ScalarWithLambda(scalar) => write!(f, "{}", scalar),
-            CanonStreamWithLambda(canon_stream) => write!(f, "{}", canon_stream),
+            Literal(literal) => write!(f, r#""{literal}""#),
+            Scalar(scalar) => write!(f, "{scalar}"),
+            ScalarWithLambda(scalar) => write!(f, "{scalar}"),
+            CanonStreamWithLambda(canon_stream) => write!(f, "{canon_stream}"),
         }
     }
 }
@@ -67,10 +67,10 @@ impl fmt::Display for ResolvableToStringVariable<'_> {
         use ResolvableToStringVariable::*;
 
         match self {
-            Literal(literal) => write!(f, r#""{}""#, literal),
-            Scalar(scalar) => write!(f, "{}", scalar),
-            ScalarWithLambda(scalar) => write!(f, "{}", scalar),
-            CanonStreamWithLambda(canon_stream) => write!(f, "{}", canon_stream),
+            Literal(literal) => write!(f, r#""{literal}""#),
+            Scalar(scalar) => write!(f, "{scalar}"),
+            ScalarWithLambda(scalar) => write!(f, "{scalar}"),
+            CanonStreamWithLambda(canon_stream) => write!(f, "{canon_stream}"),
         }
     }
 }
@@ -80,8 +80,8 @@ impl fmt::Display for CallOutputValue<'_> {
         use CallOutputValue::*;
 
         match self {
-            Scalar(scalar) => write!(f, "{}", scalar),
-            Stream(stream) => write!(f, "{}", stream),
+            Scalar(scalar) => write!(f, "{scalar}"),
+            Stream(stream) => write!(f, "{stream}"),
             None => Ok(()),
         }
     }
@@ -94,16 +94,16 @@ impl fmt::Display for ApArgument<'_> {
         match self {
             InitPeerId => write!(f, "%init_peer_id%"),
             LastError(error_accessor) => display_last_error(f, error_accessor),
-            Literal(str) => write!(f, r#""{}""#, str),
+            Literal(str) => write!(f, r#""{str}""#),
             Timestamp => write!(f, "%timestamp%"),
             TTL => write!(f, "%ttl%"),
-            Number(number) => write!(f, "{}", number),
-            Boolean(bool) => write!(f, "{}", bool),
+            Number(number) => write!(f, "{number}"),
+            Boolean(bool) => write!(f, "{bool}"),
             EmptyArray => write!(f, "[]"),
-            Scalar(scalar) => write!(f, "{}", scalar),
-            ScalarWithLambda(scalar) => write!(f, "{}", scalar),
-            CanonStream(canon_stream) => write!(f, "{}", canon_stream),
-            CanonStreamWithLambda(canon_stream) => write!(f, "{}", canon_stream),
+            Scalar(scalar) => write!(f, "{scalar}"),
+            ScalarWithLambda(scalar) => write!(f, "{scalar}"),
+            CanonStream(canon_stream) => write!(f, "{canon_stream}"),
+            CanonStreamWithLambda(canon_stream) => write!(f, "{canon_stream}"),
         }
     }
 }
@@ -121,9 +121,9 @@ impl fmt::Display for Triplet<'_> {
 impl fmt::Display for NewArgument<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Scalar(scalar) => write!(f, "{}", scalar),
-            Self::Stream(stream) => write!(f, "{}", stream),
-            Self::CanonStream(canon_stream) => write!(f, "{}", canon_stream),
+            Self::Scalar(scalar) => write!(f, "{scalar}"),
+            Self::Stream(stream) => write!(f, "{stream}"),
+            Self::CanonStream(canon_stream) => write!(f, "{canon_stream}"),
         }
     }
 }
@@ -133,8 +133,8 @@ impl fmt::Display for Number {
         use Number::*;
 
         match self {
-            Int(number) => write!(f, "{}", number),
-            Float(number) => write!(f, "{}", number),
+            Int(number) => write!(f, "{number}"),
+            Float(number) => write!(f, "{number}"),
         }
     }
 }
@@ -144,9 +144,9 @@ impl fmt::Display for FoldScalarIterable<'_> {
         use FoldScalarIterable::*;
 
         match self {
-            Scalar(scalar) => write!(f, "{}", scalar),
-            ScalarWithLambda(scalar) => write!(f, "{}", scalar),
-            CanonStream(canon_stream) => write!(f, "{}", canon_stream),
+            Scalar(scalar) => write!(f, "{scalar}"),
+            ScalarWithLambda(scalar) => write!(f, "{scalar}"),
+            CanonStream(canon_stream) => write!(f, "{canon_stream}"),
             EmptyArray => write!(f, "[]"),
         }
     }
@@ -169,7 +169,7 @@ impl From<&Number> for serde_json::Value {
 
 fn display_last_error(f: &mut fmt::Formatter, lambda_ast: &Option<LambdaAST>) -> fmt::Result {
     match lambda_ast {
-        Some(lambda_ast) => write!(f, "%last_error%{}", lambda_ast),
+        Some(lambda_ast) => write!(f, "%last_error%{lambda_ast}"),
         None => write!(f, "%last_error%"),
     }
 }

--- a/crates/air-lib/air-parser/src/ast/instructions/traits.rs
+++ b/crates/air-lib/air-parser/src/ast/instructions/traits.rs
@@ -23,21 +23,21 @@ impl fmt::Display for Instruction<'_> {
         use Instruction::*;
 
         match self {
-            Call(call) => write!(f, "{}", call),
-            Canon(canon) => write!(f, "{}", canon),
-            Ap(ap) => write!(f, "{}", ap),
-            Seq(seq) => write!(f, "{}", seq),
-            Par(par) => write!(f, "{}", par),
-            Xor(xor) => write!(f, "{}", xor),
-            Match(match_) => write!(f, "{}", match_),
-            MisMatch(mismatch) => write!(f, "{}", mismatch),
-            Fail(fail) => write!(f, "{}", fail),
-            FoldScalar(fold) => write!(f, "{}", fold),
-            FoldStream(fold) => write!(f, "{}", fold),
-            Never(never) => write!(f, "{}", never),
-            Next(next) => write!(f, "{}", next),
-            New(new) => write!(f, "{}", new),
-            Null(null) => write!(f, "{}", null),
+            Call(call) => write!(f, "{call}"),
+            Canon(canon) => write!(f, "{canon}"),
+            Ap(ap) => write!(f, "{ap}"),
+            Seq(seq) => write!(f, "{seq}"),
+            Par(par) => write!(f, "{par}"),
+            Xor(xor) => write!(f, "{xor}"),
+            Match(match_) => write!(f, "{match_}"),
+            MisMatch(mismatch) => write!(f, "{mismatch}"),
+            Fail(fail) => write!(f, "{fail}"),
+            FoldScalar(fold) => write!(f, "{fold}"),
+            FoldStream(fold) => write!(f, "{fold}"),
+            Never(never) => write!(f, "{never}"),
+            Next(next) => write!(f, "{next}"),
+            New(new) => write!(f, "{new}"),
+            Null(null) => write!(f, "{null}"),
             Error => write!(f, "error"),
         }
     }
@@ -47,7 +47,7 @@ impl fmt::Display for Call<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use itertools::Itertools;
 
-        let args = self.args.iter().map(|arg| format!("{}", arg)).join(" ");
+        let args = self.args.iter().map(|arg| format!("{arg}")).join(" ");
         write!(f, "call {} [{}] {}", self.triplet, args, self.output)
     }
 }
@@ -71,14 +71,14 @@ impl fmt::Display for Ap<'_> {
 impl fmt::Display for Fail<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Fail::Scalar(scalar) => write!(f, "fail {}", scalar),
-            Fail::ScalarWithLambda(scalar) => write!(f, "fail {}", scalar),
+            Fail::Scalar(scalar) => write!(f, "fail {scalar}"),
+            Fail::ScalarWithLambda(scalar) => write!(f, "fail {scalar}"),
             Fail::Literal {
                 ret_code,
                 error_message,
-            } => write!(f, r#"fail {} "{}""#, ret_code, error_message),
+            } => write!(f, r#"fail {ret_code} "{error_message}""#),
             Fail::CanonStreamWithLambda(stream) => {
-                write!(f, "fail {}", stream)
+                write!(f, "fail {stream}")
             }
             Fail::LastError => write!(f, "fail %last_error%"),
         }

--- a/crates/air-lib/air-parser/src/ast/values/traits.rs
+++ b/crates/air-lib/air-parser/src/ast/values/traits.rs
@@ -52,8 +52,8 @@ impl fmt::Display for ImmutableVariable<'_> {
         use ImmutableVariable::*;
 
         match self {
-            Scalar(scalar) => write!(f, "{}", scalar),
-            CanonStream(canon_stream) => write!(f, "{}", canon_stream),
+            Scalar(scalar) => write!(f, "{scalar}"),
+            CanonStream(canon_stream) => write!(f, "{canon_stream}"),
         }
     }
 }
@@ -63,8 +63,8 @@ impl fmt::Display for ImmutableVariableWithLambda<'_> {
         use ImmutableVariableWithLambda::*;
 
         match self {
-            Scalar(scalar) => write!(f, "{}", scalar),
-            CanonStream(canon_stream) => write!(f, "{}", canon_stream),
+            Scalar(scalar) => write!(f, "{scalar}"),
+            CanonStream(canon_stream) => write!(f, "{canon_stream}"),
         }
     }
 }

--- a/crates/air-lib/air-parser/src/parser/tests/call.rs
+++ b/crates/air-lib/air-parser/src/parser/tests/call.rs
@@ -294,10 +294,9 @@ fn parse_init_peer_id() {
     let source_code = format!(
         r#"
         (seq
-            (call "{}" ("local_service_id" "local_fn_name") [])
+            (call "{peer_id}" ("local_service_id" "local_fn_name") [])
             (call %init_peer_id% ("service_id" "fn_name") [])
-        )"#,
-        peer_id
+        )"#
     );
 
     let instruction = parse(&source_code);
@@ -359,13 +358,12 @@ fn parse_ttl() {
 
 #[test]
 fn parse_last_error() {
-    let source_code = format!(
-        r#"
+    let source_code = r#"
         (seq
             (call %init_peer_id% ("service_id" "fn_name") [%last_error%])
             (null)
-        )"#,
-    );
+        )"#
+    .to_string();
 
     let instruction = parse(&source_code);
     let expected = seq(

--- a/crates/air-lib/air-parser/src/parser/tests/dsl.rs
+++ b/crates/air-lib/air-parser/src/parser/tests/dsl.rs
@@ -215,9 +215,9 @@ pub(super) fn binary_instruction<'i, 'b>(
     name: &'i str,
 ) -> impl Fn(Instruction<'b>, Instruction<'b>) -> Instruction<'b> {
     match name {
-        "xor" => |l, r| xor(l, r),
-        "par" => |l, r| par(l, r),
-        "seq" => |l, r| seq(l, r),
+        "xor" => xor,
+        "par" => par,
+        "seq" => seq,
         _ => unreachable!(),
     }
 }

--- a/crates/air-lib/air-parser/src/parser/tests/fold.rs
+++ b/crates/air-lib/air-parser/src/parser/tests/fold.rs
@@ -270,7 +270,7 @@ fn parse_fold() {
             (null)
         )
         "#;
-    let instruction = parse(&source_code);
+    let instruction = parse(source_code);
     let expected = fold_scalar_variable(
         Scalar::new("iterable", 15.into()),
         Scalar::new("i", 24.into()),
@@ -289,7 +289,7 @@ fn fold_with_scalar_and_last_instruction() {
             (null)
         )
         "#;
-    let instruction = parse(&source_code);
+    let instruction = parse(source_code);
     let expected = fold_scalar_variable(
         Scalar::new("iterable", 15.into()),
         Scalar::new("i", 24.into()),
@@ -434,7 +434,7 @@ fn parse_fold_with_xor_par_seq() {
     for name in &["xor", "par", "seq"] {
         let source_code = source_fold_with(name);
         let instruction = parse(&source_code);
-        let instr = binary_instruction(*name);
+        let instr = binary_instruction(name);
         let expected = fold_scalar_variable(
             Scalar::new("iterable", 6.into()),
             Scalar::new("i", 15.into()),

--- a/crates/air-lib/air-parser/src/parser/tests/match_.rs
+++ b/crates/air-lib/air-parser/src/parser/tests/match_.rs
@@ -29,7 +29,7 @@ fn parse_match() {
             (null)
         )
         "#;
-    let instruction = parse(&source_code);
+    let instruction = parse(source_code);
     let expected = match_(
         ImmutableValue::Variable(ImmutableVariable::scalar("v1", 16.into())),
         ImmutableValue::Variable(ImmutableVariable::scalar("v2", 19.into())),
@@ -68,7 +68,7 @@ fn parse_match_with_init_peer_id() {
             (null)
         )
         "#;
-    let instruction = parse(&source_code);
+    let instruction = parse(source_code);
     let expected = match_(
         ImmutableValue::Variable(ImmutableVariable::scalar("v1", 16.into())),
         ImmutableValue::InitPeerId,
@@ -116,7 +116,7 @@ fn parse_mismatch() {
             (null)
         )
         "#;
-    let instruction = parse(&source_code);
+    let instruction = parse(source_code);
     let expected = mismatch(
         ImmutableValue::Variable(ImmutableVariable::scalar("v1", 19.into())),
         ImmutableValue::Variable(ImmutableVariable::scalar("v2", 22.into())),

--- a/crates/air-lib/air-parser/src/parser/tests/seq.rs
+++ b/crates/air-lib/air-parser/src/parser/tests/seq.rs
@@ -113,7 +113,7 @@ fn parse_seq_par_xor_seq() {
     for name in &["xor", "par", "seq"] {
         let source_code = source_seq_with(name);
         let instruction = parse(&source_code);
-        let instr = binary_instruction(*name);
+        let instr = binary_instruction(name);
         let expected = seq(instr(seqnn(), null()), instr(null(), seqnn()));
         assert_eq!(instruction, expected);
     }

--- a/crates/air-lib/interpreter-data/src/executed_state/impls.rs
+++ b/crates/air-lib/interpreter-data/src/executed_state/impls.rs
@@ -103,13 +103,13 @@ impl std::fmt::Display for ExecutedState {
             Par(ParResult {
                 left_size: left_subgraph_size,
                 right_size: right_subgraph_size,
-            }) => write!(f, "par({}, {})", left_subgraph_size, right_subgraph_size),
-            Call(RequestSentBy(sender)) => write!(f, r"{}", sender),
+            }) => write!(f, "par({left_subgraph_size}, {right_subgraph_size})"),
+            Call(RequestSentBy(sender)) => write!(f, r"{sender}"),
             Call(Executed(value)) => {
-                write!(f, "executed({})", value)
+                write!(f, "executed({value})")
             }
             Call(CallServiceFailed(ret_code, err_msg)) => {
-                write!(f, r#"call_service_failed({}, "{}")"#, ret_code, err_msg)
+                write!(f, r#"call_service_failed({ret_code}, "{err_msg}")"#)
             }
             Fold(FoldResult { lore }) => {
                 writeln!(f, "fold(",)?;
@@ -139,9 +139,9 @@ impl std::fmt::Display for ExecutedState {
 impl std::fmt::Display for Value {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Value::Scalar(value) => write!(f, "scalar: {}", value),
+            Value::Scalar(value) => write!(f, "scalar: {value}"),
             Value::Stream { value, generation } => {
-                write!(f, "stream: {} generation: {}", value, generation)
+                write!(f, "stream: {value} generation: {generation}")
             }
         }
     }
@@ -150,9 +150,9 @@ impl std::fmt::Display for Value {
 impl std::fmt::Display for Sender {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Sender::PeerId(peer_id) => write!(f, "request_sent_by({})", peer_id),
+            Sender::PeerId(peer_id) => write!(f, "request_sent_by({peer_id})"),
             Sender::PeerIdWithCallId { peer_id, call_id } => {
-                write!(f, "request_sent_by({}: {})", peer_id, call_id)
+                write!(f, "request_sent_by({peer_id}: {call_id})")
             }
         }
     }

--- a/crates/air-lib/interpreter-data/src/executed_state/se_de.rs
+++ b/crates/air-lib/interpreter-data/src/executed_state/se_de.rs
@@ -77,7 +77,7 @@ pub mod sender_serializer {
         match value {
             Sender::PeerId(peer_id) => serializer.serialize_str(peer_id.as_str()),
             Sender::PeerIdWithCallId { peer_id, call_id } => {
-                let result = format!("{}: {}", peer_id, call_id);
+                let result = format!("{peer_id}: {call_id}");
                 serializer.serialize_str(&result)
             }
         }
@@ -103,8 +103,7 @@ pub mod sender_serializer {
                         let call_id = &raw_sender[pos + 2..];
                         let call_id = call_id.parse::<u32>().map_err(|e| {
                             serde::de::Error::custom(format!(
-                                "failed to parse call_id of a sender {}: {}",
-                                call_id, e
+                                "failed to parse call_id of a sender {call_id}: {e}"
                             ))
                         })?;
                         Sender::PeerIdWithCallId {

--- a/crates/air-lib/interpreter-interface/src/interpreter_outcome.rs
+++ b/crates/air-lib/interpreter-interface/src/interpreter_outcome.rs
@@ -71,8 +71,7 @@ impl InterpreterOutcome {
         let mut record_values = try_as_record(ivalue)?.into_vec();
         if record_values.len() != OUTCOME_FIELDS_COUNT {
             return Err(format!(
-                "expected InterpreterOutcome struct with {} fields, got {:?}",
-                OUTCOME_FIELDS_COUNT, record_values
+                "expected InterpreterOutcome struct with {OUTCOME_FIELDS_COUNT} fields, got {record_values:?}"
             ));
         }
 
@@ -101,10 +100,7 @@ use fluence_it_types::ne_vec::NEVec;
 fn try_as_record(ivalue: IValue) -> Result<NEVec<IValue>, String> {
     match ivalue {
         IValue::Record(record_values) => Ok(record_values),
-        v => Err(format!(
-            "expected record for InterpreterOutcome, got {:?}",
-            v
-        )),
+        v => Err(format!("expected record for InterpreterOutcome, got {v:?}")),
     }
 }
 
@@ -112,7 +108,7 @@ fn try_as_record(ivalue: IValue) -> Result<NEVec<IValue>, String> {
 fn try_as_i64(ivalue: IValue, field_name: &str) -> Result<i64, String> {
     match ivalue {
         IValue::S64(value) => Ok(value),
-        v => Err(format!("expected an i64 for {}, got {:?}", field_name, v)),
+        v => Err(format!("expected an i64 for {field_name}, got {v:?}")),
     }
 }
 
@@ -120,7 +116,7 @@ fn try_as_i64(ivalue: IValue, field_name: &str) -> Result<i64, String> {
 fn try_as_string(ivalue: IValue, field_name: &str) -> Result<String, String> {
     match ivalue {
         IValue::String(value) => Ok(value),
-        v => Err(format!("expected a string for {}, got {:?}", field_name, v)),
+        v => Err(format!("expected a string for {field_name}, got {v:?}")),
     }
 }
 
@@ -132,18 +128,13 @@ fn try_as_byte_vec(ivalue: IValue, field_name: &str) -> Result<Vec<u8>, String> 
                 .into_iter()
                 .map(|v| match v {
                     IValue::U8(byte) => Ok(byte),
-                    v => Err(format!("expected a byte, got {:?}", v)),
+                    v => Err(format!("expected a byte, got {v:?}")),
                 })
                 .collect();
             array?
         }
         IValue::ByteArray(array) => array,
-        v => {
-            return Err(format!(
-                "expected a Vec<u8> for {}, got {:?}",
-                field_name, v
-            ))
-        }
+        v => return Err(format!("expected a Vec<u8> for {field_name}, got {v:?}")),
     };
 
     Ok(byte_vec)
@@ -157,12 +148,12 @@ fn try_as_string_vec(ivalue: IValue, field_name: &str) -> Result<Vec<String>, St
                 .into_iter()
                 .map(|v| match v {
                     IValue::String(str) => Ok(str),
-                    v => Err(format!("expected string for next_peer_pks, got {:?}", v)),
+                    v => Err(format!("expected string for next_peer_pks, got {v:?}")),
                 })
                 .collect::<Result<Vec<String>, _>>()?;
 
             Ok(array)
         }
-        v => Err(format!("expected an array for {}, got {:?}", field_name, v)),
+        v => Err(format!("expected an array for {field_name}, got {v:?}")),
     }
 }

--- a/crates/air-lib/lambda/ast/src/ast/traits.rs
+++ b/crates/air-lib/lambda/ast/src/ast/traits.rs
@@ -24,7 +24,7 @@ impl fmt::Display for LambdaAST<'_> {
         use LambdaAST::*;
 
         match self {
-            Functor(functor) => write!(f, ".{}", functor),
+            Functor(functor) => write!(f, ".{functor}"),
             ValuePath(value_path) => write!(f, ".$.{}", value_path.iter().join(".")),
         }
     }
@@ -35,9 +35,9 @@ impl fmt::Display for ValueAccessor<'_> {
         use ValueAccessor::*;
 
         match self {
-            ArrayAccess { idx } => write!(f, "[{}]", idx),
-            FieldAccessByName { field_name } => write!(f, "{}", field_name),
-            FieldAccessByScalar { scalar_name } => write!(f, "[{}]", scalar_name),
+            ArrayAccess { idx } => write!(f, "[{idx}]"),
+            FieldAccessByName { field_name } => write!(f, "{field_name}"),
+            FieldAccessByScalar { scalar_name } => write!(f, "[{scalar_name}]"),
             Error => write!(f, "a parser error occurred while parsing lambda expression"),
         }
     }

--- a/crates/air-lib/lambda/parser/src/parser/lexer/tests.rs
+++ b/crates/air-lib/lambda/parser/src/parser/lexer/tests.rs
@@ -42,7 +42,7 @@ fn array_access() {
 #[test]
 fn field_access() {
     let field_name = "some_field_name";
-    let field_access = format!(".$.{}", field_name);
+    let field_access = format!(".$.{field_name}");
 
     let actual = run_lexer(&field_access);
     let expected = vec![

--- a/crates/air-lib/lambda/parser/src/parser/tests.rs
+++ b/crates/air-lib/lambda/parser/src/parser/tests.rs
@@ -50,7 +50,7 @@ fn parse_to_functor(source_code: &str) -> Functor {
 #[test]
 fn field_access() {
     let field_name = "some_field_name";
-    let lambda = format!(".$.{}", field_name);
+    let lambda = format!(".$.{field_name}");
 
     let actual = parse_to_accessors(&lambda);
     let expected = vec![ValueAccessor::FieldAccessByName { field_name }];
@@ -60,7 +60,7 @@ fn field_access() {
 #[test]
 fn field_access_with_flattening() {
     let field_name = "some_field_name";
-    let lambda = format!(".$.{}!", field_name);
+    let lambda = format!(".$.{field_name}!");
 
     let actual = parse_to_accessors(&lambda);
     let expected = vec![ValueAccessor::FieldAccessByName { field_name }];
@@ -70,7 +70,7 @@ fn field_access_with_flattening() {
 #[test]
 fn array_access() {
     let idx = 0;
-    let lambda = format!(".$.[{}]", idx);
+    let lambda = format!(".$.[{idx}]");
 
     let actual = parse_to_accessors(&lambda);
     let expected = vec![ValueAccessor::ArrayAccess { idx }];
@@ -80,7 +80,7 @@ fn array_access() {
 #[test]
 fn array_access_with_flattening() {
     let idx = 0;
-    let lambda = format!(".$.[{}]!", idx);
+    let lambda = format!(".$.[{idx}]!");
 
     let actual = parse_to_accessors(&lambda);
     let expected = vec![ValueAccessor::ArrayAccess { idx }];
@@ -90,7 +90,7 @@ fn array_access_with_flattening() {
 #[test]
 fn scalar_access() {
     let scalar_name = "some_field_name";
-    let lambda = format!(".$.[{}]", scalar_name);
+    let lambda = format!(".$.[{scalar_name}]");
 
     let actual = parse_to_accessors(&lambda);
     let expected = vec![ValueAccessor::FieldAccessByScalar { scalar_name }];
@@ -100,7 +100,7 @@ fn scalar_access() {
 #[test]
 fn scalar_access_with_flattening() {
     let scalar_name = "some_scalar_name";
-    let lambda = format!(".$.[{}]!", scalar_name);
+    let lambda = format!(".$.[{scalar_name}]!");
 
     let actual = parse_to_accessors(&lambda);
     let expected = vec![ValueAccessor::FieldAccessByScalar { scalar_name }];
@@ -111,7 +111,7 @@ fn scalar_access_with_flattening() {
 fn field_array_access() {
     let field_name = "some_field_name";
     let idx = 1;
-    let lambda = format!(".$.{}.[{}]", field_name, idx);
+    let lambda = format!(".$.{field_name}.[{idx}]");
 
     let actual = parse_to_accessors(&lambda);
     let expected = vec![
@@ -125,7 +125,7 @@ fn field_array_access() {
 fn field_scalar_access() {
     let field_name = "some_field_name";
     let scalar_name = "some_scalar_name";
-    let lambda = format!(".$.{}.[{}]", field_name, scalar_name);
+    let lambda = format!(".$.{field_name}.[{scalar_name}]");
 
     let actual = parse_to_accessors(&lambda);
     let expected = vec![
@@ -139,7 +139,7 @@ fn field_scalar_access() {
 fn scalar_array_access() {
     let scalar_name = "some_scalar_name";
     let idx = 1;
-    let lambda = format!(".$.[{}].[{}]", scalar_name, idx);
+    let lambda = format!(".$.[{scalar_name}].[{idx}]");
 
     let actual = parse_to_accessors(&lambda);
     let expected = vec![
@@ -153,7 +153,7 @@ fn scalar_array_access() {
 fn field_array_access_without_dot() {
     let field_name = "some_field_name";
     let idx = 1;
-    let lambda = format!(".$.{}[{}]", field_name, idx);
+    let lambda = format!(".$.{field_name}[{idx}]");
 
     let actual = parse_to_accessors(&lambda);
     let expected = vec![
@@ -167,7 +167,7 @@ fn field_array_access_without_dot() {
 fn array_field_access() {
     let field_name = "some_field_name";
     let idx = 1;
-    let lambda = format!(".$.[{}].{}", idx, field_name);
+    let lambda = format!(".$.[{idx}].{field_name}");
 
     let actual = parse_to_accessors(&lambda);
     let expected = vec![
@@ -181,7 +181,7 @@ fn array_field_access() {
 fn array_scalar_access() {
     let scalar_name = "some_scalar_name";
     let idx = 1;
-    let lambda = format!(".$.[{}].[{}]", idx, scalar_name);
+    let lambda = format!(".$.[{idx}].[{scalar_name}]");
 
     let actual = parse_to_accessors(&lambda);
     let expected = vec![
@@ -197,10 +197,7 @@ fn many_array_field_access() {
     let field_name_2 = "some_field_name_2";
     let idx_1 = 1;
     let idx_2 = u32::MAX;
-    let lambda = format!(
-        ".$.[{}].{}.[{}].{}",
-        idx_1, field_name_1, idx_2, field_name_2
-    );
+    let lambda = format!(".$.[{idx_1}].{field_name_1}.[{idx_2}].{field_name_2}");
 
     let actual = parse_to_accessors(&lambda);
     let expected = vec![
@@ -225,8 +222,7 @@ fn many_array_field_scalar_access() {
     let scalar_name_1 = "some_scalar_name_1";
     let scalar_name_2 = "some_scalar_name_2";
     let lambda = format!(
-        ".$.[{}].[{}].{}.[{}].[{}].{}",
-        idx_1, scalar_name_1, field_name_1, idx_2, scalar_name_2, field_name_2
+        ".$.[{idx_1}].[{scalar_name_1}].{field_name_1}.[{idx_2}].[{scalar_name_2}].{field_name_2}"
     );
 
     let actual = parse_to_accessors(&lambda);
@@ -253,7 +249,7 @@ fn many_array_field_scalar_access() {
 fn parse_length_functor() {
     let lambda = ".length";
 
-    let actual = parse_to_functor(&lambda);
+    let actual = parse_to_functor(lambda);
     let expected = Functor::Length;
     assert_eq!(actual, expected);
 }

--- a/crates/air-lib/test-utils/src/executed_state.rs
+++ b/crates/air-lib/test-utils/src/executed_state.rs
@@ -105,7 +105,7 @@ pub fn par(left: usize, right: usize) -> ExecutedState {
 pub fn service_failed(ret_code: i32, error_message: &str) -> ExecutedState {
     ExecutedState::Call(CallResult::CallServiceFailed(
         ret_code,
-        Rc::new(format!(r#""{}""#, error_message)),
+        Rc::new(format!(r#""{error_message}""#)),
     ))
 }
 

--- a/crates/air-lib/test-utils/src/lib.rs
+++ b/crates/air-lib/test-utils/src/lib.rs
@@ -117,7 +117,7 @@ pub fn print_trace(result: &RawAVMOutcome, trace_name: &str) {
 
     println!("trace {} (states_count: {}): [", trace_name, trace.len());
     for (id, state) in trace.iter().enumerate() {
-        println!("  {}: {}", id, state);
+        println!("  {id}: {state}");
     }
     println!("]");
 }

--- a/crates/beautifier/src/beautifier.rs
+++ b/crates/beautifier/src/beautifier.rs
@@ -149,8 +149,8 @@ impl<W: io::Write> Beautifier<W> {
     fn beautify_call(&mut self, call: &ast::Call<'_>, indent: usize) -> io::Result<()> {
         fmt_indent(&mut self.output, indent)?;
         match &call.output {
-            ast::CallOutputValue::Scalar(v) => write!(&mut self.output, "{} <- ", v)?,
-            ast::CallOutputValue::Stream(v) => write!(&mut self.output, "{} <- ", v)?,
+            ast::CallOutputValue::Scalar(v) => write!(&mut self.output, "{v} <- ")?,
+            ast::CallOutputValue::Stream(v) => write!(&mut self.output, "{v} <- ")?,
             ast::CallOutputValue::None => {}
         }
         writeln!(
@@ -163,7 +163,7 @@ impl<W: io::Write> Beautifier<W> {
 
     fn beautify_simple(&mut self, instruction: impl Display, indent: usize) -> io::Result<()> {
         fmt_indent(&mut self.output, indent)?;
-        writeln!(&mut self.output, "{}", instruction)
+        writeln!(&mut self.output, "{instruction}")
     }
 
     fn beautify_seq(&mut self, seq: &ast::Seq<'_>, indent: usize) -> io::Result<()> {

--- a/crates/testing-framework/src/asserts/parser.rs
+++ b/crates/testing-framework/src/asserts/parser.rs
@@ -121,7 +121,7 @@ mod tests {
     #[test]
     fn test_parse_garbage0() {
         let res = ServiceDefinition::from_str("garbage");
-        assert!(res.is_err(), "{res:?}");
+        assert!(res.is_err(), "{}", "{res:?}");
     }
 
     #[test]

--- a/crates/testing-framework/src/asserts/parser.rs
+++ b/crates/testing-framework/src/asserts/parser.rs
@@ -121,7 +121,7 @@ mod tests {
     #[test]
     fn test_parse_garbage0() {
         let res = ServiceDefinition::from_str("garbage");
-        assert!(res.is_err(), "{:?}", res);
+        assert!(res.is_err(), "{res:?}");
     }
 
     #[test]

--- a/crates/testing-framework/src/ephemeral/neighborhood.rs
+++ b/crates/testing-framework/src/ephemeral/neighborhood.rs
@@ -270,13 +270,13 @@ mod tests {
         let other_id2: PeerId = "other2".into();
         let network = Network::empty();
 
-        let penv = PeerEnv::new(Peer::new(peer_id.clone(), Rc::from(vec![])), &network);
+        let penv = PeerEnv::new(Peer::new(peer_id, Rc::from(vec![])), &network);
         // iter is empty
         assert!(penv.iter().next().is_none());
 
         network.ensure_peer(other_id1.clone());
         network.ensure_peer(other_id2.clone());
-        let expected_neighborhood = PeerSet::from([other_id1.clone(), other_id2.clone()]);
+        let expected_neighborhood = PeerSet::from([other_id1, other_id2]);
         assert_eq!(penv.iter().collect::<PeerSet>(), expected_neighborhood);
     }
 
@@ -286,14 +286,14 @@ mod tests {
         let peer_id: PeerId = "someone".into();
         let other_id1: PeerId = "other1".into();
         let other_id2: PeerId = "other2".into();
-        let penv = PeerEnv::new(Peer::new(peer_id.clone(), Rc::from(vec![])), &network);
+        let penv = PeerEnv::new(Peer::new(peer_id, Rc::from(vec![])), &network);
 
         // iter is empty
         assert!(penv.iter().next().is_none());
 
         network.ensure_peer(other_id1.clone());
         network.ensure_peer(other_id2.clone());
-        let expected_neighborhood = PeerSet::from([other_id1.clone(), other_id2.clone()]);
+        let expected_neighborhood = PeerSet::from([other_id1, other_id2]);
         assert_eq!(PeerSet::from_iter(penv.iter()), expected_neighborhood);
     }
 
@@ -303,7 +303,7 @@ mod tests {
         let peer_id: PeerId = "someone".into();
         let other_id1: PeerId = "other1".into();
         let other_id2: PeerId = "other2".into();
-        let mut penv = PeerEnv::new(Peer::new(peer_id.clone(), Rc::from(vec![])), &network);
+        let mut penv = PeerEnv::new(Peer::new(peer_id, Rc::from(vec![])), &network);
 
         // iter is empty
         assert!(penv.iter().next().is_none());
@@ -311,7 +311,7 @@ mod tests {
         nei.alter(other_id1.clone(), AlterState::Added);
         nei.alter(other_id2.clone(), AlterState::Added);
 
-        let expected_neighborhood = PeerSet::from([other_id1.clone(), other_id2.clone()]);
+        let expected_neighborhood = PeerSet::from([other_id1, other_id2]);
         assert_eq!(PeerSet::from_iter(penv.iter()), expected_neighborhood);
     }
 
@@ -320,7 +320,7 @@ mod tests {
         let network = Network::empty();
         let peer_id: PeerId = "someone".into();
         let other_id1: PeerId = "other1".into();
-        let mut penv = PeerEnv::new(Peer::new(peer_id.clone(), Rc::from(vec![])), &network);
+        let mut penv = PeerEnv::new(Peer::new(peer_id, Rc::from(vec![])), &network);
 
         // iter is empty
         assert!(penv.iter().next().is_none());
@@ -337,7 +337,7 @@ mod tests {
     fn test_extend_neighborhood() {
         let network = Network::empty();
         let peer_id: PeerId = "someone".into();
-        let mut penv = PeerEnv::new(Peer::new(peer_id.clone(), Rc::from(vec![])), &network);
+        let mut penv = PeerEnv::new(Peer::new(peer_id, Rc::from(vec![])), &network);
         penv.get_neighborhood_mut()
             .alter(PeerId::from("zero"), AlterState::Added);
         penv.extend_neighborhood(IntoIterator::into_iter(["one", "two"]));
@@ -352,7 +352,7 @@ mod tests {
     fn test_remove_from_neiborhood() {
         let network = Network::empty();
         let peer_id: PeerId = "someone".into();
-        let mut penv = PeerEnv::new(Peer::new(peer_id.clone(), Rc::from(vec![])), &network);
+        let mut penv = PeerEnv::new(Peer::new(peer_id, Rc::from(vec![])), &network);
         penv.get_neighborhood_mut()
             .alter(PeerId::from("zero"), AlterState::Added);
         penv.extend_neighborhood(IntoIterator::into_iter(["one", "two"]));
@@ -370,7 +370,7 @@ mod tests {
         let network = Network::empty();
         let peer_id: PeerId = "someone".into();
         let other_id: PeerId = "other".into();
-        let mut penv = PeerEnv::new(Peer::new(peer_id.clone(), Rc::from(vec![])), &network);
+        let mut penv = PeerEnv::new(Peer::new(peer_id, Rc::from(vec![])), &network);
 
         let nei = penv.get_neighborhood_mut();
         nei.alter(other_id.clone(), AlterState::Added);
@@ -386,7 +386,7 @@ mod tests {
         let network = Network::empty();
         let peer_id: PeerId = "someone".into();
         let other_id: PeerId = "other".into();
-        let mut penv = PeerEnv::new(Peer::new(peer_id.clone(), Rc::from(vec![])), &network);
+        let mut penv = PeerEnv::new(Peer::new(peer_id, Rc::from(vec![])), &network);
 
         let nei = penv.get_neighborhood_mut();
         nei.alter(other_id.clone(), AlterState::Added);
@@ -407,7 +407,7 @@ mod tests {
         let network = Network::empty();
         let peer_id: PeerId = "someone".into();
         let other_id: PeerId = "other".into();
-        let mut penv = PeerEnv::new(Peer::new(peer_id.clone(), Rc::from(vec![])), &network);
+        let mut penv = PeerEnv::new(Peer::new(peer_id, Rc::from(vec![])), &network);
 
         let nei = penv.get_neighborhood_mut();
         nei.alter(other_id.clone(), AlterState::Added);

--- a/crates/testing-framework/src/execution/mod.rs
+++ b/crates/testing-framework/src/execution/mod.rs
@@ -511,7 +511,7 @@ mod tests {
 
         let transformed2 = TransformedAirScript::new(
             &f!(r#"(call "{}" ("service" "function") []) ; ok = 24"#, peer),
-            network.clone(),
+            network,
         )
         .unwrap();
         let exectution2 = AirScriptExecutor::from_transformed_air_script(
@@ -559,7 +559,7 @@ mod tests {
         )
         .unwrap();
 
-        let transformed2 = TransformedAirScript::new(&air_script, network.clone()).unwrap();
+        let transformed2 = TransformedAirScript::new(&air_script, network).unwrap();
         let exectution2 = AirScriptExecutor::from_transformed_air_script(
             TestRunParameters::from_init_peer_id(peer),
             transformed2,

--- a/crates/testing-framework/src/transform/mod.rs
+++ b/crates/testing-framework/src/transform/mod.rs
@@ -61,12 +61,10 @@ impl Sexp {
                 None => Err("cannot attach a service definition an empty list".to_owned()),
             },
             Sexp::Symbol(s) => Err(format!(
-                "cannot attach a service definition to a symbol {:?}",
-                s
+                "cannot attach a service definition to a symbol {s:?}"
             )),
             Sexp::String(ref s) => Err(format!(
-                r#"cannot attach a service definition to a string: "{:?}""#,
-                s
+                r#"cannot attach a service definition to a string: "{s:?}""#
             )),
         }
     }
@@ -86,14 +84,14 @@ impl std::fmt::Display for Sexp {
                     func = call.triplet.2,
                     args = call.args.iter().format(" "),
                     var = match &call.var {
-                        Some(var) => format!(" {}", var),
+                        Some(var) => format!(" {var}"),
                         None => "".to_owned(),
                     }
                 )
             }
             Sexp::List(items) => write!(f, "({})", items.iter().format(" ")),
-            Sexp::Symbol(symbol) => write!(f, "{}", symbol),
-            Sexp::String(string) => write!(f, r#""{}""#, string),
+            Sexp::Symbol(symbol) => write!(f, "{symbol}"),
+            Sexp::String(string) => write!(f, r#""{string}""#),
         }
     }
 }
@@ -108,34 +106,34 @@ mod tests {
     fn test_parse_fmt_call() {
         let sexp_str = r#"(call "my_id" ("serv" "function") [other_peer_id "other_arg"])"#;
         let sexp = Sexp::from_str(sexp_str).unwrap();
-        assert_eq!(format!("{}", sexp), sexp_str);
+        assert_eq!(format!("{sexp}"), sexp_str);
     }
 
     #[test]
     fn test_parse_fmt_call_var() {
         let sexp_str = r#"(call "my_id" ("serv" "function") [other_peer_id "other_arg"] var)"#;
         let sexp = Sexp::from_str(sexp_str).unwrap();
-        assert_eq!(format!("{}", sexp), sexp_str);
+        assert_eq!(format!("{sexp}"), sexp_str);
     }
 
     #[test]
     fn test_parse_fmt_symbol() {
         let sexp_str = "symbol";
         let sexp = Sexp::from_str(sexp_str).unwrap();
-        assert_eq!(format!("{}", sexp), sexp_str);
+        assert_eq!(format!("{sexp}"), sexp_str);
     }
 
     #[test]
     fn test_parse_fmt_string() {
         let sexp_str = r#""my_id""#;
         let sexp = Sexp::from_str(sexp_str).unwrap();
-        assert_eq!(format!("{}", sexp), sexp_str);
+        assert_eq!(format!("{sexp}"), sexp_str);
     }
 
     #[test]
     fn test_parse_fmt_sexp() {
         let sexp_str = r#"(par (ap x y) (fold x y (next)))"#;
         let sexp = Sexp::from_str(sexp_str).unwrap();
-        assert_eq!(format!("{}", sexp), sexp_str);
+        assert_eq!(format!("{sexp}"), sexp_str);
     }
 }

--- a/crates/testing-framework/src/transform/parser.rs
+++ b/crates/testing-framework/src/transform/parser.rs
@@ -580,7 +580,7 @@ mod tests {
   (call peerid ("serv" "func") [a b] var) ; ok=42
   (call peerid2 ("serv" "func") []))"#,
         );
-        assert!(res.is_ok(), "{:?}", res);
+        assert!(res.is_ok(), "{res:?}");
     }
 
     #[test]
@@ -609,7 +609,7 @@ mod tests {
     #[test]
     fn test_trailing_error() {
         let res = Sexp::from_str("(null))");
-        assert!(res.is_err(), "{:?}", res);
+        assert!(res.is_err(), "{res:?}");
     }
 
     #[test]
@@ -648,42 +648,42 @@ mod tests {
     fn test_parse_fmt_call() {
         let sexp_str = r#"(call "my_id" ("serv" "function") [other_peer_id "other_arg"])"#;
         let sexp = Sexp::from_str(sexp_str).unwrap();
-        assert_eq!(format!("{}", sexp), sexp_str);
+        assert_eq!(format!("{sexp}"), sexp_str);
     }
 
     #[test]
     fn test_parse_fmt_call_var() {
         let sexp_str = r#"(call "my_id" ("serv" "function") [other_peer_id "other_arg"] var)"#;
         let sexp = Sexp::from_str(sexp_str).unwrap();
-        assert_eq!(format!("{}", sexp), sexp_str);
+        assert_eq!(format!("{sexp}"), sexp_str);
     }
 
     #[test]
     fn test_parse_fmt_symbol() {
         let sexp_str = "symbol";
         let sexp = Sexp::from_str(sexp_str).unwrap();
-        assert_eq!(format!("{}", sexp), sexp_str);
+        assert_eq!(format!("{sexp}"), sexp_str);
     }
 
     #[test]
     fn test_parse_fmt_string() {
         let sexp_str = r#""my_id""#;
         let sexp = Sexp::from_str(sexp_str).unwrap();
-        assert_eq!(format!("{}", sexp), sexp_str);
+        assert_eq!(format!("{sexp}"), sexp_str);
     }
 
     #[test]
     fn test_parse_fmt_sexp() {
         let sexp_str = r#"(par (ap x y) (fold x y (next)))"#;
         let sexp = Sexp::from_str(sexp_str).unwrap();
-        assert_eq!(format!("{}", sexp), sexp_str);
+        assert_eq!(format!("{sexp}"), sexp_str);
     }
 
     #[test]
     fn test_canon_syntax() {
         let sexp_str = r#"(seq (canon peer_id $stream #canon) (fold #canon i (next)))"#;
         let res = Sexp::from_str(sexp_str);
-        assert!(res.is_ok(), "{:?}", res);
+        assert!(res.is_ok(), "{res:?}");
     }
 
     #[test]
@@ -726,7 +726,7 @@ mod tests {
           "0": null
         } |#"#;
         let res = parse_annotation_comment(multiline_annotation.into());
-        assert!(res.is_ok(), "{:?}", res);
+        assert!(res.is_ok(), "{res:?}");
     }
 
     #[test]

--- a/crates/testing-framework/src/transform/parser.rs
+++ b/crates/testing-framework/src/transform/parser.rs
@@ -580,7 +580,7 @@ mod tests {
   (call peerid ("serv" "func") [a b] var) ; ok=42
   (call peerid2 ("serv" "func") []))"#,
         );
-        assert!(res.is_ok(), "{res:?}");
+        assert!(res.is_ok(), "{}", "{res:?}");
     }
 
     #[test]
@@ -609,7 +609,7 @@ mod tests {
     #[test]
     fn test_trailing_error() {
         let res = Sexp::from_str("(null))");
-        assert!(res.is_err(), "{res:?}");
+        assert!(res.is_err(), "{}", "{res:?}");
     }
 
     #[test]
@@ -683,7 +683,7 @@ mod tests {
     fn test_canon_syntax() {
         let sexp_str = r#"(seq (canon peer_id $stream #canon) (fold #canon i (next)))"#;
         let res = Sexp::from_str(sexp_str);
-        assert!(res.is_ok(), "{res:?}");
+        assert!(res.is_ok(), "{}", "{res:?}");
     }
 
     #[test]
@@ -726,7 +726,7 @@ mod tests {
           "0": null
         } |#"#;
         let res = parse_annotation_comment(multiline_annotation.into());
-        assert!(res.is_ok(), "{res:?}");
+        assert!(res.is_ok(), "{}", "{res:?}");
     }
 
     #[test]

--- a/crates/testing-framework/src/transform/walker.rs
+++ b/crates/testing-framework/src/transform/walker.rs
@@ -94,7 +94,7 @@ impl Transformer<'_> {
 
             match &mut call.triplet.1 {
                 Sexp::String(ref mut value) => {
-                    write!(value, "..{}", call_id).unwrap();
+                    write!(value, "..{call_id}").unwrap();
                 }
                 _ => panic!("Incorrect script: non-string service string not supported"),
             }

--- a/tools/cli/air-trace/src/run.rs
+++ b/tools/cli/air-trace/src/run.rs
@@ -106,7 +106,7 @@ pub(crate) fn run(args: Args) -> anyhow::Result<()> {
             )
             .context("Failed to execute the script")?;
         if args.repeat.is_none() {
-            println!("{:?}", result);
+            println!("{result:?}");
         }
     }
 

--- a/tools/cli/air-trace/src/stats/log_data.rs
+++ b/tools/cli/air-trace/src/stats/log_data.rs
@@ -77,7 +77,7 @@ impl std::fmt::Display for Message {
         match self {
             Message::New => write!(f, "new"),
             Message::Enter => write!(f, "enter"),
-            Message::Close(c) => write!(f, "close {}", c),
+            Message::Close(c) => write!(f, "close {c}"),
         }
     }
 }


### PR DESCRIPTION
Most of changes either move variables into `format!` templates or remove excessive clones.