### PR TITLE
feat(execution-engine): join behavior for canon

### DIFF
--- a/air/src/execution_step/instructions/canon_utils/mod.rs
+++ b/air/src/execution_step/instructions/canon_utils/mod.rs
@@ -57,6 +57,8 @@ pub(crate) fn handle_canon_request_sent_by(
     exec_ctx: &mut ExecutionCtx<'_>,
     trace_ctx: &mut TraceHandler,
 ) -> ExecutionResult<()> {
+    // we do not apply join behavior here because if state exists, the variable have been defined;
+    // it cannot become undefined
     let peer_id = resolve_peer_id_to_string(peer_id, exec_ctx)?;
 
     if exec_ctx.run_parameters.current_peer_id.as_str() != peer_id {
@@ -97,7 +99,10 @@ pub(crate) fn handle_unseen_canon(
     exec_ctx: &mut ExecutionCtx<'_>,
     trace_ctx: &mut TraceHandler,
 ) -> ExecutionResult<()> {
-    let peer_id = resolve_peer_id_to_string(peer_id, exec_ctx)?;
+    use crate::execution_step::Joinable;
+    use crate::joinable;
+
+    let peer_id = joinable!(resolve_peer_id_to_string(peer_id, exec_ctx), exec_ctx, ())?;
 
     if exec_ctx.run_parameters.current_peer_id.as_str() != peer_id {
         exec_ctx.make_subgraph_incomplete();

--- a/air/src/execution_step/instructions/canon_utils/mod.rs
+++ b/air/src/execution_step/instructions/canon_utils/mod.rs
@@ -58,7 +58,7 @@ pub(crate) fn handle_canon_request_sent_by(
     trace_ctx: &mut TraceHandler,
 ) -> ExecutionResult<()> {
     // we do not apply join behavior here because if state exists, the variable have been defined;
-    // it cannot become undefined
+    // it cannot become undefined due to INV-1
     let peer_id = resolve_peer_id_to_string(peer_id, exec_ctx)?;
 
     if exec_ctx.run_parameters.current_peer_id.as_str() != peer_id {

--- a/air/tests/test_module/instructions/canon.rs
+++ b/air/tests/test_module/instructions/canon.rs
@@ -1075,8 +1075,7 @@ fn canon_join_behavoir() {
         .expect("invalid test AIR script");
     let result = executor.execute_one(init_peer_name).unwrap();
 
-    assert_eq!(result.error_message, "");
-    assert_eq!(result.ret_code, 0);
+    assert_eq!(result.ret_code, 0, "{:?}", result.error_message);
 }
 
 #[test]
@@ -1099,8 +1098,7 @@ fn canon_map_join_behavoir() {
         .expect("invalid test AIR script");
     let result = executor.execute_one(init_peer_name).unwrap();
 
-    assert_eq!(result.error_message, "");
-    assert_eq!(result.ret_code, 0);
+    assert_eq!(result.ret_code, 0, "{:?}", result.error_message);
 }
 
 #[test]
@@ -1123,6 +1121,5 @@ fn canon_map_var_join_behavoir() {
         .expect("invalid test AIR script");
     let result = executor.execute_one(init_peer_name).unwrap();
 
-    assert_eq!(result.error_message, "");
-    assert_eq!(result.ret_code, 0);
+    assert_eq!(result.ret_code, 0, "{:?}", result.error_message);
 }

--- a/air/tests/test_module/instructions/canon.rs
+++ b/air/tests/test_module/instructions/canon.rs
@@ -1054,3 +1054,75 @@ fn canon_map_2_scalar_with_lens_tetraplet_check() {
         actual_trace, expected_trace
     );
 }
+
+#[test]
+fn canon_join_behavoir() {
+    let init_peer_name = "init_peer_id";
+
+    let script = r#"
+    (seq
+       (par
+          (null)
+          (seq
+             (never)
+             (ap %init_peer_id% var)))
+       (seq
+          (ap 42 $stream)
+          (canon var $stream #canon)))
+    "#;
+
+    let executor = AirScriptExecutor::from_annotated(TestRunParameters::from_init_peer_id(init_peer_name), &script)
+        .expect("invalid test AIR script");
+    let result = executor.execute_one(init_peer_name).unwrap();
+
+    assert_eq!(result.error_message, "");
+    assert_eq!(result.ret_code, 0);
+}
+
+#[test]
+fn canon_map_join_behavoir() {
+    let init_peer_name = "init_peer_id";
+
+    let script = r#"
+    (seq
+       (par
+          (null)
+          (seq
+             (never)
+             (ap %init_peer_id% var)))
+       (seq
+          (ap ("answer" 42) %map)
+          (canon var %map #%canon)))
+    "#;
+
+    let executor = AirScriptExecutor::from_annotated(TestRunParameters::from_init_peer_id(init_peer_name), &script)
+        .expect("invalid test AIR script");
+    let result = executor.execute_one(init_peer_name).unwrap();
+
+    assert_eq!(result.error_message, "");
+    assert_eq!(result.ret_code, 0);
+}
+
+#[test]
+fn canon_map_var_join_behavoir() {
+    let init_peer_name = "init_peer_id";
+
+    let script = r#"
+    (seq
+       (par
+          (null)
+          (seq
+             (never)
+             (ap %init_peer_id% var)))
+       (seq
+          (ap ("answer" 42) %map)
+          (canon var %map value)))
+    "#;
+
+    let executor = AirScriptExecutor::from_annotated(TestRunParameters::from_init_peer_id(init_peer_name), &script)
+        .expect("invalid test AIR script");
+    let result = executor.execute_one(init_peer_name).unwrap();
+
+    assert_eq!(result.error_message, "");
+    assert_eq!(result.ret_code, 0);
+}


### PR DESCRIPTION
Implement join behavior for `canon`'s first argument `peer_id`.  It simplifies generating code in Aqua compiler when `peer_id` is defined by a variable defined in a `par` branch.