### PR TITLE
feat(air-interpreter-signatures): use (de)serialize_with

### DIFF
--- a/crates/air-lib/interpreter-signatures/src/lib.rs
+++ b/crates/air-lib/interpreter-signatures/src/lib.rs
@@ -26,6 +26,8 @@
     unreachable_patterns
 )]
 
+mod sede;
+
 use air_interpreter_cid::CID;
 use fluence_keypair::error::SigningError;
 use fluence_keypair::KeyPair;
@@ -35,43 +37,100 @@ use serde::{Deserialize, Serialize};
 use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::hash::Hash;
+use std::ops::Deref;
 
-/// An opaque serializable representation of public key.
+/// An opaque serializable representation of a public key.
 ///
-/// It can be string or binary, you shouldn't care about it unless you change serialization format.
-// surrent implementation uses string as it is used as a key in a JSON map
-#[derive(Debug, Hash, Clone, Eq, PartialEq, PartialOrd, Deserialize, Serialize)]
-#[serde(transparent)]
-pub struct PublicKey(Box<str>);
+/// It can be a string or a binary, you shouldn't care about it unless you change serialization format.
+// surrent implementation serializes to string as it is used as a key in a JSON map
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub struct PublicKey(
+    #[serde(
+        deserialize_with = "sede::b58_to_public_key",
+        serialize_with = "sede::public_key_to_b58"
+    )]
+    fluence_keypair::PublicKey,
+);
+
+impl PublicKey {
+    pub fn verify<T: Serialize + ?Sized>(
+        &self,
+        value: &T,
+        signature: &fluence_keypair::Signature,
+    ) -> Result<(), fluence_keypair::error::DecodingError> {
+        let pk = &**self;
+
+        let serialized_value =
+            serde_json::to_vec(value).expect("default serialization shouldn't fail");
+
+        pk.verify(&serialized_value, signature).expect("TODO");
+        Ok(())
+    }
+}
+
+impl Deref for PublicKey {
+    type Target = fluence_keypair::PublicKey;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Hash for PublicKey {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.to_vec().hash(state);
+    }
+}
 
 impl From<fluence_keypair::PublicKey> for PublicKey {
     fn from(value: fluence_keypair::PublicKey) -> Self {
-        Self(bs58::encode(&value.to_vec()).into_string().into())
+        Self(value)
     }
 }
 
 /// An opaque serializable representation of signature key.
 ///
 /// It can be string or binary, you shouldn't care about it unless you change serialization format.
-// surrent implementation uses string as more compact in JSON representation than number array
-#[derive(Debug, Hash, Clone, Eq, PartialEq, PartialOrd, Deserialize, Serialize)]
+// surrent implementation serializes string as more compact in JSON representation than number array
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(transparent)]
-pub struct Signature(Box<str>);
+pub struct Signature(
+    #[serde(
+        deserialize_with = "sede::b58_to_signature",
+        serialize_with = "sede::signature_to_b58"
+    )]
+    fluence_keypair::Signature,
+);
 
 impl Signature {
     fn new(signature: fluence_keypair::Signature) -> Self {
-        signature.into()
+        Self(signature)
+    }
+}
+
+impl Deref for Signature {
+    type Target = fluence_keypair::Signature;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 
 impl From<fluence_keypair::Signature> for Signature {
     fn from(value: fluence_keypair::Signature) -> Self {
-        Self(bs58::encode(value.to_vec()).into_string().into())
+        Self(value)
+    }
+}
+
+impl From<Signature> for fluence_keypair::Signature {
+    fn from(value: Signature) -> Self {
+        value.0
     }
 }
 
 #[derive(Debug, Default)]
 pub struct SignatureTracker {
+    // from peer id to CID strings
     peer_to_cids: HashMap<Box<str>, Vec<Box<str>>>,
 }
 

--- a/crates/air-lib/interpreter-signatures/src/lib.rs
+++ b/crates/air-lib/interpreter-signatures/src/lib.rs
@@ -57,14 +57,13 @@ impl PublicKey {
         &self,
         value: &T,
         signature: &fluence_keypair::Signature,
-    ) -> Result<(), fluence_keypair::error::DecodingError> {
+    ) -> Result<(), fluence_keypair::error::VerificationError> {
         let pk = &**self;
 
         let serialized_value =
             serde_json::to_vec(value).expect("default serialization shouldn't fail");
 
-        pk.verify(&serialized_value, signature).expect("TODO");
-        Ok(())
+        pk.verify(&serialized_value, signature)
     }
 }
 

--- a/crates/air-lib/interpreter-signatures/src/sede.rs
+++ b/crates/air-lib/interpreter-signatures/src/sede.rs
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2023 Fluence Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub(crate) fn public_key_to_b58<S: serde::Serializer>(
+    key: &fluence_keypair::PublicKey,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    serializer.serialize_str(&bs58::encode(key.encode()).into_string())
+}
+
+pub(crate) fn b58_to_public_key<'de, D: serde::Deserializer<'de>>(
+    deserializer: D,
+) -> Result<fluence_keypair::PublicKey, D::Error> {
+    deserializer.deserialize_str(PublicKeyVisitor)
+}
+
+/// Visitor who tries to decode base58-encoded string to a fluence_keypair::PublicKey.
+struct PublicKeyVisitor;
+
+impl serde::de::Visitor<'_> for PublicKeyVisitor {
+    type Value = fluence_keypair::PublicKey;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("expecting a base58-encoded public key string")
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        use serde::de;
+
+        let public_key = fluence_keypair::PublicKey::from_base58(v)
+            .map_err(|_| de::Error::invalid_value(de::Unexpected::Str(v), &self))?;
+        Ok(public_key)
+    }
+}
+
+pub(crate) fn signature_to_b58<S: serde::Serializer>(
+    signature: &fluence_keypair::Signature,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    serializer.serialize_str(&bs58::encode(signature.encode()).into_string())
+}
+
+pub(crate) fn b58_to_signature<'de, D: serde::Deserializer<'de>>(
+    deserializer: D,
+) -> Result<fluence_keypair::Signature, D::Error> {
+    deserializer.deserialize_str(SignatureVisitor)
+}
+
+/// Visitor who tries to decode base58-encoded string to a fluence_keypair::Signature.
+struct SignatureVisitor;
+
+impl serde::de::Visitor<'_> for SignatureVisitor {
+    type Value = fluence_keypair::Signature;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("expecting a base58-encoded signature string")
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        use serde::de;
+
+        let sig_bytes = bs58::decode(v)
+            .into_vec()
+            .map_err(|_| de::Error::invalid_value(de::Unexpected::Str(v), &self))?;
+        fluence_keypair::Signature::decode(sig_bytes)
+            .map_err(|_| de::Error::invalid_value(de::Unexpected::Str(v), &self))
+    }
+}


### PR DESCRIPTION
Wrapper types do not hold strings anymore, but use `(de)serialize_with` serde attributes to parse keys and signatures during parse time.

`PublicKey` and `Signature` traits implement `Deref` trait that returns the inner value.