### PR TITLE
chore: Add e2e label as fluencebot to trigger e2e

### DIFF
--- a/.github/workflows/e2e-label.yml
+++ b/.github/workflows/e2e-label.yml
@@ -18,5 +18,5 @@ jobs:
         uses: pullreminders/label-when-approved-action@v1.0.7
         env:
           APPROVALS: "1"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.FLUENCEBOT_RELEASE_PLEASE_PAT }}
           ADD_LABEL: "e2e"


### PR DESCRIPTION
bot users (like default github-bot) don't trigger CI