### PR TITLE
fix(aquavm-air-cli): NEAR mode fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ dependencies = [
  "newtype_derive",
  "num-traits",
  "once_cell",
- "polyplets 0.4.1",
+ "polyplets 0.5.0",
  "semver 1.0.18",
  "serde",
  "serde_json",
@@ -216,7 +216,7 @@ dependencies = [
  "bimap",
  "log",
  "num-traits",
- "polyplets 0.4.1",
+ "polyplets 0.5.0",
  "serde_json",
  "thiserror",
  "tracing",
@@ -345,7 +345,7 @@ dependencies = [
  "marine-rs-sdk",
  "non-empty-vec",
  "once_cell",
- "polyplets 0.4.1",
+ "polyplets 0.5.0",
  "pretty_assertions 0.6.1",
  "semver 1.0.18",
  "serde",
@@ -573,7 +573,7 @@ dependencies = [
  "air-utils",
  "log",
  "maplit",
- "polyplets 0.4.1",
+ "polyplets 0.5.0",
  "serde",
  "serde_json",
  "thiserror",
@@ -594,7 +594,7 @@ dependencies = [
  "maplit",
  "marine-runtime",
  "parking_lot 0.12.1",
- "polyplets 0.4.1",
+ "polyplets 0.5.0",
  "serde",
  "serde_json",
  "thiserror",
@@ -4101,7 +4101,7 @@ dependencies = [
 
 [[package]]
 name = "polyplets"
-version = "0.5.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b579a79a461ca50abb202eac61c76d8782fdf091a91775c9e181352e7cd30a8b"
 dependencies = [

--- a/tools/cli/air/src/trace/run.rs
+++ b/tools/cli/air/src/trace/run.rs
@@ -61,7 +61,7 @@ pub(crate) struct Args {
     #[clap(
         long = "near-contract",
         env = "AIR_NEAR_CONTRACT_PATH",
-        default_value = "tools/wasm/air-near-contract/target/wasm32-unknown-unknown/release/aqua_vm.wasm"
+        default_value = "tools/wasm/air-near-contract/target/wasm32-unknown-unknown/release/air-near-contract.wasm"
     )]
     air_near_contract_path: PathBuf,
 

--- a/tools/wasm/air-near-contract/Cargo.lock
+++ b/tools/wasm/air-near-contract/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
  "newtype_derive",
  "num-traits",
  "once_cell",
- "polyplets 0.4.1",
+ "polyplets 0.5.0",
  "semver 1.0.18",
  "serde",
  "serde_json",
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "air-interpreter-interface"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "fluence-it-types",
  "marine-rs-sdk",
@@ -133,7 +133,7 @@ dependencies = [
  "bimap",
  "log",
  "num-traits",
- "polyplets 0.4.1",
+ "polyplets 0.5.0",
  "serde_json",
  "thiserror",
  "tracing",
@@ -179,7 +179,7 @@ dependencies = [
  "maplit",
  "non-empty-vec",
  "once_cell",
- "polyplets 0.4.1",
+ "polyplets 0.5.0",
  "semver 1.0.18",
  "serde",
  "serde_json",
@@ -1627,7 +1627,7 @@ dependencies = [
 
 [[package]]
 name = "polyplets"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "marine-rs-sdk",
  "serde",


### PR DESCRIPTION
1. Correct default contract path.
2. More informative error messages.
3. Deserialize contract result correctly.