### PR TITLE
feat(execution-engine,interpreter-data)!: insert state for canon join

### DIFF
--- a/air/src/execution_step/instructions/canon.rs
+++ b/air/src/execution_step/instructions/canon.rs
@@ -43,12 +43,18 @@ impl<'i> super::ExecutableInstruction<'i> for ast::Canon<'i> {
         let epilog = &epilog_closure(self.canon_stream.name);
         let canon_result = trace_to_exec_err!(trace_ctx.meet_canon_start(), self)?;
 
+        // TODO return some command instead to create producer or insert command or ...
+        let create_canon_producer = create_canon_stream_producer(self.stream.name, self.stream.position);
         match canon_result {
-            MergerCanonResult::CanonResult(canon_result_cid) => {
-                handle_seen_canon(epilog, canon_result_cid, exec_ctx, trace_ctx)
-            }
+            MergerCanonResult::CanonResult(canon_result) => handle_seen_canon(
+                epilog,
+                &create_canon_producer,
+                canon_result,
+                &self.peer_id,
+                exec_ctx,
+                trace_ctx,
+            ),
             MergerCanonResult::Empty => {
-                let create_canon_producer = create_canon_stream_producer(self.stream.name, self.stream.position);
                 handle_unseen_canon(epilog, &create_canon_producer, &self.peer_id, exec_ctx, trace_ctx)
             }
         }
@@ -65,7 +71,7 @@ fn epilog_closure(canon_stream_name: &str) -> Box<CanonEpilogClosure<'_>> {
             let value = CanonStreamWithProvenance::new(canon_stream, canon_result_cid.clone());
             exec_ctx.scalars.set_canon_value(canon_stream_name, value)?;
 
-            trace_ctx.meet_canon_end(CanonResult::new(canon_result_cid));
+            trace_ctx.meet_canon_end(CanonResult::executed(canon_result_cid));
             Ok(())
         },
     )

