### PR TITLE
chore(testing-framework): clearer triplet error message

### DIFF
--- a/crates/testing-framework/src/transform/parser.rs
+++ b/crates/testing-framework/src/transform/parser.rs
@@ -239,7 +239,7 @@ fn parse_sexp_call_triplet(inp: Input<'_>) -> IResult<Input<'_>, Box<Triplet>, P
             delimited(
                 delim_ws(tag("(")),
                 separated_pair(
-                    context("triplet service name", parse_sexp_string),
+                    context("triplet service name has to be a string", parse_sexp_string),
                     sexp_multispace0,
                     context("triplet function name", parse_sexp),
                 ),


### PR DESCRIPTION
ATM service ID has to be a static string; make it more explicit in the error message.