### PR TITLE
chore(deps): Bump fluence-app-service to 0.23.0

### DIFF
--- a/air/Cargo.toml
+++ b/air/Cargo.toml
@@ -46,7 +46,7 @@ tracing = "0.1.37"
 [dev_dependencies]
 air-test-utils = { path = "../crates/air-lib/test-utils" }
 air-testing-framework = { path = "../crates/testing-framework" }
-fluence-app-service = "0.22.1"
+fluence-app-service = "0.23.0"
 marine-rs-sdk = { version = "0.7.0", features = ["logger"] }
 
 # the feature just silence a warning in the criterion 0.3.x.


### PR DESCRIPTION
In order to fix E2E in marine