### PR TITLE
chore(execution-engine): refactor unseen canon stream creation

### DIFF
--- a/air/src/execution_step/boxed_value/canon_stream.rs
+++ b/air/src/execution_step/boxed_value/canon_stream.rs
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-use super::Stream;
 use super::ValueAggregate;
-use crate::execution_step::Generation;
 use crate::JValue;
 
 use air_interpreter_cid::CID;
@@ -42,9 +40,7 @@ impl CanonStream {
         Self { values, tetraplet }
     }
 
-    pub(crate) fn from_stream(stream: &Stream, peer_pk: String) -> Self {
-        // it's always possible to iter over all generations of a stream
-        let values = stream.iter(Generation::Last).unwrap().cloned().collect::<Vec<_>>();
+    pub(crate) fn from_values(values: Vec<ValueAggregate>, peer_pk: String) -> Self {
         let tetraplet = SecurityTetraplet::new(peer_pk, "", "", "");
         Self {
             values,

--- a/air/src/execution_step/boxed_value/stream.rs
+++ b/air/src/execution_step/boxed_value/stream.rs
@@ -38,13 +38,6 @@ pub struct Stream {
 }
 
 impl Stream {
-    pub(crate) fn new(values: Vec<Vec<ValueAggregate>>, previous_gens_count: usize) -> Self {
-        Self {
-            values,
-            previous_gens_count,
-        }
-    }
-
     pub(crate) fn from_generations_count(previous_count: GenerationIdx, current_count: GenerationIdx) -> Self {
         let last_generation_count = GenerationIdx::from(1);
         // TODO: bubble up an overflow error instead of expect
@@ -217,10 +210,6 @@ impl Stream {
     /// Removes empty generations from current values.
     fn remove_empty_generations(&mut self) {
         self.values.retain(|values| !values.is_empty());
-    }
-
-    pub(crate) fn previous_gens_count(&self) -> usize {
-        self.previous_gens_count
     }
 }
 

--- a/air/src/execution_step/boxed_value/stream_map.rs
+++ b/air/src/execution_step/boxed_value/stream_map.rs
@@ -256,12 +256,12 @@ mod test {
             );
         }
 
-        let mut unique_keys_iter = stream_map.iter_unique_key();
+        let mut iter = stream_map.iter_unique_key();
 
-        assert_eq!(&json!(0), unique_keys_iter.next().unwrap().get_result().get("value").unwrap());
-        assert_eq!(&json!(1), unique_keys_iter.next().unwrap().get_result().get("value").unwrap());
-        assert_eq!(&json!(2), unique_keys_iter.next().unwrap().get_result().get("value").unwrap());
-        assert_eq!(unique_keys_iter.next(), None);
+        assert_eq!(&json!(0), iter.next().unwrap().get_result().get("value").unwrap());
+        assert_eq!(&json!(1), iter.next().unwrap().get_result().get("value").unwrap());
+        assert_eq!(&json!(2), iter.next().unwrap().get_result().get("value").unwrap());
+        assert_eq!(iter.next(), None);
     }
 
     #[test]
@@ -280,12 +280,12 @@ mod test {
         insert_into_map(&mut stream_map, &key_values[1], Generation::nth(4), CurrentData);
         insert_into_map(&mut stream_map, &key_values[3], Generation::nth(2), CurrentData);
 
-        let mut unique_keys_iter = stream_map.iter_unique_key();
+        let mut iter = stream_map.iter_unique_key();
 
-        assert_eq!(&json!(0), unique_keys_iter.next().unwrap().get_result().get("value").unwrap());
-        assert_eq!(&json!(2), unique_keys_iter.next().unwrap().get_result().get("value").unwrap());
-        assert_eq!(&json!(3), unique_keys_iter.next().unwrap().get_result().get("value").unwrap());
-        assert_eq!(&json!(1), unique_keys_iter.next().unwrap().get_result().get("value").unwrap());
-        assert_eq!(unique_keys_iter.next(), None);
+        assert_eq!(&json!(0), iter.next().unwrap().get_result().get("value").unwrap());
+        assert_eq!(&json!(2), iter.next().unwrap().get_result().get("value").unwrap());
+        assert_eq!(&json!(3), iter.next().unwrap().get_result().get("value").unwrap());
+        assert_eq!(&json!(1), iter.next().unwrap().get_result().get("value").unwrap());
+        assert_eq!(iter.next(), None);
     }
 }

--- a/air/src/execution_step/boxed_value/stream_map.rs
+++ b/air/src/execution_step/boxed_value/stream_map.rs
@@ -81,32 +81,18 @@ impl StreamMap {
         &mut self.stream
     }
 
-    // TODO: change the implementation to mutate the underlying stream
-    // instead of creating a new one
-    pub(crate) fn create_unique_keys_stream(&self) -> Stream {
+    /// Returns an iterator to values with unique keys.
+    pub(crate) fn iter_unique_key(&self) -> impl Iterator<Item = &ValueAggregate> {
         use std::collections::HashSet;
 
         let mut met_keys = HashSet::new();
 
-        // unwrap is safe because slice_iter always returns Some if supplied generations are valid
-        let new_values = self
-            .stream
-            .slice_iter(Generation::Nth(0.into()), Generation::Last)
-            .unwrap()
-            .map(|values| {
-                values
-                    .iter()
-                    .filter(|v| {
-                        StreamMapKey::from_kvpair(v)
-                            .map(|key| met_keys.insert(key))
-                            .unwrap_or(false)
-                    })
-                    .cloned()
-                    .collect::<Vec<_>>()
-            })
-            .collect::<Vec<_>>();
-
-        Stream::new(new_values, self.stream.previous_gens_count())
+        // it's always possible to go through all values
+        self.stream.iter(Generation::Last).unwrap().filter(move |value| {
+            StreamMapKey::from_kvpair(value)
+                .map(|key| met_keys.insert(key))
+                .unwrap_or(false)
+        })
     }
 }
 

--- a/air/src/execution_step/boxed_value/stream_map.rs
+++ b/air/src/execution_step/boxed_value/stream_map.rs
@@ -256,13 +256,12 @@ mod test {
             );
         }
 
-        let unique_keys_only = stream_map.create_unique_keys_stream();
-        let mut iter = unique_keys_only.iter(Generation::Last).unwrap();
+        let mut unique_keys_iter = stream_map.iter_unique_key();
 
-        assert_eq!(&json!(0), iter.next().unwrap().get_result().get("value").unwrap());
-        assert_eq!(&json!(1), iter.next().unwrap().get_result().get("value").unwrap());
-        assert_eq!(&json!(2), iter.next().unwrap().get_result().get("value").unwrap());
-        assert_eq!(iter.next(), None);
+        assert_eq!(&json!(0), unique_keys_iter.next().unwrap().get_result().get("value").unwrap());
+        assert_eq!(&json!(1), unique_keys_iter.next().unwrap().get_result().get("value").unwrap());
+        assert_eq!(&json!(2), unique_keys_iter.next().unwrap().get_result().get("value").unwrap());
+        assert_eq!(unique_keys_iter.next(), None);
     }
 
     #[test]