--- a/air/src/execution_step/instructions/canon_utils/mod.rs
+++ b/air/src/execution_step/instructions/canon_utils/mod.rs
@@ -103,7 +103,7 @@ pub(crate) fn handle_unseen_canon(
         exec_ctx.make_subgraph_incomplete();
         exec_ctx.next_peer_pks.push(peer_id);
 
-        trace_ctx.meet_canon_end(CanonResult::send_request_by(
+        trace_ctx.meet_canon_end(CanonResult::request_sent_by(
             exec_ctx.run_parameters.current_peer_id.clone(),
         ));
         Ok(())

--- a/air/src/execution_step/instructions/canon_utils/mod.rs
+++ b/air/src/execution_step/instructions/canon_utils/mod.rs
@@ -65,7 +65,7 @@ pub(crate) fn handle_canon_request_sent_by(
         trace_ctx.meet_canon_end(canon_result);
         Ok(())
     } else {
-        instantiate_canon_stream(epilog, create_canon_stream, peer_id, exec_ctx, trace_ctx)
+        create_canon_stream_for_first_time(epilog, create_canon_stream, peer_id, exec_ctx, trace_ctx)
     }
 }
 
@@ -103,17 +103,15 @@ pub(crate) fn handle_unseen_canon(
         exec_ctx.make_subgraph_incomplete();
         exec_ctx.next_peer_pks.push(peer_id);
 
-        trace_ctx.meet_canon_end(CanonResult::request_sent_by(
-            exec_ctx.run_parameters.current_peer_id.clone(),
-        ));
+        let canon_result = CanonResult::request_sent_by(exec_ctx.run_parameters.current_peer_id.clone());
+        trace_ctx.meet_canon_end(canon_result);
         Ok(())
     } else {
-        instantiate_canon_stream(epilog, create_canon_stream, peer_id, exec_ctx, trace_ctx)
+        create_canon_stream_for_first_time(epilog, create_canon_stream, peer_id, exec_ctx, trace_ctx)
     }
 }
 
-// TODO rename
-fn instantiate_canon_stream(
+fn create_canon_stream_for_first_time(
     epilog: &CanonEpilogClosure<'_>,
     create_canon_stream: &CreateCanonStreamClosure<'_>,
     peer_id: String,

--- a/air/src/execution_step/instructions/canon_utils/mod.rs
+++ b/air/src/execution_step/instructions/canon_utils/mod.rs
@@ -22,6 +22,7 @@ use crate::execution_step::ExecutionResult;
 use crate::execution_step::TraceHandler;
 
 use air_interpreter_cid::CID;
+use air_interpreter_data::CanonResult;
 use air_interpreter_data::CanonResultCidAggregate;
 use air_parser::ast::ResolvableToPeerIdVariable;
 
@@ -33,6 +34,42 @@ pub(crate) type CanonEpilogClosure<'closure> = dyn Fn(CanonStream, Rc<CID<CanonR
 pub(crate) type CreateCanonStreamClosure<'closure> = dyn Fn(&mut ExecutionCtx<'_>, String) -> CanonStream + 'closure;
 
 pub(crate) fn handle_seen_canon(
+    epilog: &CanonEpilogClosure<'_>,
+    create_canon_stream: &CreateCanonStreamClosure<'_>,
+    canon_result: CanonResult,
+    peer_id: &ResolvableToPeerIdVariable<'_>,
+    exec_ctx: &mut ExecutionCtx<'_>,
+    trace_ctx: &mut TraceHandler,
+) -> ExecutionResult<()> {
+    match canon_result {
+        CanonResult::RequestSentBy(..) => {
+            handle_canon_request_sent_by(epilog, create_canon_stream, peer_id, canon_result, exec_ctx, trace_ctx)
+        }
+        CanonResult::Executed(canon_result_cid) => handle_canon_executed(epilog, canon_result_cid, exec_ctx, trace_ctx),
+    }
+}
+
+pub(crate) fn handle_canon_request_sent_by(
+    epilog: &CanonEpilogClosure<'_>,
+    create_canon_stream: &CreateCanonStreamClosure<'_>,
+    peer_id: &ResolvableToPeerIdVariable<'_>,
+    canon_result: CanonResult,
+    exec_ctx: &mut ExecutionCtx<'_>,
+    trace_ctx: &mut TraceHandler,
+) -> ExecutionResult<()> {
+    let peer_id = resolve_peer_id_to_string(peer_id, exec_ctx)?;
+
+    if exec_ctx.run_parameters.current_peer_id.as_str() != peer_id {
+        // nothing to execute yet; just leave the canon_result as is
+        exec_ctx.make_subgraph_incomplete();
+        trace_ctx.meet_canon_end(canon_result);
+        Ok(())
+    } else {
+        instantiate_canon_stream(epilog, create_canon_stream, peer_id, exec_ctx, trace_ctx)
+    }
+}
+
+pub(crate) fn handle_canon_executed(
     epilog: &CanonEpilogClosure<'_>,
     canon_result_cid: Rc<CID<CanonResultCidAggregate>>,
     exec_ctx: &mut ExecutionCtx<'_>,
@@ -65,15 +102,24 @@ pub(crate) fn handle_unseen_canon(
     if exec_ctx.run_parameters.current_peer_id.as_str() != peer_id {
         exec_ctx.make_subgraph_incomplete();
         exec_ctx.next_peer_pks.push(peer_id);
-        //this branch is executed only when
-        //  this canon instruction executes for the first time
-        //  a peer is different from one set in peer_id of a this canon instruction
-        //
-        // the former means that there was no canon associated state in data, and the latter means
-        // that it can't be obtained on this peer, so it's intended not to call meet_canon_end here.
-        return Ok(());
-    }
 
+        trace_ctx.meet_canon_end(CanonResult::send_request_by(
+            exec_ctx.run_parameters.current_peer_id.clone(),
+        ));
+        Ok(())
+    } else {
+        instantiate_canon_stream(epilog, create_canon_stream, peer_id, exec_ctx, trace_ctx)
+    }
+}
+
+// TODO rename
+fn instantiate_canon_stream(
+    epilog: &CanonEpilogClosure<'_>,
+    create_canon_stream: &CreateCanonStreamClosure<'_>,
+    peer_id: String,
+    exec_ctx: &mut ExecutionCtx<'_>,
+    trace_ctx: &mut TraceHandler,
+) -> ExecutionResult<()> {
     let canon_stream = create_canon_stream(exec_ctx, peer_id);
     let canon_result_cid = populate_cid_context(exec_ctx, &canon_stream)?;
     epilog(canon_stream, canon_result_cid, exec_ctx, trace_ctx)

--- a/air/src/execution_step/value_types/stream/stream_definition.rs
+++ b/air/src/execution_step/value_types/stream/stream_definition.rs
@@ -515,7 +515,7 @@ mod test {
 
         let trace = ExecutionTrace::from(vec![]);
         let mut trace_ctx = TraceHandler::from_trace(trace.clone(), trace);
-        let canon_result = CanonResult(Rc::new(CID::new("fake canon CID")));
+        let canon_result = CanonResult::executed(Rc::new(CID::new("fake canon CID")));
         trace_ctx.meet_canon_end(canon_result.clone());
         trace_ctx.meet_canon_end(canon_result.clone());
         trace_ctx.meet_canon_end(canon_result);

--- a/air/src/execution_step/value_types/stream_map.rs
+++ b/air/src/execution_step/value_types/stream_map.rs
@@ -195,7 +195,7 @@ mod test {
 
         let trace = ExecutionTrace::from(vec![]);
         let mut trace_ctx = TraceHandler::from_trace(trace.clone(), trace);
-        let canon_result = CanonResult(Rc::new(CID::new("fake canon CID")));
+        let canon_result = CanonResult::executed(Rc::new(CID::new("fake canon CID")));
         trace_ctx.meet_canon_end(canon_result.clone());
         trace_ctx.meet_canon_end(canon_result.clone());
         trace_ctx.meet_canon_end(canon_result);

--- a/air/tests/test_module/instructions/canon.rs
+++ b/air/tests/test_module/instructions/canon.rs
@@ -507,7 +507,7 @@ fn canon_map_scalar_with_par() {
     let value1 = json!([{"key": "k", "value": "v1"}, {"key": -42, "value": "v2"}]);
 
     let mut states_vec = vec![
-        executed_state::par(4, 2),
+        executed_state::par(4, 3),
         executed_state::ap(0),
         executed_state::ap(0),
         canon_tracked(
@@ -541,6 +541,7 @@ fn canon_map_scalar_with_par() {
         ),
         executed_state::ap(0),
         executed_state::ap(0),
+        canon_request(vm_peer_id_1),
     ];
 
     let expected_trace = ExecutionTrace::from(states_vec.clone());
@@ -551,6 +552,10 @@ fn canon_map_scalar_with_par() {
 
     let value2 = json!([{"key": "k", "value": "v1"}, {"key": -42, "value": "v2"},{"key": 42, "value": "v3"}, {"key": "42", "value": "v4"}]);
     states_vec[0] = executed_state::par(4, 4);
+    // remove last state to be replaced
+    let can_req = states_vec.pop();
+    assert_eq!(can_req, Some(canon_request(vm_peer_id_1)), "test invalid");
+
     states_vec.extend(vec![
         canon_tracked(
             json!({"tetraplet": {"function_name": "", "json_path": "", "peer_pk": "vm_peer_id_2", "service_id": ""},

--- a/air/tests/test_module/negative_tests/uncatchable_trace_related.rs
+++ b/air/tests/test_module/negative_tests/uncatchable_trace_related.rs
@@ -416,8 +416,8 @@ fn canon_result_error() {
     let expected_error = UncatchableError::TraceError {
         trace_error: MergeError(air_trace_handler::MergeError::IncorrectCanonResult(
             CanonResultError::IncompatibleState {
-                prev_canon_result: air_interpreter_data::CanonResult::new(prev_cid),
-                current_canon_result: air_interpreter_data::CanonResult::new(curr_cid),
+                prev_canon_result: air_interpreter_data::CanonResult::executed(prev_cid),
+                current_canon_result: air_interpreter_data::CanonResult::executed(curr_cid),
             },
         )),
         instruction: String::from(r#"canon "vm_peer_id_1" $stream #canon"#),

--- a/crates/air-lib/interpreter-data/src/executed_state.rs
+++ b/crates/air-lib/interpreter-data/src/executed_state.rs
@@ -185,8 +185,13 @@ pub struct ApResult {
 
 /// Contains ids of element that were on a stream at the moment of an appropriate canon call.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(transparent)]
-pub struct CanonResult(pub Rc<CID<CanonResultCidAggregate>>);
+#[serde(rename_all = "snake_case")]
+pub enum CanonResult {
+    /// Request was sent to a target node by node with such public key and it shouldn't be called again.
+    #[serde(rename = "sent_by")]
+    RequestSentBy(Rc<String>),
+    Executed(Rc<CID<CanonResultCidAggregate>>),
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/crates/air-lib/interpreter-data/src/executed_state/impls.rs
+++ b/crates/air-lib/interpreter-data/src/executed_state/impls.rs
@@ -113,7 +113,7 @@ impl CanonResult {
         CanonResult::Executed(cid)
     }
 
-    pub fn send_request_by(peer_id: Rc<String>) -> Self {
+    pub fn request_sent_by(peer_id: Rc<String>) -> Self {
         CanonResult::RequestSentBy(peer_id)
     }
 }

--- a/crates/air-lib/interpreter-data/src/executed_state/impls.rs
+++ b/crates/air-lib/interpreter-data/src/executed_state/impls.rs
@@ -109,8 +109,12 @@ impl ApResult {
 }
 
 impl CanonResult {
-    pub fn new(cid: Rc<CID<CanonResultCidAggregate>>) -> Self {
-        Self(cid)
+    pub fn executed(cid: Rc<CID<CanonResultCidAggregate>>) -> Self {
+        CanonResult::Executed(cid)
+    }
+
+    pub fn send_request_by(peer_id: Rc<String>) -> Self {
+        CanonResult::RequestSentBy(peer_id)
     }
 }
 

--- a/crates/air-lib/test-utils/src/executed_state.rs
+++ b/crates/air-lib/test-utils/src/executed_state.rs
@@ -200,7 +200,11 @@ pub fn canon_tracked(
         .canon_result_tracker
         .track_value(canon_result.clone())
         .unwrap_or_else(|e| panic!("{:?}: failed to compute CID of {:?}", e, canon_result));
-    ExecutedState::Canon(CanonResult::new(canon_result_cid))
+    ExecutedState::Canon(CanonResult::executed(canon_result_cid))
+}
+
+pub fn canon_request(peer_id: impl Into<String>) -> ExecutedState {
+    ExecutedState::Canon(CanonResult::send_request_by(peer_id.into().into()))
 }
 
 #[macro_export]
@@ -389,8 +393,8 @@ pub fn extract_service_result_cid(
 
 pub fn extract_canon_result_cid(canon_state: &ExecutedState) -> Rc<CID<CanonResultCidAggregate>> {
     match canon_state {
-        ExecutedState::Canon(CanonResult(cid)) => cid.clone(),
-        _ => panic!("the function is intended for canon only"),
+        ExecutedState::Canon(CanonResult::Executed(cid)) => cid.clone(),
+        _ => panic!("the function is intended for executed canon only"),
     }
 }
 

--- a/crates/air-lib/test-utils/src/executed_state.rs
+++ b/crates/air-lib/test-utils/src/executed_state.rs
@@ -204,7 +204,7 @@ pub fn canon_tracked(
 }
 
 pub fn canon_request(peer_id: impl Into<String>) -> ExecutedState {
-    ExecutedState::Canon(CanonResult::send_request_by(peer_id.into().into()))
+    ExecutedState::Canon(CanonResult::request_sent_by(peer_id.into().into()))
 }
 
 #[macro_export]

--- a/crates/air-lib/test-utils/src/lib.rs
+++ b/crates/air-lib/test-utils/src/lib.rs
@@ -141,7 +141,7 @@ pub fn print_trace(result: &RawAVMOutcome, trace_name: &str) {
         print!("  {id}: {state}");
         match state {
             ExecutedState::Call(call_result) => print_call_value(&data, call_result),
-            ExecutedState::Canon(CanonResult(canon_cid)) => print_canon_values(&data, canon_cid),
+            ExecutedState::Canon(canon_result) => print_canon_values(&data, canon_result),
             ExecutedState::Par(_) | ExecutedState::Fold(_) | ExecutedState::Ap(_) => {}
         }
         println!();
@@ -170,10 +170,11 @@ fn print_call_value(data: &InterpreterData, call_result: &CallResult) {
     print!(" => {:#?}", value);
 }
 
-fn print_canon_values(
-    data: &InterpreterData,
-    canon_result_cid: &std::rc::Rc<air_interpreter_cid::CID<CanonResultCidAggregate>>,
-) {
+fn print_canon_values(data: &InterpreterData, canon_result: &CanonResult) {
+    let canon_result_cid = match canon_result {
+        CanonResult::RequestSentBy(_) => return,
+        CanonResult::Executed(cid) => cid,
+    };
     let canon_agg = data
         .cid_info
         .canon_result_store

--- a/crates/air-lib/trace-handler/src/merger/canon_merger.rs
+++ b/crates/air-lib/trace-handler/src/merger/canon_merger.rs
@@ -17,10 +17,6 @@
 use super::*;
 use crate::merger::errors::CanonResultError;
 
-use air_interpreter_cid::CID;
-
-use std::rc::Rc;
-
 const EXPECTED_STATE_NAME: &str = "canon";
 
 #[derive(Debug, Clone)]
@@ -30,7 +26,7 @@ pub enum MergerCanonResult {
 
     /// There was a state in at least one of the contexts. If there were two states in
     /// both contexts, they were successfully merged.
-    CanonResult(Rc<CID<CanonResultCidAggregate>>),
+    CanonResult(CanonResult),
 }
 
 pub(crate) fn try_merge_next_state_as_canon(data_keeper: &mut DataKeeper) -> MergeResult<MergerCanonResult> {
@@ -40,7 +36,7 @@ pub(crate) fn try_merge_next_state_as_canon(data_keeper: &mut DataKeeper) -> Mer
     let current_state = data_keeper.current_slider_mut().next_state();
 
     match (prev_state, current_state) {
-        (Some(Canon(prev_canon)), Some(Canon(current_canon))) => prepare_both_canon_result(prev_canon, &current_canon),
+        (Some(Canon(prev_canon)), Some(Canon(current_canon))) => prepare_both_canon_result(prev_canon, current_canon),
         (Some(Canon(prev_canon)), None) => prepare_single_canon_result(prev_canon),
         (None, Some(Canon(current_canon))) => prepare_single_canon_result(current_canon),
         (None, None) => Ok(MergerCanonResult::Empty),
@@ -54,26 +50,34 @@ pub(crate) fn try_merge_next_state_as_canon(data_keeper: &mut DataKeeper) -> Mer
 
 fn prepare_both_canon_result(
     prev_canon_result: CanonResult,
-    current_canon_result: &CanonResult,
+    current_canon_result: CanonResult,
 ) -> MergeResult<MergerCanonResult> {
-    check_canon_results(&prev_canon_result, current_canon_result).map_err(MergeError::IncorrectCanonResult)?;
-    prepare_single_canon_result(prev_canon_result)
+    let canon_result =
+        merge_canon_results(prev_canon_result, current_canon_result).map_err(MergeError::IncorrectCanonResult)?;
+    prepare_single_canon_result(canon_result)
 }
 
 fn prepare_single_canon_result(canon_result: CanonResult) -> MergeResult<MergerCanonResult> {
-    Ok(MergerCanonResult::CanonResult(canon_result.0))
+    let merger_result = MergerCanonResult::CanonResult(canon_result);
+    Ok(merger_result)
 }
 
-fn check_canon_results(
-    prev_canon_result: &CanonResult,
-    current_canon_result: &CanonResult,
-) -> Result<(), CanonResultError> {
-    if prev_canon_result != current_canon_result {
-        return Err(CanonResultError::incompatible_state(
-            prev_canon_result.clone(),
-            current_canon_result.clone(),
-        ));
+fn merge_canon_results(
+    prev_canon_result: CanonResult,
+    current_canon_result: CanonResult,
+) -> Result<CanonResult, CanonResultError> {
+    match (&prev_canon_result, &current_canon_result) {
+        (CanonResult::Executed(ref prev), CanonResult::Executed(ref cur)) => {
+            if prev == cur {
+                Ok(prev_canon_result)
+            } else {
+                Err(CanonResultError::incompatible_state(
+                    prev_canon_result,
+                    current_canon_result,
+                ))
+            }
+        }
+        (CanonResult::RequestSentBy(_), CanonResult::Executed(_)) => Ok(current_canon_result),
+        _ => Ok(prev_canon_result),
     }
-
-    Ok(())
 }

--- a/crates/air-lib/trace-handler/src/merger/canon_merger.rs
+++ b/crates/air-lib/trace-handler/src/merger/canon_merger.rs
@@ -66,18 +66,17 @@ fn merge_canon_results(
     prev_canon_result: CanonResult,
     current_canon_result: CanonResult,
 ) -> Result<CanonResult, CanonResultError> {
+    use CanonResult::*;
+
     match (&prev_canon_result, &current_canon_result) {
-        (CanonResult::Executed(ref prev), CanonResult::Executed(ref cur)) => {
-            if prev == cur {
-                Ok(prev_canon_result)
-            } else {
-                Err(CanonResultError::incompatible_state(
-                    prev_canon_result,
-                    current_canon_result,
-                ))
-            }
+        (Executed(prev), Executed(cur)) if prev != cur => Err(CanonResultError::incompatible_state(
+            prev_canon_result,
+            current_canon_result,
+        )),
+        (RequestSentBy(_), Executed(_)) => Ok(current_canon_result),
+
+        (RequestSentBy(_), RequestSentBy(_)) | (Executed(_), RequestSentBy(_)) | (Executed(_), Executed(_)) => {
+            Ok(prev_canon_result)
         }
-        (CanonResult::RequestSentBy(_), CanonResult::Executed(_)) => Ok(current_canon_result),
-        _ => Ok(prev_canon_result),
     }
 }


### PR DESCRIPTION
If `canon` is to be executed on another peer and the particle is to be
sent here, current peer inserts canon request-sent-by state to avoid
repeated requests, similar to `call` instruction.