### PR TITLE
feat(execution-engine)!: make StreamDontHaveSuchGeneration uncatchable…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "air-beautifier"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "air-parser",
  "itertools",
@@ -61,7 +61,7 @@ dependencies = [
 
 [[package]]
 name = "air-beautify"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "air-beautifier",
  "anyhow",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "air-beautify-wasm"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "air-beautifier",
  "wasm-bindgen",
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "air-execution-info-collector"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "air-parser",
 ]
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "air-interpreter-data"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "air-interpreter-cid",
  "air-interpreter-interface",
@@ -168,7 +168,7 @@ version = "0.1.0"
 
 [[package]]
 name = "air-parser"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "air-lambda-ast",
  "air-lambda-parser",
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "air-trace-handler"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "air-interpreter-cid",
  "air-interpreter-data",
@@ -341,7 +341,7 @@ dependencies = [
 
 [[package]]
 name = "avm-interface"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "air-interpreter-interface",
  "air-utils",

--- a/air/src/execution_step/boxed_value/jvaluable/stream.rs
+++ b/air/src/execution_step/boxed_value/jvaluable/stream.rs
@@ -94,11 +94,11 @@ impl<'stream> StreamJvaluableIngredients<'stream> {
     }
 
     pub(self) fn iter(&self) -> ExecutionResult<StreamIter<'_>> {
-        use crate::execution_step::UncatchableError::StreamNotContainNeededGeneration;
+        use crate::execution_step::UncatchableError::StreamDontHaveSuchGeneration;
 
         match self.stream.iter(self.generation) {
             Some(iter) => Ok(iter),
-            None => Err(StreamNotContainNeededGeneration {
+            None => Err(StreamDontHaveSuchGeneration {
                 stream: self.stream.clone(),
                 generation: self.generation,
             }

--- a/air/src/execution_step/boxed_value/jvaluable/stream.rs
+++ b/air/src/execution_step/boxed_value/jvaluable/stream.rs
@@ -94,18 +94,15 @@ impl<'stream> StreamJvaluableIngredients<'stream> {
     }
 
     pub(self) fn iter(&self) -> ExecutionResult<StreamIter<'_>> {
-        use crate::execution_step::CatchableError::StreamDontHaveSuchGeneration;
+        use crate::execution_step::UncatchableError::StreamNotContainNeededGeneration;
 
         match self.stream.iter(self.generation) {
             Some(iter) => Ok(iter),
-            None => {
-                let generation = match self.generation {
-                    Generation::Nth(generation) => generation,
-                    Generation::Last => unreachable!(),
-                };
-
-                Err(StreamDontHaveSuchGeneration(self.stream.clone(), generation as usize).into())
+            None => Err(StreamNotContainNeededGeneration {
+                stream: self.stream.clone(),
+                generation: self.generation,
             }
+            .into()),
         }
     }
 }

--- a/air/src/execution_step/boxed_value/stream.rs
+++ b/air/src/execution_step/boxed_value/stream.rs
@@ -88,7 +88,7 @@ impl Stream {
         };
 
         if generation_number >= self.values.len() {
-            return Err(UncatchableError::StreamNotContainNeededGeneration {
+            return Err(UncatchableError::StreamDontHaveSuchGeneration {
                 stream: self.clone(),
                 generation,
             }
@@ -335,7 +335,7 @@ impl fmt::Display for Generation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Generation::Nth(generation) => write!(f, "{}", generation),
-            Generation::Last => write!(f, "last"),
+            Generation::Last => write!(f, "Last"),
         }
     }
 }

--- a/air/src/execution_step/errors/catchable_errors.rs
+++ b/air/src/execution_step/errors/catchable_errors.rs
@@ -16,7 +16,6 @@
 
 use super::Joinable;
 use super::LastErrorAffectable;
-use super::Stream;
 use crate::execution_step::execution_context::LastErrorObjectError;
 use crate::execution_step::lambda_applier::LambdaError;
 use crate::JValue;
@@ -74,10 +73,6 @@ pub enum CatchableError {
     /// An error occurred while trying to apply lambda to a value.
     #[error(transparent)]
     LambdaApplierError(#[from] LambdaError),
-
-    /// Errors occurred while insertion of a value inside stream that doesn't have corresponding generation.
-    #[error("stream {0:?} doesn't have generation with number {1}, probably a supplied to the interpreter data is corrupted")]
-    StreamDontHaveSuchGeneration(Stream, usize),
 
     /// This error type is produced by a fail instruction that tries to throw a scalar that have inappropriate type.
     #[error(transparent)]

--- a/air/src/execution_step/errors/uncatchable_errors.rs
+++ b/air/src/execution_step/errors/uncatchable_errors.rs
@@ -106,9 +106,9 @@ pub enum UncatchableError {
     /// Errors occurred while insertion of a value inside stream that doesn't have corresponding generation.
     #[error(
         "stream doesn't have generation with number {generation}, supplied to the interpreter data is corrupted,\n\
-             stream is {stream}"
+             stream is {stream:?}"
     )]
-    StreamNotContainNeededGeneration { stream: Stream, generation: Generation },
+    StreamDontHaveSuchGeneration { stream: Stream, generation: Generation },
 }
 
 impl ToErrorCode for UncatchableError {

--- a/air/src/execution_step/errors/uncatchable_errors.rs
+++ b/air/src/execution_step/errors/uncatchable_errors.rs
@@ -105,7 +105,7 @@ pub enum UncatchableError {
 
     /// Errors occurred while insertion of a value inside stream that doesn't have corresponding generation.
     #[error(
-    "stream doesn't have generation with number {generation}, supplied to the interpreter data is corrupted,\n\
+        "stream doesn't have generation with number {generation}, supplied to the interpreter data is corrupted,\n\
              stream is {stream}"
     )]
     StreamNotContainNeededGeneration { stream: Stream, generation: Generation },

--- a/air/src/execution_step/errors/uncatchable_errors.rs
+++ b/air/src/execution_step/errors/uncatchable_errors.rs
@@ -83,13 +83,6 @@ pub enum UncatchableError {
     #[error("new end block tries to pop up a variable '{scalar_name}' that wasn't defined at depth {depth}")]
     ScalarsStateCorrupted { scalar_name: String, depth: usize },
 
-    /// Errors occurred while insertion of a value inside stream that doesn't have corresponding generation.
-    #[error(
-        "stream doesn't have generation with number {generation}, supplied to the interpreter data is corrupted,\n\
-             stream is {stream}"
-    )]
-    StreamNotContainNeededGeneration { stream: Stream, generation: Generation },
-
     /// Variable with such a position wasn't defined during AIR script execution.
     /// Canon instruction requires this value to be present in data, otherwise it's considered
     /// as a hard error.
@@ -109,6 +102,13 @@ pub enum UncatchableError {
     /// and not having any CID is considered a non-catching error.
     #[error("{0} for CID {1:?} not found")]
     ValueForCidNotFound(&'static str, String),
+
+    /// Errors occurred while insertion of a value inside stream that doesn't have corresponding generation.
+    #[error(
+    "stream doesn't have generation with number {generation}, supplied to the interpreter data is corrupted,\n\
+             stream is {stream}"
+    )]
+    StreamNotContainNeededGeneration { stream: Stream, generation: Generation },
 }
 
 impl ToErrorCode for UncatchableError {

--- a/air/src/execution_step/errors/uncatchable_errors.rs
+++ b/air/src/execution_step/errors/uncatchable_errors.rs
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+use super::Stream;
+use crate::execution_step::Generation;
 use crate::JValue;
 use crate::ToErrorCode;
 
@@ -23,6 +25,7 @@ use air_interpreter_data::ValueRef;
 use air_trace_handler::merger::MergerApResult;
 use air_trace_handler::GenerationCompatificationError;
 use air_trace_handler::TraceHandlerError;
+
 use strum::IntoEnumIterator;
 use strum_macros::EnumDiscriminants;
 use strum_macros::EnumIter;
@@ -79,6 +82,13 @@ pub enum UncatchableError {
     /// be caught by a xor instruction.
     #[error("new end block tries to pop up a variable '{scalar_name}' that wasn't defined at depth {depth}")]
     ScalarsStateCorrupted { scalar_name: String, depth: usize },
+
+    /// Errors occurred while insertion of a value inside stream that doesn't have corresponding generation.
+    #[error(
+        "stream doesn't have generation with number {generation}, supplied to the interpreter data is corrupted,\n\
+             stream is {stream}"
+    )]
+    StreamNotContainNeededGeneration { stream: Stream, generation: Generation },
 
     /// Variable with such a position wasn't defined during AIR script execution.
     /// Canon instruction requires this value to be present in data, otherwise it's considered


### PR DESCRIPTION
StreamDontHaveSuchGeneration is a catchable error that could be caught by a xor instruction and then handled by a user. But it makes no sense because this error could arise only iff smth went wrong during merging or when data is corrupted.