@@ -281,13 +280,12 @@ mod test {
         insert_into_map(&mut stream_map, &key_values[1], Generation::nth(4), CurrentData);
         insert_into_map(&mut stream_map, &key_values[3], Generation::nth(2), CurrentData);
 
-        let unique_keys_only = stream_map.create_unique_keys_stream();
-        let mut iter = unique_keys_only.iter(Generation::Last).unwrap();
+        let mut unique_keys_iter = stream_map.iter_unique_key();
 
-        assert_eq!(&json!(0), iter.next().unwrap().get_result().get("value").unwrap());
-        assert_eq!(&json!(2), iter.next().unwrap().get_result().get("value").unwrap());
-        assert_eq!(&json!(3), iter.next().unwrap().get_result().get("value").unwrap());
-        assert_eq!(&json!(1), iter.next().unwrap().get_result().get("value").unwrap());
-        assert_eq!(iter.next(), None);
+        assert_eq!(&json!(0), unique_keys_iter.next().unwrap().get_result().get("value").unwrap());
+        assert_eq!(&json!(2), unique_keys_iter.next().unwrap().get_result().get("value").unwrap());
+        assert_eq!(&json!(3), unique_keys_iter.next().unwrap().get_result().get("value").unwrap());
+        assert_eq!(&json!(1), unique_keys_iter.next().unwrap().get_result().get("value").unwrap());
+        assert_eq!(unique_keys_iter.next(), None);
     }
 }

