### PR TITLE
chore(ci): Notify on release failures and other small CI changes [fixes FLU-222, FLU-194, FLU-41 and FLU-196]

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,8 +12,9 @@
       "enabled": false
     },
     {
-      "matchManagers": ["cargo"],
+      "matchManagers": ["cargo", "npm"],
       "matchPackagePatterns": [
+        "@fluencelabs/.*",
         "fluence-.*",
         "marine-.*",
         "marine"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,6 +8,21 @@
   "schedule": "every weekend",
   "packageRules": [
     {
+      "matchPackagePatterns": ["^@wasmer", "^wasmer", "^wasm-bindgen"],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["cargo"],
+      "matchPackagePatterns": [
+        "fluence-.*",
+        "marine-.*",
+        "marine"
+      ],
+      "semanticCommitType": "fix",
+      "semanticCommitScope": "deps",
+      "schedule": "at any time"
+    },
+    {
       "matchDepTypes": ["devDependencies"],
       "prPriority": -1
     },
@@ -16,14 +31,8 @@
       "prConcurrentLimit": 1
     },
     {
-      "matchManagers": [ "github-actions" ],
-      "automerge": true,
-      "automergeType": "branch",
+      "matchManagers": ["github-actions"],
       "prPriority": 1
-    },
-    {
-      "matchPackagePatterns": ["^@wasmer", "^wasmer", "^wasm-bindgen"],
-      "enabled": false
     }
   ]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: "aquavm"
+name: "Run tests"
 
 on:
   pull_request:
@@ -11,8 +11,9 @@ env:
   RUST_TEST_THREADS: 1
 
 jobs:
-  aquavm:
-    name: "Run tests"
+  tests:
+    name: "aquavm / cargo test"
+    timeout-minutes: 60
     runs-on: builder
 
     steps:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -120,3 +120,28 @@ jobs:
       aqua-version: "${{ needs.aqua.outputs.aqua-version }}"
       fluence-js-version: "${{ needs.fluence-js.outputs.fluence-js-version }}"
       rust-peer-image: "${{ needs.rust-peer.outputs.rust-peer-image }}"
+
+  status:
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - fluence-cli
+      - registry
+      - aqua-playground
+
+    steps:
+      - uses: lwhiteley/dependent-jobs-result-check@v1
+        id: status
+        with:
+          statuses: failure,cancelled
+          dependencies: ${{ toJSON(needs) }}
+
+      - name: Log output
+        run: |
+          echo "statuses:" "${{ steps.status.outputs.statuses }}"
+          echo "jobs:" "${{ steps.status.outputs.jobs }}"
+          echo "found any?:" "${{ steps.status.outputs.found }}"
+
+      - name: Fail run
+        if: fromJSON(steps.status.outputs.found)
+        run: exit 1

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -133,7 +133,7 @@ jobs:
       - uses: lwhiteley/dependent-jobs-result-check@v1
         id: status
         with:
-          statuses: failure,cancelled
+          statuses: failure,cancelled,skipped
           dependencies: ${{ toJSON(needs) }}
 
       - name: Log output

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -288,7 +288,7 @@ jobs:
       - crates
       - air
       - air-interpreter-wasm
-      - air-intepreter
+      - air-interpreter
       - air-beautify-wasm
 
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -322,7 +322,7 @@ jobs:
             kv/slack/release-please webhook | SLACK_WEBHOOK_URL
 
       - uses: ravsamhq/notify-slack-action@v2
-        if: steps.status.outputs.found
+        if: steps.status.outputs.found == true
         with:
           status: "failure"
           notification_title: "*{workflow}* has {status_message}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,6 +171,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: "16"
+          registry-url: "https://registry.npmjs.org"
           cache-dependency-path: avm/client/package-lock.json
           cache: "npm"
 
@@ -271,7 +272,59 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: "16"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Publish to npm registry
         run: npm publish --access public
         working-directory: tools/wasm/air-beautify-wasm/pkg
+
+  slack:
+    if: always()
+    name: "Notify"
+    runs-on: ubuntu-latest
+
+    needs:
+      - release-please
+      - crates
+      - air
+      - air-interpreter-wasm
+      - air-intepreter
+      - air-beautify-wasm
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: lwhiteley/dependent-jobs-result-check@v1
+        id: status
+        with:
+          statuses: failure
+          dependencies: ${{ toJSON(needs) }}
+
+      - name: Log output
+        run: |
+          echo "statuses:" "${{ steps.status.outputs.statuses }}"
+          echo "jobs:" "${{ steps.status.outputs.jobs }}"
+          echo "found any?:" "${{ steps.status.outputs.found }}"
+
+      - name: Import secrets
+        uses: hashicorp/vault-action@v2.4.3
+        with:
+          url: https://vault.fluence.dev
+          path: jwt/github
+          role: ci
+          method: jwt
+          jwtGithubAudience: "https://github.com/fluencelabs"
+          jwtTtl: 300
+          exportToken: false
+          secrets: |
+            kv/slack/release-please webhook | SLACK_WEBHOOK_URL
+
+      - uses: ravsamhq/notify-slack-action@v2
+        if: steps.status.outputs.found
+        with:
+          status: "failure"
+          notification_title: "*{workflow}* has {status_message}"
+          message_format: "${{ steps.status.outputs.jobs }} {status_message} in <{repo_url}|{repo}>"
+          footer: "<{run_url}>"

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -28,6 +28,7 @@ jobs:
   wasm:
     name: "Build air-interpreter-wasm"
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
       - name: Checkout AquaVM
@@ -57,6 +58,7 @@ jobs:
   cargo-snapshot:
     name: "Publish cargo snapshots"
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     needs: wasm
 
@@ -121,6 +123,7 @@ jobs:
   publish-avm:
     name: "Publish @fluencelabs/avm snapshot"
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     needs: wasm
 
@@ -188,6 +191,7 @@ jobs:
   publish-air-beautify:
     name: "Publish air-beautify-wasm snapshot"
     runs-on: builder
+    timeout-minutes: 60
 
     outputs:
       version: "${{ steps.snapshot.outputs.version }}"


### PR DESCRIPTION
Please add `e2e / status` to required checks

- notify on release failure to slack
- run renovate any time for fluencelabs dependencies and use prefix fix(deps) for them
- add `e2e / status` check that should be set as required for PR before merge (please do it in settings before merge)