### PR TITLE
fix(interpreter-interface): Remove the `cid` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Version 0.34.0 (2022-12-26)
+
+[PR 414](https://github.com/fluencelabs/aquavm/pull/414):  
+Remove the `InterpreterOutcome::cid` as it is not really neaded,
+but makes integration more difficult.
+
 ## Version 0.33.0 (2022-12-21)
 
 [PR 401](https://github.com/fluencelabs/aquavm/pull/401):  

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "air"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "air-execution-info-collector",
  "air-interpreter-cid",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "air-interpreter"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "air",
  "air-interpreter-interface",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,9 +126,8 @@ dependencies = [
 
 [[package]]
 name = "air-interpreter-interface"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
- "air-interpreter-cid",
  "fluence-it-types",
  "marine-rs-sdk",
  "serde",
@@ -338,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "avm-interface"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "air-interpreter-interface",
  "air-utils",
@@ -354,7 +353,7 @@ dependencies = [
 
 [[package]]
 name = "avm-server"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "air-interpreter-interface",
  "air-utils",

--- a/air-interpreter/Cargo.toml
+++ b/air-interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "air-interpreter"
-version = "0.33.0"
+version = "0.34.0"
 description = "Crate-wrapper for air"
 authors = ["Fluence Labs"]
 edition = "2018"

--- a/air/Cargo.toml
+++ b/air/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "air"
-version = "0.33.0"
+version = "0.34.0"
 description = "Interpreter of AIR scripts intended to coordinate request flow in the Fluence network"
 authors = ["Fluence Labs"]
 edition = "2018"

--- a/avm/interface/CHANGELOG.md
+++ b/avm/interface/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.1] - 2022-12-26
+
+### Changed
+
+- Bump version of `avm-interpreter-interface` to 0.12.1:
+  it has removed a new `cid` field in the `InterpreterOutcome`.
+
 ## [0.28.0] - 2022-12-21
 
 ### Changed

--- a/avm/interface/Cargo.toml
+++ b/avm/interface/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "avm-interface"
 description = "Fluence AIR VM interfacing"
-version = "0.28.0"
+version = "0.28.1"
 authors = ["Fluence Labs"]
 edition = "2018"
 license = "Apache-2.0"
@@ -15,7 +15,7 @@ name = "avm_interface"
 path = "src/lib.rs"
 
 [dependencies]
-air-interpreter-interface = { version = "0.12.0", path = "../../crates/air-lib/interpreter-interface", default-features = false }
+air-interpreter-interface = { version = "0.12.1", path = "../../crates/air-lib/interpreter-interface", default-features = false }
 air-utils = { version = "0.1.0", path = "../../crates/air-lib/utils" }
 avm-data-store = { version = "0.4.1", path = "../../crates/data-store" }
 polyplets = { version = "0.3.2", path = "../../crates/air-lib/polyplets" }

--- a/avm/interface/src/raw_outcome.rs
+++ b/avm/interface/src/raw_outcome.rs
@@ -41,7 +41,6 @@ impl RawAVMOutcome {
             data,
             call_requests,
             next_peer_pks,
-            cid: _,
         } = outcome;
 
         let call_requests = crate::from_raw_call_requests(call_requests)?;

--- a/avm/server/CHANGELOG.md
+++ b/avm/server/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.1] - 2022-12-26
+
++ Update `avm-interface` version after `air-interpreter-interface` version bump.
+
 ## [0.28.0] - 2022-12-21
 
 + Update `avm-interface` version after `air-interpreter-interface` version bump.

--- a/avm/server/Cargo.toml
+++ b/avm/server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "avm-server"
 description = "Fluence AIR VM"
-version = "0.28.0"
+version = "0.28.1"
 authors = ["Fluence Labs"]
 edition = "2018"
 license = "Apache-2.0"
@@ -15,7 +15,7 @@ name = "avm_server"
 path = "src/lib.rs"
 
 [dependencies]
-air-interpreter-interface = { version = "0.12.0", path = "../../crates/air-lib/interpreter-interface" }
+air-interpreter-interface = { version = "0.12.1", path = "../../crates/air-lib/interpreter-interface" }
 air-utils = { version = "0.1.0", path = "../../crates/air-lib/utils" }
 avm-data-store = { version = "0.4.1", path = "../../crates/data-store" }
 marine-runtime = "0.24.0"

--- a/crates/air-lib/interpreter-interface/CHANGELOG.md
+++ b/crates/air-lib/interpreter-interface/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.1] - 2022-12-26
+
++ Remove the new `cid` field of the `InterpreterOutcome` as it is not really needed.
+
 ## [0.12.0] - 2022-12-21
 
 + New `cid` field of the `InterpreterOutcome` contains CID of the data.

--- a/crates/air-lib/interpreter-interface/Cargo.toml
+++ b/crates/air-lib/interpreter-interface/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "air-interpreter-interface"
 description = "Interface of the AIR interpreter"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Fluence Labs"]
 edition = "2018"
 license = "Apache-2.0"
@@ -15,7 +15,6 @@ name = "air_interpreter_interface"
 path = "src/lib.rs"
 
 [dependencies]
-air-interpreter-cid = { version = "0.1.0", path = "../interpreter-cid" }
 marine-rs-sdk = { version = "0.7.1", optional = true }
 fluence-it-types = { version = "0.3.2", optional = true }
 

--- a/crates/air-lib/interpreter-interface/src/interpreter_outcome.rs
+++ b/crates/air-lib/interpreter-interface/src/interpreter_outcome.rs
@@ -43,9 +43,6 @@ pub struct InterpreterOutcome {
 
     /// Collected parameters of all met call instructions that could be executed on a current peer.
     pub call_requests: Vec<u8>,
-
-    /// IPLD CID of the data field.
-    pub cid: String,
 }
 
 impl InterpreterOutcome {
@@ -56,15 +53,12 @@ impl InterpreterOutcome {
         next_peer_pks: Vec<String>,
         call_requests: Vec<u8>,
     ) -> Self {
-        let cid = air_interpreter_cid::json_data_cid(&data).into();
-
         Self {
             ret_code,
             error_message,
             data,
             next_peer_pks,
             call_requests,
-            cid,
         }
     }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # AquaVM can be built with "stable", "nightly" required only to build Marine tests
-channel = "nightly"
+channel = "nightly-2022-12-01"
 components = [ "rustfmt", "clippy" ]
 targets = [ "x86_64-unknown-linux-gnu", "x86_64-apple-darwin", "wasm32-wasi" ]
 profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # AquaVM can be built with "stable", "nightly" required only to build Marine tests
-channel = "nightly-2022-12-01"
+channel = "nightly"
 components = [ "rustfmt", "clippy" ]
 targets = [ "x86_64-unknown-linux-gnu", "x86_64-apple-darwin", "wasm32-wasi" ]
 profile = "minimal"


### PR DESCRIPTION
The `InterpreterOutcome::cid` field is not really needed, but makes integration more difficult.