--- a/air/src/execution_step/instructions/call/call_result_setter.rs
+++ b/air/src/execution_step/instructions/call/call_result_setter.rs
@@ -39,10 +39,10 @@ pub(crate) fn populate_context_from_peer_service_result<'i>(
     match output {
         CallOutputValue::Scalar(scalar) => {
             let peer_id: Box<str> = tetraplet.peer_pk.as_str().into();
-            let service_result_agg_cid = exec_ctx
-                .cid_state
-                .track_service_result(executed_result.result.clone(), tetraplet, argument_hash)
-                .map_err(UncatchableError::from)?;
+            let service_result_agg_cid =
+                exec_ctx
+                    .cid_state
+                    .track_service_result(executed_result.result.clone(), tetraplet, argument_hash)?;
             let executed_result = ValueAggregate::from_service_result(executed_result, service_result_agg_cid.clone());
 
             exec_ctx.scalars.set_scalar_value(scalar.name, executed_result)?;
@@ -51,10 +51,10 @@ pub(crate) fn populate_context_from_peer_service_result<'i>(
         }
         CallOutputValue::Stream(stream) => {
             let peer_id: Box<str> = tetraplet.peer_pk.as_str().into();
-            let service_result_agg_cid = exec_ctx
-                .cid_state
-                .track_service_result(executed_result.result.clone(), tetraplet, argument_hash)
-                .map_err(UncatchableError::from)?;
+            let service_result_agg_cid =
+                exec_ctx
+                    .cid_state
+                    .track_service_result(executed_result.result.clone(), tetraplet, argument_hash)?;
 
             let executed_result = ValueAggregate::from_service_result(executed_result, service_result_agg_cid.clone());
 

--- a/air/src/execution_step/instructions/call/call_result_setter.rs
+++ b/air/src/execution_step/instructions/call/call_result_setter.rs
@@ -41,7 +41,7 @@ pub(crate) fn populate_context_from_peer_service_result<'i>(
             let peer_id: Box<str> = tetraplet.peer_pk.as_str().into();
             let service_result_agg_cid = exec_ctx
                 .cid_state
-                .insert_value(executed_result.result.clone(), tetraplet, argument_hash)
+                .track_service_result(executed_result.result.clone(), tetraplet, argument_hash)
                 .map_err(UncatchableError::from)?;
             let executed_result = ValueAggregate::from_service_result(executed_result, service_result_agg_cid.clone());
 
@@ -53,7 +53,7 @@ pub(crate) fn populate_context_from_peer_service_result<'i>(
             let peer_id: Box<str> = tetraplet.peer_pk.as_str().into();
             let service_result_agg_cid = exec_ctx
                 .cid_state
-                .insert_value(executed_result.result.clone(), tetraplet, argument_hash)
+                .track_service_result(executed_result.result.clone(), tetraplet, argument_hash)
                 .map_err(UncatchableError::from)?;
 
             let executed_result = ValueAggregate::from_service_result(executed_result, service_result_agg_cid.clone());

--- a/air/src/execution_step/instructions/call/prev_result_handler.rs
+++ b/air/src/execution_step/instructions/call/prev_result_handler.rs
@@ -181,7 +181,7 @@ fn handle_service_error(
     let peer_id: Box<str> = tetraplet.peer_pk.as_str().into();
     let service_result_agg_cid = exec_ctx
         .cid_state
-        .insert_value(failed_value.into(), tetraplet, argument_hash)
+        .track_service_result(failed_value.into(), tetraplet, argument_hash)
         .map_err(UncatchableError::from)?;
 
     exec_ctx.record_call_cid(peer_id, &service_result_agg_cid);
@@ -209,7 +209,7 @@ fn try_to_service_result(
 
             let service_result_agg_cid = exec_ctx
                 .cid_state
-                .insert_value(failed_value.into(), tetraplet.clone(), argument_hash.clone())
+                .track_service_result(failed_value.into(), tetraplet.clone(), argument_hash.clone())
                 .map_err(UncatchableError::from)?;
             let error = CallResult::failed(service_result_agg_cid);
 

--- a/air/src/execution_step/instructions/call/prev_result_handler.rs
+++ b/air/src/execution_step/instructions/call/prev_result_handler.rs
@@ -179,10 +179,10 @@ fn handle_service_error(
     let failed_value = CallServiceFailed::new(service_result.ret_code, error_message).to_value();
 
     let peer_id: Box<str> = tetraplet.peer_pk.as_str().into();
-    let service_result_agg_cid = exec_ctx
-        .cid_state
-        .track_service_result(failed_value.into(), tetraplet, argument_hash)
-        .map_err(UncatchableError::from)?;
+    let service_result_agg_cid =
+        exec_ctx
+            .cid_state
+            .track_service_result(failed_value.into(), tetraplet, argument_hash)?;
 
     exec_ctx.record_call_cid(peer_id, &service_result_agg_cid);
     trace_ctx.meet_call_end(Failed(service_result_agg_cid));
@@ -207,10 +207,11 @@ fn try_to_service_result(
 
             let failed_value = CallServiceFailed::new(i32::MAX, error_msg.clone()).to_value();
 
-            let service_result_agg_cid = exec_ctx
-                .cid_state
-                .track_service_result(failed_value.into(), tetraplet.clone(), argument_hash.clone())
-                .map_err(UncatchableError::from)?;
+            let service_result_agg_cid = exec_ctx.cid_state.track_service_result(
+                failed_value.into(),
+                tetraplet.clone(),
+                argument_hash.clone(),
+            )?;
             let error = CallResult::failed(service_result_agg_cid);
 
             trace_ctx.meet_call_end(error);

--- a/air/src/execution_step/instructions/canon.rs
+++ b/air/src/execution_step/instructions/canon.rs
@@ -49,8 +49,8 @@ impl<'i> super::ExecutableInstruction<'i> for ast::Canon<'i> {
                 handle_seen_canon(epilog, canon_result_cid, exec_ctx, trace_ctx)
             }
             MergerCanonResult::Empty => {
-                let create_canon_stream = create_canon_stream_closure(self.stream.name, self.stream.position);
-                handle_unseen_canon(epilog, &create_canon_stream, &self.peer_id, exec_ctx, trace_ctx)
+                let create_canon_producer = create_canon_stream_producer(self.stream.name, self.stream.position);
+                handle_unseen_canon(epilog, &create_canon_producer, &self.peer_id, exec_ctx, trace_ctx)
             }
         }
     }
@@ -75,7 +75,7 @@ fn epilog_closure(canon_stream_name: &str) -> Box<CanonEpilogClosure<'_>> {
 /// The result closure creates canon stream based on the underlying stream or an empty stream
 /// if no stream created yet. The latter is crucial for deterministic behaviour, for more info see
 /// github.com/fluencelabs/aquavm/issues/346.
-fn create_canon_stream_closure<'closure, 'name: 'closure>(
+fn create_canon_stream_producer<'closure, 'name: 'closure>(
     stream_name: &'name str,
     position: AirPos,
 ) -> Box<CreateCanonStreamClosure<'closure>> {

--- a/air/src/execution_step/instructions/canon.rs
+++ b/air/src/execution_step/instructions/canon.rs
@@ -14,189 +14,80 @@
  * limitations under the License.
  */
 
+use super::canon_utils::handle_seen_canon;
+use super::canon_utils::handle_unseen_canon;
+use super::canon_utils::CanonEpilogClosure;
+use super::canon_utils::CreateCanonStreamClosure;
 use super::ExecutionCtx;
 use super::ExecutionResult;
 use super::TraceHandler;
 use crate::execution_step::boxed_value::CanonStream;
 use crate::execution_step::boxed_value::CanonStreamWithProvenance;
-use crate::execution_step::instructions::resolve_peer_id_to_string;
-use crate::execution_step::Stream;
+use crate::execution_step::Generation;
 use crate::log_instruction;
 use crate::trace_to_exec_err;
-use crate::UncatchableError;
 
 use air_interpreter_cid::CID;
-use air_interpreter_data::CanonCidAggregate;
 use air_interpreter_data::CanonResult;
 use air_interpreter_data::CanonResultCidAggregate;
 use air_parser::ast;
-use air_parser::ast::ResolvableToPeerIdVariable;
 use air_parser::AirPos;
 use air_trace_handler::merger::MergerCanonResult;
 
 use std::borrow::Cow;
 use std::rc::Rc;
 
-pub(super) type CanonEpilogClosure<'ctx> =
-    dyn for<'i> Fn(StreamWithSerializedView, &mut ExecutionCtx<'i>, &mut TraceHandler) -> ExecutionResult<()> + 'ctx;
-
 impl<'i> super::ExecutableInstruction<'i> for ast::Canon<'i> {
     #[tracing::instrument(level = "debug", skip(exec_ctx, trace_ctx))]
     fn execute(&self, exec_ctx: &mut ExecutionCtx<'i>, trace_ctx: &mut TraceHandler) -> ExecutionResult<()> {
         log_instruction!(call, exec_ctx, trace_ctx);
+        let epilog = &epilog_closure(self.canon_stream.name);
         let canon_result = trace_to_exec_err!(trace_ctx.meet_canon_start(), self)?;
-
-        let epilog: &CanonEpilogClosure<'_> = &|stream_with_positions: StreamWithSerializedView,
-                                                exec_ctx: &mut ExecutionCtx<'_>,
-                                                trace_ctx: &mut TraceHandler|
-         -> ExecutionResult<()> {
-            let StreamWithSerializedView {
-                canon_stream,
-                canon_result_cid,
-            } = stream_with_positions;
-
-            let value = CanonStreamWithProvenance::new(canon_stream, canon_result_cid.clone());
-            exec_ctx.scalars.set_canon_value(self.canon_stream.name, value)?;
-
-            trace_ctx.meet_canon_end(CanonResult::new(canon_result_cid));
-            Ok(())
-        };
 
         match canon_result {
             MergerCanonResult::CanonResult(canon_result_cid) => {
                 handle_seen_canon(epilog, canon_result_cid, exec_ctx, trace_ctx)
             }
             MergerCanonResult::Empty => {
-                let get_stream_or_default = get_stream_or_default_closure(self.stream.name, self.stream.position);
-                handle_unseen_canon(epilog, &get_stream_or_default, &self.peer_id, exec_ctx, trace_ctx)
+                let create_canon_stream = create_canon_stream_closure(self.stream.name, self.stream.position);
+                handle_unseen_canon(epilog, &create_canon_stream, &self.peer_id, exec_ctx, trace_ctx)
             }
         }
     }
 }
 
