### PR TITLE
feat(execution-engine)!: this introduces a hardcoded limit for a number of values in a stream [fixes VM-324]

### DIFF
--- a/air/src/execution_step/errors/uncatchable_errors.rs
+++ b/air/src/execution_step/errors/uncatchable_errors.rs
@@ -101,7 +101,7 @@ pub enum UncatchableError {
 
     /// Stream size estimate goes over a hardcoded limit.
     #[error("stream size goes over the allowed limit of {STREAM_MAX_SIZE}")]
-    StreamSizeLimit,
+    StreamSizeLimitExceeded,
 }
 
 impl ToErrorCode for UncatchableError {

--- a/air/src/execution_step/errors/uncatchable_errors.rs
+++ b/air/src/execution_step/errors/uncatchable_errors.rs
@@ -16,6 +16,7 @@
 
 use super::Stream;
 use crate::execution_step::Generation;
+use crate::execution_step::STREAM_MAX_SIZE;
 use crate::ToErrorCode;
 
 use air_interpreter_cid::CidCalculationError;
@@ -97,6 +98,10 @@ pub enum UncatchableError {
 
     #[error("failed to deserialize to CallServiceFailed: {0}")]
     MalformedCallServiceFailed(serde_json::Error),
+
+    /// Stream size estimate goes over a hardcoded limit.
+    #[error("stream size goes over the allowed limit of {STREAM_MAX_SIZE}")]
+    StreamSizeLimit,
 }
 
 impl ToErrorCode for UncatchableError {

--- a/air/src/execution_step/execution_context/stream_maps_variables.rs
+++ b/air/src/execution_step/execution_context/stream_maps_variables.rs
@@ -120,7 +120,7 @@ impl StreamMaps {
         &mut self,
         key: StreamMapKey<'_>,
         value_descriptor: StreamMapValueDescriptor<'_>,
-    ) {
+    ) -> ExecutionResult<()> {
         let StreamMapValueDescriptor {
             value,
             name,
@@ -139,9 +139,10 @@ impl StreamMaps {
                 //  - and by this function, and if there is no such a streams in streams,
                 //    it means that a new global one should be created.
                 let mut stream_map = StreamMap::new();
-                stream_map.insert(key, &value, generation);
+                stream_map.insert(key, &value, generation)?;
                 let descriptor = StreamMapDescriptor::global(stream_map);
                 self.stream_maps.insert(name.to_string(), vec![descriptor]);
+                Ok(())
             }
         }
     }

--- a/air/src/execution_step/instructions/ap.rs
+++ b/air/src/execution_step/instructions/ap.rs
@@ -81,16 +81,12 @@ fn populate_context<'ctx>(
     exec_ctx: &mut ExecutionCtx<'ctx>,
 ) -> ExecutionResult<()> {
     match ap_result {
-        ast::ApResult::Scalar(scalar) => {
-            exec_ctx.scalars.set_scalar_value(scalar.name, result)?;
-        }
+        ast::ApResult::Scalar(scalar) => exec_ctx.scalars.set_scalar_value(scalar.name, result).map(|_| ()),
         ast::ApResult::Stream(stream) => {
             let value_descriptor = generate_value_descriptor(result, stream, merger_ap_result);
-            exec_ctx.streams.add_stream_value(value_descriptor);
+            exec_ctx.streams.add_stream_value(value_descriptor)
         }
-    };
-
-    Ok(())
+    }
 }
 
 fn maybe_update_trace(should_touch_trace: bool, trace_ctx: &mut TraceHandler) {

--- a/air/src/execution_step/instructions/ap_map.rs
+++ b/air/src/execution_step/instructions/ap_map.rs
@@ -45,7 +45,7 @@ impl<'i> super::ExecutableInstruction<'i> for ApMap<'i> {
 
         let merger_ap_result = to_merger_ap_map_result(&self, trace_ctx)?;
         let key = resolve_if_needed(&self.key, exec_ctx, self.map.name)?;
-        populate_context(key, &self.map, &merger_ap_result, result, exec_ctx);
+        populate_context(key, &self.map, &merger_ap_result, result, exec_ctx)?;
         trace_ctx.meet_ap_end(ApResult::stub());
 
         Ok(())
@@ -63,9 +63,9 @@ fn populate_context<'ctx>(
     merger_ap_result: &MergerApResult,
     result: ValueAggregate,
     exec_ctx: &mut ExecutionCtx<'ctx>,
-) {
+) -> ExecutionResult<()> {
     let value_descriptor = generate_map_value_descriptor(result, ap_map_result, merger_ap_result);
-    exec_ctx.stream_maps.add_stream_map_value(key, value_descriptor);
+    exec_ctx.stream_maps.add_stream_map_value(key, value_descriptor)
 }
 
 fn resolve_if_needed<'ctx>(

