### PR TITLE
fix(interpreter-cid): Fix interpreter-cid compilation

### DIFF
--- a/crates/air-lib/interpreter-cid/Cargo.toml
+++ b/crates/air-lib/interpreter-cid/Cargo.toml
@@ -13,5 +13,5 @@ categories = ["wasm"]
 [dependencies]
 cid = { version = "0.9.0", default-features = false, features = ["std"] }
 multihash = { version = "0.17.0", default-features = false, features = ["multihash-impl", "std", "sha2"] }
-serde = "1.0.147"
+serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.89"


### PR DESCRIPTION
The serde crate was missing "derive" feature.