-pub(super) fn handle_seen_canon(
-    epilog: &CanonEpilogClosure<'_>,
-    canon_result_cid: Rc<CID<CanonResultCidAggregate>>,
-    exec_ctx: &mut ExecutionCtx<'_>,
-    trace_ctx: &mut TraceHandler,
-) -> ExecutionResult<()> {
-    let canon_result_agg = exec_ctx.cid_state.get_canon_result_by_cid(&canon_result_cid)?;
-    let tetraplet_cid = canon_result_agg.tetraplet.clone();
-    let tetraplet = exec_ctx.cid_state.get_tetraplet_by_cid(&tetraplet_cid)?;
+fn epilog_closure(canon_stream_name: &str) -> Box<CanonEpilogClosure<'_>> {
+    Box::new(
+        move |canon_stream: CanonStream,
+              canon_result_cid: Rc<CID<CanonResultCidAggregate>>,
+              exec_ctx: &mut ExecutionCtx<'_>,
+              trace_ctx: &mut TraceHandler|
+              -> ExecutionResult<()> {
+            let value = CanonStreamWithProvenance::new(canon_stream, canon_result_cid.clone());
+            exec_ctx.scalars.set_canon_value(canon_stream_name, value)?;
 
-    exec_ctx.record_canon_cid(&*tetraplet.peer_pk, &canon_result_cid);
-
-    let value_cids = canon_result_agg.values.clone();
-    let values = value_cids
-        .iter()
-        .map(|canon_value_cid| exec_ctx.cid_state.get_canon_value_by_cid(canon_value_cid))
-        .collect::<Result<Vec<_>, _>>()?;
-
-    let canon_stream = CanonStream::new(values, tetraplet);
-
-    let canon_stream_with_se = StreamWithSerializedView {
-        canon_stream,
-        canon_result_cid,
-    };
-
-    epilog(canon_stream_with_se, exec_ctx, trace_ctx)
+            trace_ctx.meet_canon_end(CanonResult::new(canon_result_cid));
+            Ok(())
+        },
+    )
 }
 
-pub(super) fn handle_unseen_canon(
-    epilog: &CanonEpilogClosure<'_>,
-    get_stream_or_default: &GetStreamClosure<'_>,
-    peer_id: &ResolvableToPeerIdVariable<'_>,
-    exec_ctx: &mut ExecutionCtx<'_>,
-    trace_ctx: &mut TraceHandler,
-) -> ExecutionResult<()> {
-    let peer_id = resolve_peer_id_to_string(peer_id, exec_ctx)?;
-
-    if exec_ctx.run_parameters.current_peer_id.as_str() != peer_id {
-        exec_ctx.make_subgraph_incomplete();
-        exec_ctx.next_peer_pks.push(peer_id);
-        //this branch is executed only when
-        //  this canon instruction executes for the first time
-        //  a peer is different from one set in peer_id of a this canon instruction
-        //
-        // the former means that there wasn't canon associated state in data, the latter that it
-        // can't be obtained on this peer, so it's intended not to call meet_canon_end here.
-        return Ok(());
-    }
-
-    let stream_with_positions = create_canon_stream_from_name(get_stream_or_default, peer_id, exec_ctx)?;
-    epilog(stream_with_positions, exec_ctx, trace_ctx)
-}
-
-pub(super) struct StreamWithSerializedView {
-    pub(super) canon_stream: CanonStream,
-    pub(super) canon_result_cid: Rc<CID<CanonResultCidAggregate>>,
-}
-
-fn create_canon_stream_from_name(
-    get_stream_or_default: &GetStreamClosure<'_>,
-    peer_id: String,
-    exec_ctx: &mut ExecutionCtx<'_>,
-) -> ExecutionResult<StreamWithSerializedView> {
-    let stream = get_stream_or_default(exec_ctx);
-
-    let canon_stream = CanonStream::from_stream(stream.as_ref(), peer_id);
-
-    let value_cids = canon_stream
-        .iter()
-        .map(|val| -> Result<_, UncatchableError> {
-            let canon_value_aggregate = CanonCidAggregate {
-                value: exec_ctx
-                    .cid_state
-                    .value_tracker
-                    .record_value(val.get_result().clone())?,
-                tetraplet: exec_ctx.cid_state.tetraplet_tracker.record_value(val.get_tetraplet())?,
-                provenance: val.get_provenance(),
-            };
-            Ok(exec_ctx
-                .cid_state
-                .canon_element_tracker
-                .record_value(canon_value_aggregate)?)
-        })
-        .collect::<Result<_, _>>()?;
-    let tetraplet = canon_stream.tetraplet();
-    let tetraplet_cid = exec_ctx
-        .cid_state
-        .tetraplet_tracker
-        .record_value(tetraplet.clone())
-        .map_err(UncatchableError::from)?;
-
-    let canon_result = CanonResultCidAggregate::new(tetraplet_cid, value_cids);
-    let canon_result_cid = exec_ctx
-        .cid_state
-        .canon_result_tracker
-        .record_value(canon_result)
-        .map_err(UncatchableError::from)?;
-
-    exec_ctx.record_canon_cid(&*tetraplet.peer_pk, &canon_result_cid);
-
-    let result = StreamWithSerializedView {
-        canon_stream,
-        canon_result_cid,
-    };
-
-    Ok(result)
-}
-
-pub(super) type GetStreamClosure<'obj> = dyn for<'ctx> Fn(&'ctx mut ExecutionCtx<'_>) -> Cow<'ctx, Stream> + 'obj;
-
-/// The resulting closure gets underlying stream in a context
-/// or returns a default empty stream,
-/// it is crucial for deterministic behaviour, for more info see
+/// The result closure creates canon stream based on the underlying stream or an empty stream
+/// if no stream created yet. The latter is crucial for deterministic behaviour, for more info see
 /// github.com/fluencelabs/aquavm/issues/346.
