### PR TITLE
fix(air): demote some AquaVM logging statements

### DIFF
--- a/air/src/execution_step/errors/catchable_errors.rs
+++ b/air/src/execution_step/errors/catchable_errors.rs
@@ -125,7 +125,7 @@ impl LastErrorAffectable for CatchableError {
 
 macro_rules! log_join {
     ($($args:tt)*) => {
-        log::info!(target: air_log_targets::JOIN_BEHAVIOUR, $($args)*)
+        log::trace!(target: air_log_targets::JOIN_BEHAVIOUR, $($args)*)
     }
 }
 

--- a/air/src/execution_step/instructions/call.rs
+++ b/air/src/execution_step/instructions/call.rs
@@ -68,7 +68,7 @@ fn set_last_error<'i>(
         None => exec_ctx.run_parameters.current_peer_id.to_string(),
     };
 
-    log::warn!(
+    log::debug!(
         "call failed with an error `{}`, peerId `{}`",
         catchable_error,
         current_peer_id

--- a/air/src/execution_step/instructions/xor.rs
+++ b/air/src/execution_step/instructions/xor.rs
@@ -49,5 +49,5 @@ fn print_xor_log(e: &ExecutionError) {
         return;
     }
 
-    log::debug!("xor caught an error: {}", e);
+    log::trace!("xor caught an error: {}", e);
 }

--- a/air/src/execution_step/instructions/xor.rs
+++ b/air/src/execution_step/instructions/xor.rs
@@ -49,5 +49,5 @@ fn print_xor_log(e: &ExecutionError) {
         return;
     }
 
-    log::warn!("xor caught an error: {}", e);
+    log::debug!("xor caught an error: {}", e);
 }


### PR DESCRIPTION
Users complain that `warn` level produces lot of unnecessary logs.
+ join behavior logging is demoted to `trace`;
+ xor logging is demoted to `trace`;
+ service error logging is demoted to `debug`.