### PR TITLE
chore(execution-engine): move get_unique_map_keys_stream into StreamMap

### DIFF
--- a/air/src/execution_step/boxed_value/stream.rs
+++ b/air/src/execution_step/boxed_value/stream.rs
@@ -323,14 +323,11 @@ mod test {
     use super::Stream;
     use super::ValueAggregate;
     use super::ValueSource;
-    use crate::execution_step::boxed_value::stream_map::from_key_value;
-    use crate::execution_step::execution_context::stream_map_key::StreamMapKey;
     use crate::execution_step::ServiceResultAggregate;
 
     use air_interpreter_cid::CID;
     use serde_json::json;
 
-    use std::borrow::Cow;
     use std::rc::Rc;
 
     #[test]
@@ -410,71 +407,5 @@ mod test {
 
         assert_eq!(stream_value_1, &value_2);
         assert_eq!(stream_value_2, &value_1);
-    }
-
-    #[test]
-    fn test_get_unique_map_keys_stream() {
-        let key_prefix = "some_key".to_string();
-
-        let values = (0..3)
-            .map(|id| {
-                let key = key_prefix.clone() + &id.to_string();
-                let key = StreamMapKey::Str(Cow::Borrowed(key.as_str()));
-                let value = json!([{"top_level": [{"first": 42 + id },{"second": 43 - id}]}]);
-                let obj = from_key_value(key, &value);
-                ValueAggregate::new(
-                    obj,
-                    <_>::default(),
-                    0.into(),
-                    air_interpreter_data::Provenance::literal(),
-                )
-            })
-            .collect::<Vec<_>>();
-        let mut stream = Stream::from_generations_count(5.into(), 5.into());
-        stream
-            .add_value(values[0].clone(), Generation::nth(0), ValueSource::CurrentData)
-            .unwrap();
-        stream
-            .add_value(values[0].clone(), Generation::nth(1), ValueSource::CurrentData)
-            .unwrap();
-        stream
-            .add_value(values[2].clone(), Generation::nth(1), ValueSource::CurrentData)
-            .unwrap();
-        stream
-            .add_value(values[2].clone(), Generation::nth(3), ValueSource::CurrentData)
-            .unwrap();
-        stream
-            .add_value(values[2].clone(), Generation::nth(4), ValueSource::CurrentData)
-            .unwrap();
-        stream
-            .add_value(values[1].clone(), Generation::nth(4), ValueSource::CurrentData)
-            .unwrap();
-
-        let unique_keys_only = stream.get_unique_map_keys_stream();
-        let mut iter = unique_keys_only.iter(Generation::Last).unwrap();
-
-        assert_eq!(&values[0], iter.next().unwrap());
-        assert_eq!(&values[2], iter.next().unwrap());
-        assert_eq!(&values[1], iter.next().unwrap());
-        assert_eq!(iter.next(), None);
-
-        let mut stream = Stream::from_generations_count(5.into(), 5.into());
-        stream
-            .add_value(values[0].clone(), Generation::nth(0), ValueSource::CurrentData)
-            .unwrap();
-        stream
-            .add_value(values[1].clone(), Generation::nth(2), ValueSource::CurrentData)
-            .unwrap();
-        stream
-            .add_value(values[2].clone(), Generation::nth(3), ValueSource::CurrentData)
-            .unwrap();
-
-        let unique_keys_only = stream.get_unique_map_keys_stream();
-        let mut iter = unique_keys_only.iter(Generation::Last).unwrap();
-
-        assert_eq!(&values[0], iter.next().unwrap());
-        assert_eq!(&values[1], iter.next().unwrap());
-        assert_eq!(&values[2], iter.next().unwrap());
-        assert_eq!(iter.next(), None);
     }
 }

--- a/air/src/execution_step/boxed_value/stream.rs
+++ b/air/src/execution_step/boxed_value/stream.rs
@@ -16,16 +16,12 @@
 
 use super::ExecutionResult;
 use super::ValueAggregate;
-use crate::execution_step::execution_context::stream_map_key::StreamMapKey;
 use crate::ExecutionError;
 use crate::UncatchableError;
 
 use air_interpreter_data::GenerationIdx;
 use air_trace_handler::merger::ValueSource;
 use air_trace_handler::TraceHandler;
