### PR TITLE
chore: Fix rust toolchain version

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # AquaVM can be built with "stable", "nightly" required only to build Marine tests
-channel = "nightly"
+channel = "nightly-01-12-2022"
 components = [ "rustfmt", "clippy" ]
 targets = [ "x86_64-unknown-linux-gnu", "x86_64-apple-darwin", "wasm32-wasi" ]
 profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # AquaVM can be built with "stable", "nightly" required only to build Marine tests
-channel = "nightly-01-12-2022"
+channel = "nightly-2022-12-01"
 components = [ "rustfmt", "clippy" ]
 targets = [ "x86_64-unknown-linux-gnu", "x86_64-apple-darwin", "wasm32-wasi" ]
 profile = "minimal"


### PR DESCRIPTION
Newer toolchain enables bulk-memory target feature that is not compatible with our wasmer version.