### PR TITLE
chore(ci): change pinned rust toolchain version

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # AquaVM can be built with "stable", "nightly" required only to build Marine tests
-channel = "nightly-2022-12-01"
+channel = "nightly-2022-11-01"
 components = [ "rustfmt", "clippy", "rust-src" ]
 targets = [ "x86_64-unknown-linux-gnu", "x86_64-apple-darwin", "wasm32-wasi" ]
 profile = "minimal"


### PR DESCRIPTION
I experienced some problems with the current rust toolchain version:

```
  Compiling once_cell v1.16.0
error[E0463]: can't find crate for `std`

error[E0463]: can't find crate for `core`
```