-
-use std::borrow::Cow;
-use std::collections::HashSet;
 
 /// Streams are CRDT-like append only data structures. They are guaranteed to have the same order
 /// of values on each peer.
@@ -292,7 +288,6 @@ impl<'slice> Iterator for StreamSliceIter<'slice> {
 }
 
 use std::fmt;
-use tracing::Value;
 
 impl fmt::Display for Stream {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/air/src/execution_step/boxed_value/stream_map.rs
+++ b/air/src/execution_step/boxed_value/stream_map.rs
@@ -87,6 +87,7 @@ impl StreamMap {
 
         let mut distinct_keys = HashSet::new();
 
+        // unwrap is safe because slice_iter always returns Some iff generation slice is valid
         let new_values = self
             .stream
             .slice_iter(Generation::Nth(0.into()), Generation::Last)

--- a/air/src/execution_step/boxed_value/stream_map.rs
+++ b/air/src/execution_step/boxed_value/stream_map.rs
@@ -86,9 +86,9 @@ impl StreamMap {
     pub(crate) fn create_unique_keys_stream(&self) -> Stream {
         use std::collections::HashSet;
 
-        let mut meet_keys = HashSet::new();
+        let mut met_keys = HashSet::new();
 
-        // unwrap is safe because slice_iter always returns Some iff generation slice is valid
+        // unwrap is safe because slice_iter always returns Some if supplied generations are valid
         let new_values = self
             .stream
             .slice_iter(Generation::Nth(0.into()), Generation::Last)
@@ -98,7 +98,7 @@ impl StreamMap {
                     .iter()
                     .filter(|v| {
                         StreamMapKey::from_kvpair(v)
-                            .map(|key| meet_keys.insert(key))
+                            .map(|key| met_keys.insert(key))
                             .unwrap_or(false)
                     })
                     .cloned()
@@ -281,52 +281,19 @@ mod test {
 
     #[test]
     fn get_unique_map_keys_stream_removes_duplicates() {
+        use ValueSource::CurrentData;
+
         const TEST_DATA_SIZE: usize = 5;
         let key_values = generate_key_values(TEST_DATA_SIZE);
 
         let mut stream_map = StreamMap::from_generations_count(0.into(), TEST_DATA_SIZE.into());
-        insert_into_map(
-            &mut stream_map,
-            &key_values[0],
-            Generation::nth(0),
-            ValueSource::CurrentData,
-        );
-        insert_into_map(
-            &mut stream_map,
-            &key_values[0],
-            Generation::nth(1),
-            ValueSource::CurrentData,
-        );
-        insert_into_map(
-            &mut stream_map,
-            &key_values[2],
-            Generation::nth(1),
-            ValueSource::CurrentData,
-        );
-        insert_into_map(
-            &mut stream_map,
-            &key_values[2],
-            Generation::nth(3),
-            ValueSource::CurrentData,
-        );
-        insert_into_map(
-            &mut stream_map,
-            &key_values[2],
-            Generation::nth(4),
-            ValueSource::CurrentData,
-        );
-        insert_into_map(
-            &mut stream_map,
-            &key_values[1],
-            Generation::nth(4),
-            ValueSource::CurrentData,
-        );
-        insert_into_map(
-            &mut stream_map,
-            &key_values[3],
-            Generation::nth(2),
-            ValueSource::CurrentData,
-        );
+        insert_into_map(&mut stream_map, &key_values[0], Generation::nth(0), CurrentData);
+        insert_into_map(&mut stream_map, &key_values[0], Generation::nth(1), CurrentData);
+        insert_into_map(&mut stream_map, &key_values[2], Generation::nth(1), CurrentData);
+        insert_into_map(&mut stream_map, &key_values[2], Generation::nth(3), CurrentData);
+        insert_into_map(&mut stream_map, &key_values[2], Generation::nth(4), CurrentData);
+        insert_into_map(&mut stream_map, &key_values[1], Generation::nth(4), CurrentData);
+        insert_into_map(&mut stream_map, &key_values[3], Generation::nth(2), CurrentData);
 
         let unique_keys_only = stream_map.create_unique_keys_stream();
         let mut iter = unique_keys_only.iter(Generation::Last).unwrap();

--- a/air/src/execution_step/boxed_value/stream_map.rs
+++ b/air/src/execution_step/boxed_value/stream_map.rs
@@ -81,6 +81,8 @@ impl StreamMap {
         &mut self.stream
     }
 
+    // TODO: change the implementation to mutate the underlying stream
+    // instead of creating a new one
     pub(crate) fn create_unique_keys_stream(&self) -> Stream {
         use std::collections::HashSet;
 

--- a/air/src/execution_step/instructions/canon.rs
+++ b/air/src/execution_step/instructions/canon.rs
@@ -67,8 +67,7 @@ impl<'i> super::ExecutableInstruction<'i> for ast::Canon<'i> {
                 handle_seen_canon(epilog, canon_result_cid, exec_ctx, trace_ctx)
             }
             MergerCanonResult::Empty => {
-                let get_stream_or_default: Box<GetStreamClosure<'_>> =
-                    get_stream_or_default_function(self.stream.name, self.stream.position);
+                let get_stream_or_default = get_stream_or_default_closure(self.stream.name, self.stream.position);
                 handle_unseen_canon(epilog, &get_stream_or_default, &self.peer_id, exec_ctx, trace_ctx)
             }
         }
@@ -189,7 +188,7 @@ pub(super) type GetStreamClosure<'obj> = dyn for<'ctx> Fn(&'ctx mut ExecutionCtx
 /// or returns a default empty stream,
 /// it is crucial for deterministic behaviour, for more info see
 /// github.com/fluencelabs/aquavm/issues/346.
-fn get_stream_or_default_function<'obj, 'n: 'obj>(
+fn get_stream_or_default_closure<'obj, 'n: 'obj>(
     stream_name: &'n str,
     position: AirPos,
 ) -> Box<GetStreamClosure<'obj>> {

--- a/air/src/execution_step/instructions/canon_stream_map_scalar.rs
+++ b/air/src/execution_step/instructions/canon_stream_map_scalar.rs
@@ -74,8 +74,8 @@ impl<'i> super::ExecutableInstruction<'i> for ast::CanonStreamMapScalar<'i> {
                 handle_seen_canon(epilog, canon_result_cid, exec_ctx, trace_ctx)
             }
             MergerCanonResult::Empty => {
-                let get_stream_or_default: Box<GetStreamClosure<'_>> =
-                    get_stream_or_default_function(self.stream_map.name, self.stream_map.position);
+                let get_stream_or_default =
+                    get_stream_or_default_closure(self.stream_map.name, self.stream_map.position);
                 handle_unseen_canon(epilog, &get_stream_or_default, &self.peer_id, exec_ctx, trace_ctx)
             }
         }
@@ -86,7 +86,7 @@ impl<'i> super::ExecutableInstruction<'i> for ast::CanonStreamMapScalar<'i> {
 /// or returns a default empty stream,
 /// it is crucial for deterministic behaviour, for more info see
 /// github.com/fluencelabs/aquavm/issues/346.
-fn get_stream_or_default_function<'obj, 'n: 'obj>(
+fn get_stream_or_default_closure<'obj, 'n: 'obj>(
     stream_map_name: &'n str,
     position: AirPos,
 ) -> Box<GetStreamClosure<'obj>> {

--- a/air/src/execution_step/instructions/canon_stream_map_scalar.rs
+++ b/air/src/execution_step/instructions/canon_stream_map_scalar.rs
@@ -94,7 +94,7 @@ fn get_stream_or_default_function<'obj, 'n: 'obj>(
         exec_ctx
             .stream_maps
             .get_mut(stream_map_name, position)
-            .map(|stream_map| stream_map.get_unique_map_keys_stream())
+            .map(|stream_map| Cow::Owned(stream_map.create_unique_keys_stream()))
             .or_else(<_>::default)
             .unwrap()
     })


### PR DESCRIPTION
This PR moves the creation of a stream with unique keys from `Stream` to `StreamMap` to improve code isolation. Before this PR `Stream` has known about `StreamMapKey` which wasn't compatible with the dependencies flow.

It is needed in order to support #621. 