-fn get_stream_or_default_closure<'obj, 'n: 'obj>(
-    stream_name: &'n str,
+fn create_canon_stream_closure<'closure, 'name: 'closure>(
+    stream_name: &'name str,
     position: AirPos,
-) -> Box<GetStreamClosure<'obj>> {
-    Box::new(move |exec_ctx: &mut ExecutionCtx<'_>| -> Cow<'_, Stream> {
-        exec_ctx
+) -> Box<CreateCanonStreamClosure<'closure>> {
+    Box::new(move |exec_ctx: &mut ExecutionCtx<'_>, peer_pk: String| -> CanonStream {
+        let stream = exec_ctx
             .streams
             .get(stream_name, position)
             .map(Cow::Borrowed)
-            .unwrap_or_default()
+            .unwrap_or_default();
+
+        // it's always possible to iter over all generations of a stream
+        let values = stream.iter(Generation::Last).unwrap().cloned().collect::<Vec<_>>();
+        CanonStream::from_values(values, peer_pk)
     })
 }

--- a/air/src/execution_step/instructions/canon_stream_map_scalar.rs
+++ b/air/src/execution_step/instructions/canon_stream_map_scalar.rs
@@ -51,8 +51,9 @@ impl<'i> super::ExecutableInstruction<'i> for ast::CanonStreamMapScalar<'i> {
                 handle_seen_canon(epilog, canon_result_cid, exec_ctx, trace_ctx)
             }
             MergerCanonResult::Empty => {
-                let create_canon_stream = create_canon_stream_closure(self.stream_map.name, self.stream_map.position);
-                handle_unseen_canon(epilog, &create_canon_stream, &self.peer_id, exec_ctx, trace_ctx)
+                let create_canon_producer =
+                    create_canon_stream_producer(self.stream_map.name, self.stream_map.position);
+                handle_unseen_canon(epilog, &create_canon_producer, &self.peer_id, exec_ctx, trace_ctx)
             }
         }
     }
@@ -83,7 +84,7 @@ fn epilog_closure<'closure, 'name: 'closure>(scalar_name: &'name str) -> Box<Can
 /// The result closure creates canon stream based on the underlying stream or an empty stream
 /// if no stream created yet. The latter is crucial for deterministic behaviour, for more info see
 /// github.com/fluencelabs/aquavm/issues/346.
-fn create_canon_stream_closure<'closure, 'name: 'closure>(
+fn create_canon_stream_producer<'closure, 'name: 'closure>(
     stream_map_name: &'name str,
     position: AirPos,
 ) -> Box<CreateCanonStreamClosure<'closure>> {

--- a/air/src/execution_step/instructions/canon_stream_map_scalar.rs
+++ b/air/src/execution_step/instructions/canon_stream_map_scalar.rs
@@ -14,23 +14,24 @@
  * limitations under the License.
  */
 
-use super::canon::handle_seen_canon;
-use super::canon::handle_unseen_canon;
-use super::canon::GetStreamClosure;
+use super::canon_utils::handle_seen_canon;
+use super::canon_utils::handle_unseen_canon;
+use super::canon_utils::CanonEpilogClosure;
+use super::canon_utils::CreateCanonStreamClosure;
 use super::ExecutionCtx;
 use super::ExecutionResult;
 use super::TraceHandler;
+use crate::execution_step::boxed_value::CanonStream;
 use crate::execution_step::boxed_value::JValuable;
-use crate::execution_step::instructions::canon::CanonEpilogClosure;
-use crate::execution_step::instructions::canon::StreamWithSerializedView;
 use crate::execution_step::CanonResultAggregate;
-use crate::execution_step::Stream;
 use crate::execution_step::ValueAggregate;
 use crate::log_instruction;
 use crate::trace_to_exec_err;
 use crate::UncatchableError;
 
+use air_interpreter_cid::CID;
 use air_interpreter_data::CanonResult;
+use air_interpreter_data::CanonResultCidAggregate;
 use air_parser::ast;
 use air_parser::AirPos;
 use air_trace_handler::merger::MergerCanonResult;
@@ -42,60 +43,58 @@ impl<'i> super::ExecutableInstruction<'i> for ast::CanonStreamMapScalar<'i> {
     #[tracing::instrument(level = "debug", skip(exec_ctx, trace_ctx))]
     fn execute(&self, exec_ctx: &mut ExecutionCtx<'i>, trace_ctx: &mut TraceHandler) -> ExecutionResult<()> {
         log_instruction!(call, exec_ctx, trace_ctx);
+        let epilog = &epilog_closure(self.scalar.name);
         let canon_result = trace_to_exec_err!(trace_ctx.meet_canon_start(), self)?;
-
-        let epilog: &CanonEpilogClosure<'_> = &|stream_with_positions: StreamWithSerializedView,
-                                                exec_ctx: &mut ExecutionCtx<'_>,
-                                                trace_ctx: &mut TraceHandler|
-         -> ExecutionResult<()> {
-            let StreamWithSerializedView {
-                canon_stream,
-                canon_result_cid,
-            } = stream_with_positions;
-
-            let value = JValuable::as_jvalue(&&canon_stream).into_owned();
-            let tetraplet = canon_stream.tetraplet().clone();
-            let position = trace_ctx.trace_pos().map_err(UncatchableError::from)?;
-            let value = CanonResultAggregate::new(
-                Rc::new(value),
-                tetraplet.peer_pk.as_str().into(),
-                &tetraplet.json_path,
-                position,
-            );
-            let result = ValueAggregate::from_canon_result(value, canon_result_cid.clone());
-
-            exec_ctx.scalars.set_scalar_value(self.scalar.name, result)?;
-            trace_ctx.meet_canon_end(CanonResult::new(canon_result_cid));
-            Ok(())
-        };
 
         match canon_result {
             MergerCanonResult::CanonResult(canon_result_cid) => {
                 handle_seen_canon(epilog, canon_result_cid, exec_ctx, trace_ctx)
             }
             MergerCanonResult::Empty => {
-                let get_stream_or_default =
-                    get_stream_or_default_closure(self.stream_map.name, self.stream_map.position);
-                handle_unseen_canon(epilog, &get_stream_or_default, &self.peer_id, exec_ctx, trace_ctx)
+                let create_canon_stream = create_canon_stream_closure(self.stream_map.name, self.stream_map.position);
+                handle_unseen_canon(epilog, &create_canon_stream, &self.peer_id, exec_ctx, trace_ctx)
             }
         }
     }
 }
 