--- a/air/src/execution_step/instructions/call/call_result_setter.rs
+++ b/air/src/execution_step/instructions/call/call_result_setter.rs
@@ -60,7 +60,7 @@ pub(crate) fn populate_context_from_peer_service_result<'i>(
 
             let value_descriptor =
                 StreamValueDescriptor::new(executed_result, stream.name, Generation::New, stream.position);
-            exec_ctx.streams.add_stream_value(value_descriptor);
+            exec_ctx.streams.add_stream_value(value_descriptor)?;
             exec_ctx.record_call_cid(&*peer_id, &service_result_agg_cid);
             Ok(CallResult::executed_stream_stub(service_result_agg_cid))
         }
@@ -95,7 +95,7 @@ pub(crate) fn populate_context_from_data<'i>(
             let result = ValueAggregate::from_service_result(result, cid);
             let generation = Generation::from_data(value_source, generation);
             let value_descriptor = StreamValueDescriptor::new(result, stream.name, generation, stream.position);
-            exec_ctx.streams.add_stream_value(value_descriptor);
+            exec_ctx.streams.add_stream_value(value_descriptor)?;
         }
         (CallOutputValue::None, ValueRef::Unused(_)) => {}
         (_, value) => {

--- a/air/src/execution_step/mod.rs
+++ b/air/src/execution_step/mod.rs
@@ -51,6 +51,7 @@ pub(super) use value_types::ScalarRef;
 pub(super) use value_types::ServiceResultAggregate;
 pub(super) use value_types::Stream;
 pub(super) use value_types::ValueAggregate;
+pub(self) use value_types::STREAM_MAX_SIZE;
 
 pub(crate) use air_trace_handler::TraceHandler;
 

--- a/air/src/execution_step/value_types/mod.rs
+++ b/air/src/execution_step/value_types/mod.rs
@@ -38,6 +38,7 @@ pub(crate) use stream::Generation;
 pub(crate) use stream::IterableValue;
 pub(crate) use stream::RecursiveCursorState;
 pub(crate) use stream::RecursiveStreamCursor;
+pub(super) use stream::STREAM_MAX_SIZE;
 pub(crate) use stream_map::StreamMap;
 
 pub(crate) use utils::populate_tetraplet_with_lambda;

--- a/air/src/execution_step/value_types/stream/mod.rs
+++ b/air/src/execution_step/value_types/stream/mod.rs
@@ -24,3 +24,4 @@ pub(crate) use recursive_stream::RecursiveStreamCursor;
 pub(crate) use recursive_stream::StreamCursor;
 pub(crate) use stream_definition::Generation;
 pub(crate) use stream_definition::Stream;
+pub(crate) use stream_definition::STREAM_MAX_SIZE;

--- a/air/src/execution_step/value_types/stream/recursive_stream.rs
+++ b/air/src/execution_step/value_types/stream/recursive_stream.rs
@@ -194,7 +194,7 @@ mod test {
         let mut recursive_stream = RecursiveStreamCursor::new();
 
         let value = create_value(json!("1"));
-        stream.add_value(value, Generation::Current(0.into()));
+        stream.add_value(value, Generation::current(0)).unwrap();
 
         let cursor_state = recursive_stream.met_fold_start(&mut stream);
         let iterables = iterables_unwrap(cursor_state);
@@ -210,14 +210,14 @@ mod test {
         let mut recursive_stream = RecursiveStreamCursor::new();
 
         let value = create_value(json!("1"));
-        stream.add_value(value.clone(), Generation::Current(0.into()));
+        stream.add_value(value.clone(), Generation::current(0)).unwrap();
 
         let cursor_state = recursive_stream.met_fold_start(&mut stream);
         let iterables = iterables_unwrap(cursor_state);
         assert_eq!(iterables.len(), 1);
 
-        stream.add_value(value.clone(), Generation::New);
-        stream.add_value(value, Generation::New);
+        stream.add_value(value.clone(), Generation::new()).unwrap();
+        stream.add_value(value, Generation::new()).unwrap();
 
         let cursor_state = recursive_stream.met_iteration_end(&mut stream);
         let iterables = iterables_unwrap(cursor_state);
@@ -233,17 +233,17 @@ mod test {
         let mut recursive_stream = RecursiveStreamCursor::new();
 
         let value = create_value(json!("1"));
-        stream.add_value(value.clone(), Generation::Current(0.into()));
+        stream.add_value(value.clone(), Generation::current(0)).unwrap();
 
         let cursor_state = recursive_stream.met_fold_start(&mut stream);
         assert!(cursor_state.should_continue());
 
-        stream.add_value(value.clone(), Generation::Previous(0.into()));
+        stream.add_value(value.clone(), Generation::previous(0)).unwrap();
 
         let cursor_state = recursive_stream.met_iteration_end(&mut stream);
         assert!(cursor_state.should_continue());
 
-        stream.add_value(value, Generation::Current(1.into()));
+        stream.add_value(value, Generation::current(1)).unwrap();
 
         let cursor_state = recursive_stream.met_iteration_end(&mut stream);
         assert!(cursor_state.should_continue());

--- a/air/src/execution_step/value_types/stream/stream_definition.rs
+++ b/air/src/execution_step/value_types/stream/stream_definition.rs
@@ -81,13 +81,13 @@ impl<'value, T: 'value> Stream<T> {
         use crate::execution_step::ExecutionError;
         use crate::UncatchableError;
 
-        let prev_size_estimate = self.previous_values.get_size();
-        let curr_size_estimate = self.current_values.get_size();
-        let new_size_estimate = self.new_values.get_size();
-        let cumulative_size = prev_size_estimate + curr_size_estimate + new_size_estimate;
+        let prev_size = self.previous_values.get_size();
+        let curr_size = self.current_values.get_size();
+        let new_size = self.new_values.get_size();
+        let cumulative_size = prev_size + curr_size + new_size;
 
         if cumulative_size >= STREAM_MAX_SIZE {
-            Err(ExecutionError::Uncatchable(UncatchableError::StreamSizeLimit))
+            Err(ExecutionError::Uncatchable(UncatchableError::StreamSizeLimitExceeded))
         } else {
             Ok(())
         }
@@ -598,8 +598,7 @@ mod test {
 
         let add_value_result = stream.add_value(value.clone(), Generation::new());
 
-        assert!(matches!(add_value_result, Err(ExecutionError::Uncatchable(_))));
         let Err(ExecutionError::Uncatchable(error)) = add_value_result else { panic!("there must be CatchableError")};
-        assert!(matches!(error, UncatchableError::StreamSizeLimit));
+        assert!(matches!(error, UncatchableError::StreamSizeLimitExceeded));
     }
 }

--- a/air/src/execution_step/value_types/stream/stream_definition.rs
+++ b/air/src/execution_step/value_types/stream/stream_definition.rs
@@ -23,6 +23,10 @@ use crate::execution_step::ExecutionResult;
 use air_interpreter_data::GenerationIdx;
 use air_trace_handler::TraceHandler;
 
+/// This const limits the number of values in a Stream to mitigate
+/// endless recursive stream loop issue.
+pub(crate) const STREAM_MAX_SIZE: usize = 1024;
+
 /// Streams are CRDT-like append only data structures. They are guaranteed to have locally
 /// the same order of values on each peer.
 #[derive(Debug, Clone)]
@@ -72,15 +76,34 @@ impl<'value, T: 'value> Stream<T> {
     pub(super) fn new_values(&mut self) -> &mut NewValuesMatrix<T> {
         &mut self.new_values
     }
+
+    fn check_stream_size_limit(&self) -> ExecutionResult<()> {
+        use crate::execution_step::ExecutionError;
+        use crate::UncatchableError;
+
+        let prev_size_estimate = self.previous_values.get_size();
+        let curr_size_estimate = self.current_values.get_size();
+        let new_size_estimate = self.new_values.get_size();
+        let cumulative_size = prev_size_estimate + curr_size_estimate + new_size_estimate;
+
+        if cumulative_size >= STREAM_MAX_SIZE {
+            Err(ExecutionError::Uncatchable(UncatchableError::StreamSizeLimit))
+        } else {
+            Ok(())
+        }
+    }
 }
 
 impl<'value, T: 'value + Clone + fmt::Display> Stream<T> {
-    pub(crate) fn add_value(&mut self, value: T, generation: Generation) {
+    pub(crate) fn add_value(&mut self, value: T, generation: Generation) -> ExecutionResult<()> {
         match generation {
             Generation::Previous(previous_gen) => self.previous_values.add_value_to_generation(value, previous_gen),
             Generation::Current(current_gen) => self.current_values.add_value_to_generation(value, current_gen),
             Generation::New => self.new_values.add_to_last_generation(value),
         }
+        // This check limits the cumulative number of values in a stream to
+        // prevent neverending recursive stream use case.
+        self.check_stream_size_limit()
     }
 }
 
@@ -244,8 +267,8 @@ mod test {
         let value_2 = create_value(json!("value_2"));
         let mut stream = Stream::new();
 
-        stream.add_value(value_1.clone(), Generation::previous(0));
-        stream.add_value(value_2.clone(), Generation::previous(1));
+        stream.add_value(value_1.clone(), Generation::previous(0)).unwrap();
+        stream.add_value(value_2.clone(), Generation::previous(1)).unwrap();
 
         let mut iter = stream.iter();
         println!("  after getting iter");
@@ -262,10 +285,10 @@ mod test {
         let value_4 = create_value(json!("value_4"));
         let mut stream = Stream::new();
 
-        stream.add_value(value_1.clone(), Generation::previous(0));
-        stream.add_value(value_2.clone(), Generation::previous(0));
-        stream.add_value(value_3.clone(), Generation::previous(0));
-        stream.add_value(value_4.clone(), Generation::previous(0));
+        stream.add_value(value_1.clone(), Generation::previous(0)).unwrap();
+        stream.add_value(value_2.clone(), Generation::previous(0)).unwrap();
+        stream.add_value(value_3.clone(), Generation::previous(0)).unwrap();
+        stream.add_value(value_4.clone(), Generation::previous(0)).unwrap();
 
         let mut slice_iter = stream.slice_iter(StreamCursor::empty());
         assert_eq!(
@@ -283,10 +306,10 @@ mod test {
         let value_4 = create_value(json!("value_4"));
         let mut stream = Stream::new();
 
-        stream.add_value(value_1.clone(), Generation::current(0));
-        stream.add_value(value_2.clone(), Generation::current(0));
-        stream.add_value(value_3.clone(), Generation::current(0));
-        stream.add_value(value_4.clone(), Generation::current(0));
+        stream.add_value(value_1.clone(), Generation::current(0)).unwrap();
+        stream.add_value(value_2.clone(), Generation::current(0)).unwrap();
+        stream.add_value(value_3.clone(), Generation::current(0)).unwrap();
+        stream.add_value(value_4.clone(), Generation::current(0)).unwrap();
 
         let mut slice_iter = stream.slice_iter(StreamCursor::empty());
         assert_eq!(
@@ -304,10 +327,10 @@ mod test {
         let value_4 = create_value(json!("value_4"));
         let mut stream = Stream::new();
 
-        stream.add_value(value_1.clone(), Generation::New);
-        stream.add_value(value_2.clone(), Generation::New);
-        stream.add_value(value_3.clone(), Generation::New);
-        stream.add_value(value_4.clone(), Generation::New);
+        stream.add_value(value_1.clone(), Generation::New).unwrap();
+        stream.add_value(value_2.clone(), Generation::New).unwrap();
+        stream.add_value(value_3.clone(), Generation::New).unwrap();
+        stream.add_value(value_4.clone(), Generation::New).unwrap();
 
         let mut slice_iter = stream.slice_iter(StreamCursor::empty());
         assert_eq!(
@@ -339,8 +362,8 @@ mod test {
         let value_2 = create_value(json!("value_2"));
         let mut stream = Stream::new();
 
-        stream.add_value(value_1.clone(), Generation::current(0));
-        stream.add_value(value_2.clone(), Generation::previous(0));
+        stream.add_value(value_1.clone(), Generation::current(0)).unwrap();
+        stream.add_value(value_2.clone(), Generation::previous(0)).unwrap();
 
         let mut iter = stream.iter();
         assert_eq!(iter.next(), Some(&value_2));
@@ -355,9 +378,9 @@ mod test {
         let value_3 = create_value(json!("value_3"));
         let mut stream = Stream::new();
 
-        stream.add_value(value_1.clone(), Generation::New);
-        stream.add_value(value_2.clone(), Generation::current(0));
-        stream.add_value(value_3.clone(), Generation::previous(0));
+        stream.add_value(value_1.clone(), Generation::new()).unwrap();
+        stream.add_value(value_2.clone(), Generation::current(0)).unwrap();
+        stream.add_value(value_3.clone(), Generation::previous(0)).unwrap();
 
         let mut iter = stream.iter();
         assert_eq!(iter.next(), Some(&value_3));
@@ -373,9 +396,9 @@ mod test {
         let value_3 = create_value(json!("value_3"));
         let mut stream = Stream::new();
 
-        stream.add_value(value_1.clone(), Generation::previous(0));
-        stream.add_value(value_2.clone(), Generation::previous(1));
-        stream.add_value(value_3.clone(), Generation::previous(3));
+        stream.add_value(value_1.clone(), Generation::previous(0)).unwrap();
+        stream.add_value(value_2.clone(), Generation::previous(1)).unwrap();
+        stream.add_value(value_3.clone(), Generation::previous(3)).unwrap();
 
         let mut slice_iter = stream.slice_iter(StreamCursor::empty());
         assert_eq!(slice_iter.next(), Some(vec![value_1].as_slice()));
@@ -391,9 +414,9 @@ mod test {
         let value_3 = create_value(json!("value_3"));
         let mut stream = Stream::new();
 
-        stream.add_value(value_1.clone(), Generation::current(0));
-        stream.add_value(value_2.clone(), Generation::current(1));
-        stream.add_value(value_3.clone(), Generation::current(3));
+        stream.add_value(value_1.clone(), Generation::current(0)).unwrap();
+        stream.add_value(value_2.clone(), Generation::current(1)).unwrap();
+        stream.add_value(value_3.clone(), Generation::current(3)).unwrap();
 
         let mut slice_iter = stream.slice_iter(StreamCursor::empty());
         assert_eq!(slice_iter.next(), Some(vec![value_1].as_slice()));
@@ -408,8 +431,8 @@ mod test {
         let value_2 = create_value_with_pos(json!("value_2"), 1.into());
         let mut stream = Stream::new();
 
-        stream.add_value(value_1.clone(), Generation::previous(0));
-        stream.add_value(value_2.clone(), Generation::New);
+        stream.add_value(value_1.clone(), Generation::previous(0)).unwrap();
+        stream.add_value(value_2.clone(), Generation::new()).unwrap();
 
         let trace = ExecutionTrace::from(vec![]);
         let mut trace_ctx = TraceHandler::from_trace(trace.clone(), trace);
@@ -437,9 +460,9 @@ mod test {
         let value_3 = create_value_with_pos(json!("value_3"), 2.into());
         let mut stream = Stream::new();
 
-        stream.add_value(value_1.clone(), Generation::current(0));
-        stream.add_value(value_2.clone(), Generation::current(2));
-        stream.add_value(value_3.clone(), Generation::current(4));
+        stream.add_value(value_1.clone(), Generation::current(0)).unwrap();
+        stream.add_value(value_2.clone(), Generation::current(2)).unwrap();
+        stream.add_value(value_3.clone(), Generation::current(4)).unwrap();
 
         let trace = ExecutionTrace::from(vec![]);
         let mut trace_ctx = TraceHandler::from_trace(trace.clone(), trace);
@@ -472,12 +495,12 @@ mod test {
         let value_6 = create_value_with_pos(json!("value_3"), 5.into());
         let mut stream = Stream::new();
 
-        stream.add_value(value_1.clone(), Generation::New);
-        stream.add_value(value_2.clone(), Generation::current(4));
-        stream.add_value(value_3.clone(), Generation::current(0));
-        stream.add_value(value_4.clone(), Generation::previous(100));
-        stream.add_value(value_5.clone(), Generation::New);
-        stream.add_value(value_6.clone(), Generation::current(2));
+        stream.add_value(value_1.clone(), Generation::new()).unwrap();
+        stream.add_value(value_2.clone(), Generation::current(4)).unwrap();
+        stream.add_value(value_3.clone(), Generation::current(0)).unwrap();
+        stream.add_value(value_4.clone(), Generation::previous(100)).unwrap();
+        stream.add_value(value_5.clone(), Generation::new()).unwrap();
+        stream.add_value(value_6.clone(), Generation::current(2)).unwrap();
 
         let trace = ExecutionTrace::from(vec![]);
         let mut trace_ctx = TraceHandler::from_trace(trace.clone(), trace);
@@ -511,7 +534,7 @@ mod test {
         let value_1 = create_value(json!("value_1"));
         let mut stream = Stream::new();
 
-        stream.add_value(value_1.clone(), Generation::current(0));
+        stream.add_value(value_1.clone(), Generation::current(0)).unwrap();
 
         let trace = ExecutionTrace::from(vec![]);
         let mut trace_ctx = TraceHandler::from_trace(trace.clone(), trace);
@@ -536,7 +559,7 @@ mod test {
         let value_1 = create_value(json!("value_1"));
         let mut stream = Stream::new();
 
-        stream.add_value(value_1.clone(), Generation::current(0));
+        stream.add_value(value_1.clone(), Generation::current(0)).unwrap();
 
         let trace = ExecutionTrace::from(vec![]);
         let mut trace_ctx = TraceHandler::from_trace(trace.clone(), trace);
@@ -550,5 +573,33 @@ mod test {
                 )
             ))
         ));
+    }
+
+    #[test]
+    fn stream_size_limit() {
+        use super::STREAM_MAX_SIZE;
+        use crate::UncatchableError;
+
+        let mut stream = Stream::new();
+
+        let value = create_value(json!("1"));
+
+        for _ in 0..STREAM_MAX_SIZE / 2 {
+            stream.add_value(value.clone(), Generation::current(0)).unwrap();
+        }
+
+        for _ in 0..STREAM_MAX_SIZE / 4 {
+            stream.add_value(value.clone(), Generation::previous(0)).unwrap();
+        }
+
+        for _ in 0..STREAM_MAX_SIZE / 4 - 1 {
+            stream.add_value(value.clone(), Generation::new()).unwrap();
+        }
+
+        let add_value_result = stream.add_value(value.clone(), Generation::new());
+
+        assert!(matches!(add_value_result, Err(ExecutionError::Uncatchable(_))));
+        let Err(ExecutionError::Uncatchable(error)) = add_value_result else { panic!("there must be CatchableError")};
+        assert!(matches!(error, UncatchableError::StreamSizeLimit));
     }
 }

--- a/air/src/execution_step/value_types/stream/values_matrix.rs
+++ b/air/src/execution_step/value_types/stream/values_matrix.rs
@@ -30,7 +30,7 @@ pub(crate) struct ValuesMatrix<T> {
     /// of values that interpreter obtained from one particle. It means that number of generation on
     /// a peer is equal to number of the interpreter runs in context of one particle.
     values: TiVec<GenerationIdx, Vec<T>>,
-    /// This is a counter to track number of values in the matrix
+    /// This is a counter to track number of values in the matrix.
     size: usize,
 }
 

--- a/air/src/execution_step/value_types/stream/values_matrix.rs
+++ b/air/src/execution_step/value_types/stream/values_matrix.rs
@@ -30,11 +30,16 @@ pub(crate) struct ValuesMatrix<T> {
     /// of values that interpreter obtained from one particle. It means that number of generation on
     /// a peer is equal to number of the interpreter runs in context of one particle.
     values: TiVec<GenerationIdx, Vec<T>>,
+    /// This is a counter to track number of values in the matrix
+    size: usize,
 }
 
 impl<T> ValuesMatrix<T> {
     pub fn new() -> Self {
-        Self { values: TiVec::new() }
+        Self {
+            values: TiVec::new(),
+            size: 0,
+        }
     }
 
     pub fn remove_empty_generations(&mut self) {
@@ -56,6 +61,10 @@ impl<T> ValuesMatrix<T> {
             .skip(skip.into())
             .map(|generation| generation.as_ref())
     }
+
+    pub fn get_size(&self) -> usize {
+        self.size
+    }
 }
 
 impl<T: Clone> ValuesMatrix<T> {
@@ -67,6 +76,7 @@ impl<T: Clone> ValuesMatrix<T> {
         }
 
         self.values[generation_idx].push(value);
+        self.size += 1;
     }
 }
 
@@ -120,6 +130,10 @@ impl<T> NewValuesMatrix<T> {
 
         (values_len - 1).into()
     }
+
+    pub fn get_size(&self) -> usize {
+        self.0.size
+    }
 }
 
 impl<T: Clone> NewValuesMatrix<T> {
@@ -131,7 +145,10 @@ impl<T: Clone> NewValuesMatrix<T> {
 
 impl<T> Default for ValuesMatrix<T> {
     fn default() -> Self {
-        Self { values: TiVec::new() }
+        Self {
+            values: TiVec::new(),
+            size: 0,
+        }
     }
 }
 

--- a/air/src/execution_step/value_types/stream_map.rs
+++ b/air/src/execution_step/value_types/stream_map.rs
@@ -41,7 +41,12 @@ impl StreamMap {
         Self { stream: Stream::new() }
     }
 
-    pub(crate) fn insert(&mut self, key: StreamMapKey<'_>, value: &ValueAggregate, generation: Generation) {
+    pub(crate) fn insert(
+        &mut self,
+        key: StreamMapKey<'_>,
+        value: &ValueAggregate,
+        generation: Generation,
+    ) -> ExecutionResult<()> {
         let obj = from_key_value(key, value.get_result());
         let value = ValueAggregate::new(
             obj,
@@ -129,7 +134,9 @@ mod test {
         let value_aggregate = create_value_aggregate(value.clone());
 
         let mut stream_map = StreamMap::new();
-        stream_map.insert(key.clone(), &value_aggregate, Generation::New);
+        stream_map
+            .insert(key.clone(), &value_aggregate, Generation::New)
+            .unwrap();
         let mut iter = stream_map.stream.iter();
 
         assert!(compare_stream_iter(&mut iter, key, &value));
@@ -143,7 +150,9 @@ mod test {
         let value_aggregate = create_value_aggregate(value.clone());
 
         let mut stream_map = StreamMap::new();
-        stream_map.insert(key.clone(), &value_aggregate, Generation::New);
+        stream_map
+            .insert(key.clone(), &value_aggregate, Generation::New)
+            .unwrap();
         let mut iter = stream_map.stream.iter();
 
         assert!(compare_stream_iter(&mut iter, key, &value));
@@ -160,18 +169,26 @@ mod test {
         let value_aggregate_2 = create_value_aggregate(value_2.clone());
 
         let mut stream_map = StreamMap::new();
-        stream_map.insert(key_1_2.clone(), &value_aggregate_1, Generation::New);
-        stream_map.insert(key_1_2.clone(), &value_aggregate_2, Generation::Current(0.into()));
+        stream_map
+            .insert(key_1_2.clone(), &value_aggregate_1, Generation::new())
+            .unwrap();
+        stream_map
+            .insert(key_1_2.clone(), &value_aggregate_2, Generation::current(0))
+            .unwrap();
 
         let key_3 = StreamMapKey::Str(Cow::Borrowed("other_key"));
         let value_3 = Rc::new(json!("3"));
         let value_aggregate_3 = create_value_aggregate(value_3.clone());
-        stream_map.insert(key_3.clone(), &value_aggregate_3, Generation::Current(0.into()));
+        stream_map
+            .insert(key_3.clone(), &value_aggregate_3, Generation::current(0))
+            .unwrap();
 
         let key_4 = StreamMapKey::I64(42.into());
         let value_4 = Rc::new(json!("4"));
         let value_aggregate_4 = create_value_aggregate(value_4.clone());
-        stream_map.insert(key_4.clone(), &value_aggregate_4, Generation::Current(0.into()));
+        stream_map
+            .insert(key_4.clone(), &value_aggregate_4, Generation::current(0))
+            .unwrap();
 
         let mut iter = stream_map.stream.iter();
 
@@ -191,7 +208,9 @@ mod test {
         let value_aggregate = create_value_aggregate(value.clone());
         let mut stream_map = StreamMap::new();
 
-        stream_map.insert(key, &value_aggregate, Generation::Current(0.into()));
+        stream_map
+            .insert(key, &value_aggregate, Generation::current(0))
+            .unwrap();
 
         let trace = ExecutionTrace::from(vec![]);
         let mut trace_ctx = TraceHandler::from_trace(trace.clone(), trace);
@@ -218,7 +237,9 @@ mod test {
         let value_aggregate = create_value_aggregate(value.clone());
         let mut stream_map = StreamMap::new();
 
-        stream_map.insert(key, &value_aggregate, Generation::current(0));
+        stream_map
+            .insert(key, &value_aggregate, Generation::current(0))
+            .unwrap();
 
         let trace = ExecutionTrace::from(vec![]);
         let mut trace_ctx = TraceHandler::from_trace(trace.clone(), trace);
@@ -252,7 +273,9 @@ mod test {
     }
 
     fn insert_into_map(stream_map: &mut StreamMap, key_value: &(String, ValueAggregate), generation: Generation) {
-        stream_map.insert(key_value.0.as_str().into(), &key_value.1, generation);
+        stream_map
+            .insert(key_value.0.as_str().into(), &key_value.1, generation)
+            .unwrap();
     }
 
     #[test]

--- a/air/tests/test_module/features/streams/recursive_streams.rs
+++ b/air/tests/test_module/features/streams/recursive_streams.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use air::UncatchableError::StreamSizeLimit;
+use air::UncatchableError::StreamSizeLimitExceeded;
 use air_interpreter_data::ExecutionTrace;
 use air_test_framework::AirScriptExecutor;
 use air_test_utils::prelude::*;
@@ -495,6 +495,6 @@ fn recursive_stream_size_limit() {
     let result = executor.execute_all(vm_peer_id_1).unwrap();
     let result = result.last().unwrap();
 
-    let expected_error = StreamSizeLimit;
+    let expected_error = StreamSizeLimitExceeded;
     assert!(check_error(&result, expected_error));
 }

--- a/air/tests/test_module/features/streams/recursive_streams.rs
+++ b/air/tests/test_module/features/streams/recursive_streams.rs
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
+use air::UncatchableError::StreamSizeLimit;
 use air_interpreter_data::ExecutionTrace;
+use air_test_framework::AirScriptExecutor;
 use air_test_utils::prelude::*;
 
 use pretty_assertions::assert_eq;
@@ -469,4 +471,30 @@ fn recursive_stream_fold_with_n_service_call() {
     let expected_fold_lores = stop_request_id + 1;
 
     assert_eq!(actual_fold_state.lore.len(), expected_fold_lores);
+}
+
+#[test]
+fn recursive_stream_size_limit() {
+    let vm_peer_id_1 = "vm_peer_id_1";
+
+    let script = format!(
+        r#"
+        (seq
+            (ap 42 $stream)
+            (fold $stream i
+                (seq
+                    (ap i $stream)
+                    (next i)
+                )
+            )
+        )"#
+    );
+
+    let executor = AirScriptExecutor::from_annotated(TestRunParameters::from_init_peer_id(vm_peer_id_1), &script)
+        .expect("invalid test AIR script");
+    let result = executor.execute_all(vm_peer_id_1).unwrap();
+    let result = result.last().unwrap();
+
+    let expected_error = StreamSizeLimit;
+    assert!(check_error(&result, expected_error));
 }

--- a/air/tests/test_module/negative_tests/uncatchable_trace_unrelated.rs
+++ b/air/tests/test_module/negative_tests/uncatchable_trace_unrelated.rs
@@ -19,6 +19,7 @@ use air::ExecutionCidState;
 use air::UncatchableError::*;
 use air_interpreter_cid::CID;
 use air_interpreter_data::ValueRef;
+use air_test_framework::AirScriptExecutor;
 use air_test_utils::prelude::*;
 
 #[test]
@@ -158,5 +159,31 @@ fn malformed_call_service_failed() {
     let result = vm.call(&air, vec![], data, TestRunParameters::default()).unwrap();
     let expected_serde_error = serde_json::from_value::<CallServiceFailed>(value).unwrap_err();
     let expected_error = MalformedCallServiceFailed(expected_serde_error);
+    assert!(check_error(&result, expected_error));
+}
+
+#[test]
+fn recursive_stream_size_limit() {
+    let vm_peer_id_1 = "vm_peer_id_1";
+
+    let script = format!(
+        r#"
+        (seq
+            (ap 42 $stream)
+            (fold $stream i
+                (seq
+                    (ap i $stream)
+                    (next i)
+                )
+            )
+        )"#
+    );
+
+    let executor = AirScriptExecutor::from_annotated(TestRunParameters::from_init_peer_id(vm_peer_id_1), &script)
+        .expect("invalid test AIR script");
+    let result = executor.execute_all(vm_peer_id_1).unwrap();
+    let result = result.last().unwrap();
+
+    let expected_error = StreamSizeLimit;
     assert!(check_error(&result, expected_error));
 }

--- a/air/tests/test_module/negative_tests/uncatchable_trace_unrelated.rs
+++ b/air/tests/test_module/negative_tests/uncatchable_trace_unrelated.rs
@@ -184,6 +184,6 @@ fn recursive_stream_size_limit() {
     let result = executor.execute_all(vm_peer_id_1).unwrap();
     let result = result.last().unwrap();
 
-    let expected_error = StreamSizeLimit;
+    let expected_error = StreamSizeLimitExceeded;
     assert!(check_error(&result, expected_error));
 }


### PR DESCRIPTION
The Stream size limit controls how many values can be stored in a Stream to resolve self-feeding recursive stream case. The example below now stops after 1024 fold iterations.
```
(seq
    (ap 42 $stream)
    (fold $stream i
        (seq
            (ap i $stream)
            (next i)
        )
    ) 
)
```