-/// The resulting closure gets underlying stream from a StreamMap in a context
-/// or returns a default empty stream,
-/// it is crucial for deterministic behaviour, for more info see
+fn epilog_closure<'closure, 'name: 'closure>(scalar_name: &'name str) -> Box<CanonEpilogClosure<'closure>> {
+    Box::new(
+        move |canon_stream: CanonStream,
+              canon_result_cid: Rc<CID<CanonResultCidAggregate>>,
+              exec_ctx: &mut ExecutionCtx<'_>,
+              trace_ctx: &mut TraceHandler|
+              -> ExecutionResult<()> {
+            let value = JValuable::as_jvalue(&&canon_stream).into_owned();
+            let tetraplet = canon_stream.tetraplet();
+            let position = trace_ctx.trace_pos().map_err(UncatchableError::from)?;
+            let peer_pk = tetraplet.peer_pk.as_str().into();
+
+            let value = CanonResultAggregate::new(Rc::new(value), peer_pk, &tetraplet.json_path, position);
+            let result = ValueAggregate::from_canon_result(value, canon_result_cid.clone());
+
+            exec_ctx.scalars.set_scalar_value(scalar_name, result)?;
+            trace_ctx.meet_canon_end(CanonResult::new(canon_result_cid));
+            Ok(())
+        },
+    )
+}
+
+/// The result closure creates canon stream based on the underlying stream or an empty stream
+/// if no stream created yet. The latter is crucial for deterministic behaviour, for more info see
 /// github.com/fluencelabs/aquavm/issues/346.
-fn get_stream_or_default_closure<'obj, 'n: 'obj>(
-    stream_map_name: &'n str,
+fn create_canon_stream_closure<'closure, 'name: 'closure>(
+    stream_map_name: &'name str,
     position: AirPos,
-) -> Box<GetStreamClosure<'obj>> {
-    Box::new(move |exec_ctx: &mut ExecutionCtx<'_>| -> Cow<'_, Stream> {
-        exec_ctx
+) -> Box<CreateCanonStreamClosure<'closure>> {
+    Box::new(move |exec_ctx: &mut ExecutionCtx<'_>, peer_pk: String| -> CanonStream {
+        let stream_map = exec_ctx
             .stream_maps
             .get_mut(stream_map_name, position)
-            .map(|stream_map| Cow::Owned(stream_map.create_unique_keys_stream()))
-            .or_else(<_>::default)
-            .unwrap()
+            .map(|stream_map| Cow::Borrowed(stream_map))
+            .unwrap_or_default();
+
+        let values = stream_map.iter_unique_key().cloned().collect::<Vec<_>>();
+        CanonStream::from_values(values, peer_pk)
     })
 }

--- a/air/src/execution_step/instructions/canon_utils/mod.rs
+++ b/air/src/execution_step/instructions/canon_utils/mod.rs
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2022 Fluence Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use crate::execution_step::boxed_value::CanonStream;
+use crate::execution_step::errors::UncatchableError;
+use crate::execution_step::instructions::resolve_peer_id_to_string;
+use crate::execution_step::ExecutionCtx;
+use crate::execution_step::ExecutionResult;
+use crate::execution_step::TraceHandler;
+
+use air_interpreter_cid::CID;
+use air_interpreter_data::CanonResultCidAggregate;
+use air_parser::ast::ResolvableToPeerIdVariable;
+
+use std::rc::Rc;
+
+pub(crate) type CanonEpilogClosure<'closure> = dyn Fn(CanonStream, Rc<CID<CanonResultCidAggregate>>, &mut ExecutionCtx<'_>, &mut TraceHandler) -> ExecutionResult<()>
+    + 'closure;
+
+pub(crate) type CreateCanonStreamClosure<'closure> = dyn Fn(&mut ExecutionCtx<'_>, String) -> CanonStream + 'closure;
+
+pub(crate) fn handle_seen_canon(
+    epilog: &CanonEpilogClosure<'_>,
+    canon_result_cid: Rc<CID<CanonResultCidAggregate>>,
+    exec_ctx: &mut ExecutionCtx<'_>,
+    trace_ctx: &mut TraceHandler,
+) -> ExecutionResult<()> {
+    let canon_result_agg = exec_ctx.cid_state.get_canon_result_by_cid(&canon_result_cid)?;
+    let tetraplet = exec_ctx.cid_state.get_tetraplet_by_cid(&canon_result_agg.tetraplet)?;
+
+    exec_ctx.record_canon_cid(&*tetraplet.peer_pk, &canon_result_cid);
+
+    let value_cids = canon_result_agg.values.clone();
+    let values = value_cids
+        .iter()
+        .map(|canon_value_cid| exec_ctx.cid_state.get_canon_value_by_cid(canon_value_cid))
+        .collect::<Result<Vec<_>, _>>()?;
+    let canon_stream = CanonStream::new(values, tetraplet);
+
+    epilog(canon_stream, canon_result_cid, exec_ctx, trace_ctx)
+}
+
+pub(crate) fn handle_unseen_canon(
+    epilog: &CanonEpilogClosure<'_>,
+    create_canon_stream: &CreateCanonStreamClosure<'_>,
+    peer_id: &ResolvableToPeerIdVariable<'_>,
+    exec_ctx: &mut ExecutionCtx<'_>,
+    trace_ctx: &mut TraceHandler,
+) -> ExecutionResult<()> {
+    let peer_id = resolve_peer_id_to_string(peer_id, exec_ctx)?;
+
+    if exec_ctx.run_parameters.current_peer_id.as_str() != peer_id {
+        exec_ctx.make_subgraph_incomplete();
+        exec_ctx.next_peer_pks.push(peer_id);
+        //this branch is executed only when
+        //  this canon instruction executes for the first time
+        //  a peer is different from one set in peer_id of a this canon instruction
+        //
+        // the former means that there wasn't canon associated state in data, the latter that it
+        // can't be obtained on this peer, so it's intended not to call meet_canon_end here.
+        return Ok(());
+    }
+
+    let canon_stream = create_canon_stream(exec_ctx, peer_id);
+    let canon_result_cid = populate_cid_context(exec_ctx, &canon_stream)?;
+    epilog(canon_stream, canon_result_cid, exec_ctx, trace_ctx)
+}
+
+fn populate_cid_context(
+    exec_ctx: &mut ExecutionCtx<'_>,
+    canon_stream: &CanonStream,
+) -> ExecutionResult<Rc<CID<CanonResultCidAggregate>>> {
+    let value_cids = canon_stream
+        .iter()
+        .map(|canon_value| exec_ctx.cid_state.track_canon_value(canon_value))
+        .collect::<Result<_, _>>()?;
+
+    let tetraplet = canon_stream.tetraplet();
+    let tetraplet_cid = exec_ctx
+        .cid_state
+        .tetraplet_tracker
+        .track_value(tetraplet.clone())
+        .map_err(UncatchableError::from)?;
+
+    let canon_result = CanonResultCidAggregate::new(tetraplet_cid, value_cids);
+    let canon_result_cid = exec_ctx
+        .cid_state
+        .canon_result_tracker
+        .track_value(canon_result)
+        .map_err(UncatchableError::from)?;
+
+    exec_ctx.record_canon_cid(&*tetraplet.peer_pk, &canon_result_cid);
+    Ok(canon_result_cid)
+}

--- a/air/src/execution_step/instructions/canon_utils/mod.rs
+++ b/air/src/execution_step/instructions/canon_utils/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Fluence Labs Limited
+ * Copyright 2023 Fluence Labs Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,8 +69,8 @@ pub(crate) fn handle_unseen_canon(
         //  this canon instruction executes for the first time
         //  a peer is different from one set in peer_id of a this canon instruction
         //
-        // the former means that there wasn't canon associated state in data, the latter that it
-        // can't be obtained on this peer, so it's intended not to call meet_canon_end here.
+        // the former means that there was no canon associated state in data, and the latter means
+        // that it can't be obtained on this peer, so it's intended not to call meet_canon_end here.
         return Ok(());
     }
 

--- a/air/src/execution_step/instructions/mod.rs
+++ b/air/src/execution_step/instructions/mod.rs
@@ -19,6 +19,7 @@ mod ap_map;
 mod call;
 mod canon;
 mod canon_stream_map_scalar;
+mod canon_utils;
 mod compare_matchable;
 mod fail;
 mod fold;

--- a/air/tests/test_module/features/cid/canon.rs
+++ b/air/tests/test_module/features/cid/canon.rs
@@ -267,7 +267,7 @@ fn test_canon_root_tetraplet_not_found() {
 
     let mut fake_tetraplet_tracker = CidTracker::<_>::new();
     fake_tetraplet_tracker
-        .record_value(SecurityTetraplet::literal_tetraplet(other_peer_id))
+        .track_value(SecurityTetraplet::literal_tetraplet(other_peer_id))
         .unwrap();
 
     cid_state.tetraplet_tracker = fake_tetraplet_tracker;
@@ -324,7 +324,7 @@ fn test_canon_tetraplet_not_found() {
 
     let mut fake_tetraplet_tracker = CidTracker::<_>::new();
     fake_tetraplet_tracker
-        .record_value(SecurityTetraplet::literal_tetraplet(init_peer_id))
+        .track_value(SecurityTetraplet::literal_tetraplet(init_peer_id))
         .unwrap();
 
     cid_state.tetraplet_tracker = fake_tetraplet_tracker;

--- a/air/tests/test_module/negative_tests/uncatchable_trace_unrelated.rs
+++ b/air/tests/test_module/negative_tests/uncatchable_trace_unrelated.rs
@@ -137,9 +137,9 @@ fn malformed_call_service_failed() {
 
     // Craft an artificial incorrect error result
     let value = json!("error");
-    let value_cid = cid_state.value_tracker.record_value(value.clone()).unwrap();
+    let value_cid = cid_state.value_tracker.track_value(value.clone()).unwrap();
     let tetraplet = SecurityTetraplet::literal_tetraplet(peer_id);
-    let tetraplet_cid = cid_state.tetraplet_tracker.record_value(tetraplet).unwrap();
+    let tetraplet_cid = cid_state.tetraplet_tracker.track_value(tetraplet).unwrap();
     let service_result_agg = ServiceResultCidAggregate {
         value_cid,
         argument_hash: "0000000000000".into(),
@@ -147,7 +147,7 @@ fn malformed_call_service_failed() {
     };
     let service_result_agg_cid = cid_state
         .service_result_agg_tracker
-        .record_value(service_result_agg)
+        .track_value(service_result_agg)
         .unwrap();
 
     let trace = ExecutionTrace::from(vec![ExecutedState::Call(CallResult::Failed(service_result_agg_cid))]);

--- a/crates/air-lib/interpreter-data/src/cid_store.rs
+++ b/crates/air-lib/interpreter-data/src/cid_store.rs
@@ -78,7 +78,7 @@ impl<Val> CidTracker<Val> {
 }
 
 impl<Val: Serialize> CidTracker<Val> {
-    pub fn record_value(
+    pub fn track_value(
         &mut self,
         value: impl Into<Rc<Val>>,
     ) -> Result<Rc<CID<Val>>, CidCalculationError> {
@@ -123,11 +123,11 @@ mod tests {
     #[test]
     fn test_iter() {
         let mut tracker = CidTracker::new();
-        tracker.record_value(json!("test")).unwrap();
-        tracker.record_value(json!(1)).unwrap();
-        tracker.record_value(json!([1, 2, 3])).unwrap();
+        tracker.track_value(json!("test")).unwrap();
+        tracker.track_value(json!(1)).unwrap();
+        tracker.track_value(json!([1, 2, 3])).unwrap();
         tracker
-            .record_value(json!({
+            .track_value(json!({
                 "key": 42,
             }))
             .unwrap();
@@ -165,11 +165,11 @@ mod tests {
     #[test]
     fn test_store() {
         let mut tracker = CidTracker::new();
-        tracker.record_value(json!("test")).unwrap();
-        tracker.record_value(json!(1)).unwrap();
-        tracker.record_value(json!([1, 2, 3])).unwrap();
+        tracker.track_value(json!("test")).unwrap();
+        tracker.track_value(json!(1)).unwrap();
+        tracker.track_value(json!([1, 2, 3])).unwrap();
         tracker
-            .record_value(json!({
+            .track_value(json!({
                 "key": 42,
             }))
             .unwrap();

--- a/crates/air-lib/interpreter-data/src/executed_state/impls.rs
+++ b/crates/air-lib/interpreter-data/src/executed_state/impls.rs
@@ -119,6 +119,34 @@ impl CanonResultCidAggregate {
     }
 }
 
+impl CanonCidAggregate {
+    pub fn new(
+        value: Rc<CID<serde_json::Value>>,
+        tetraplet: Rc<CID<SecurityTetraplet>>,
+        provenance: Provenance,
+    ) -> Self {
+        Self {
+            value,
+            tetraplet,
+            provenance,
+        }
+    }
+}
+
+impl ServiceResultCidAggregate {
+    pub fn new(
+        value_cid: Rc<CID<JValue>>,
+        argument_hash: Rc<str>,
+        tetraplet_cid: Rc<CID<SecurityTetraplet>>,
+    ) -> Self {
+        Self {
+            value_cid,
+            argument_hash,
+            tetraplet_cid,
+        }
+    }
+}
+
 impl Provenance {
     #[inline]
     pub fn literal() -> Self {

--- a/crates/air-lib/test-utils/src/executed_state.rs
+++ b/crates/air-lib/test-utils/src/executed_state.rs
@@ -48,12 +48,12 @@ pub fn simple_value_aggregate_cid(
 ) -> Rc<CID<ServiceResultCidAggregate>> {
     let value_cid = cid_state
         .value_tracker
-        .record_value(Rc::new(result.into()))
+        .track_value(Rc::new(result.into()))
         .unwrap();
     let tetraplet = SecurityTetraplet::default();
     let tetraplet_cid = cid_state
         .tetraplet_tracker
-        .record_value(Rc::new(tetraplet))
+        .track_value(Rc::new(tetraplet))
         .unwrap();
     let service_result_agg = ServiceResultCidAggregate {
         value_cid,
@@ -62,7 +62,7 @@ pub fn simple_value_aggregate_cid(
     };
     cid_state
         .service_result_agg_tracker
-        .record_value(Rc::new(service_result_agg))
+        .track_value(Rc::new(service_result_agg))
         .unwrap()
 }
 
@@ -74,11 +74,11 @@ pub fn value_aggregate_cid(
 ) -> Rc<CID<ServiceResultCidAggregate>> {
     let value_cid = cid_state
         .value_tracker
-        .record_value(Rc::new(result.into()))
+        .track_value(Rc::new(result.into()))
         .unwrap();
     let tetraplet_cid = cid_state
         .tetraplet_tracker
-        .record_value(Rc::new(tetraplet))
+        .track_value(Rc::new(tetraplet))
         .unwrap();
 
     let arguments = serde_json::Value::Array(args);
@@ -92,7 +92,7 @@ pub fn value_aggregate_cid(
 
     cid_state
         .service_result_agg_tracker
-        .record_value(Rc::new(service_result_agg))
+        .track_value(Rc::new(service_result_agg))
         .unwrap()
 }
 
@@ -169,7 +169,7 @@ pub fn canon_tracked(
         .expect("Malformed canon input");
     let tetraplet_cid = cid_state
         .tetraplet_tracker
-        .record_value(canon_input.tetraplet.clone())
+        .track_value(canon_input.tetraplet.clone())
         .unwrap_or_else(|e| {
             panic!(
                 "{:?}: failed to compute CID of {:?}",
@@ -180,13 +180,13 @@ pub fn canon_tracked(
         .values
         .iter()
         .map(|value| {
-            let value_cid = cid_state.value_tracker.record_value(value.result.clone())?;
+            let value_cid = cid_state.value_tracker.track_value(value.result.clone())?;
             let tetraplet_cid = cid_state
                 .tetraplet_tracker
-                .record_value(value.tetraplet.clone())?;
+                .track_value(value.tetraplet.clone())?;
             cid_state
                 .canon_element_tracker
-                .record_value(CanonCidAggregate {
+                .track_value(CanonCidAggregate {
                     value: value_cid,
                     tetraplet: tetraplet_cid,
                     provenance: value.provenance.clone().unwrap_or_else(Provenance::literal),
@@ -198,7 +198,7 @@ pub fn canon_tracked(
     let canon_result = CanonResultCidAggregate::new(tetraplet_cid, value_cids);
     let canon_result_cid = cid_state
         .canon_result_tracker
-        .record_value(canon_result.clone())
+        .track_value(canon_result.clone())
         .unwrap_or_else(|e| panic!("{:?}: failed to compute CID of {:?}", e, canon_result));
     ExecutedState::Canon(CanonResult::new(canon_result_cid))
 }


### PR DESCRIPTION
- refactor canon instruction implementation
- `get_stream_or_default` creates a new `CanonStream` instead of returning a stream 
- `record_value` renamed to `track_value`

In order to support #621.