### PR TITLE
fix(execution-engine)!: canon map lens access now returns a correct number of kvpairs in a canon stream

### DIFF
--- a/air/src/execution_step/execution_context/stream_maps_variables/stream_map_key.rs
+++ b/air/src/execution_step/execution_context/stream_maps_variables/stream_map_key.rs
@@ -58,12 +58,6 @@ impl<'value> StreamMapKey<'value> {
         StreamMapKey::from_value(key)
     }
 
-    pub(crate) fn from_kvpair(value: &'value ValueAggregate) -> Option<Self> {
-        let object = value.get_result().as_object()?;
-        let key = object.get(KEY_FIELD_NAME)?;
-        StreamMapKey::from_value_ref(key)
-    }
-
     pub(crate) fn into_owned(self) -> StreamMapKey<'static> {
         match self {
             StreamMapKey::Str(s) => {

--- a/air/src/execution_step/instructions/canon_map.rs
+++ b/air/src/execution_step/instructions/canon_map.rs
@@ -94,7 +94,7 @@ fn create_canon_stream_producer<'closure, 'name: 'closure>(
             .map(|stream_map| Cow::Borrowed(stream_map))
             .unwrap_or_default();
 
-        let values = stream_map.iter_unique_key().cloned().collect::<Vec<_>>();
+        let values = stream_map.iter().cloned().collect::<Vec<_>>();
         CanonStream::from_values(values, peer_pk)
     })
 }

--- a/air/tests/test_module/instructions/canon.rs
+++ b/air/tests/test_module/instructions/canon.rs
@@ -749,6 +749,97 @@ fn canon_stream_map() {
 }
 
 #[test]
+fn canon_map_2_indices_tetraplet_check() {
+    let vm_peer_id_1 = "vm_peer_id_1";
+    let arg_tetraplets = Rc::new(RefCell::new(vec![]));
+
+    let echo_call_service: CallServiceClosure = Box::new(move |mut params| -> CallServiceResult {
+        let arg_tetraplets_inner = arg_tetraplets.clone();
+        arg_tetraplets_inner.borrow_mut().push(params.tetraplets.clone());
+        CallServiceResult::ok(params.arguments.remove(0))
+    });
+
+    let (echo_call_service, tetraplet_checker) = tetraplet_host_function(echo_call_service);
+    let mut vm_1 = create_avm(echo_call_service, vm_peer_id_1);
+
+    let script = format!(
+        r#"
+        (seq
+            (seq
+                (ap (42 "value2") %map)
+                (seq
+                    (ap ("key" 43) %map)
+                    (ap (42 "value1") %map)
+                )
+            )
+            (seq
+                (canon "{vm_peer_id_1}" %map #%canon_map)
+                (call "{vm_peer_id_1}" ("" "") [#%canon_map.$.[42].[0]] output)
+            )
+        )
+    "#
+    );
+
+    let result = checked_call_vm!(vm_1, <_>::default(), &script, "", "");
+    let actual_trace = trace_from_result(&result);
+
+    let mut cid_state: ExecutionCidState = ExecutionCidState::new();
+    let map_value1 = json!({"key": 42, "value": "value2"});
+    let map_value2 = json!({"key": "key", "value": 43});
+    let map_value3 = json!({"key": 42, "value": "value1"});
+    let call_result = json!("value2");
+
+    let tetraplet = json!({"function_name": "", "json_path": "", "peer_pk": "vm_peer_id_1", "service_id": ""});
+    let empty_tetraplet = json!({"function_name": "", "json_path": "", "peer_pk": "", "service_id": ""});
+
+    let states_vec = vec![
+        executed_state::ap(0),
+        executed_state::ap(0),
+        executed_state::ap(0),
+        canon_tracked(
+            json!({"tetraplet": tetraplet,
+            "values": [
+            {
+                "result": map_value1,
+                "tetraplet": empty_tetraplet,
+                "provenance": Provenance::Literal,
+            },
+            {
+                "result": map_value2,
+                "tetraplet": empty_tetraplet,
+                "provenance": Provenance::Literal,
+            },
+            {
+                "result": map_value3,
+                "tetraplet": empty_tetraplet,
+                "provenance": Provenance::Literal,
+            },
+            ]}),
+            &mut cid_state,
+        ),
+        scalar_tracked!(
+            call_result.clone(),
+            cid_state,
+            peer = vm_peer_id_1,
+            service = "",
+            function = "",
+            args = vec![call_result]
+        ),
+    ];
+
+    let expected_trace = ExecutionTrace::from(states_vec.clone());
+    let expected_tetraplet = RefCell::new(vec![vec![SecurityTetraplet::new(vm_peer_id_1, "", "", ".$.[42].[0]")]]);
+
+    assert_eq!(
+        actual_trace, expected_trace,
+        "left {:#?} \n right {:#?}",
+        actual_trace, expected_trace
+    );
+
+    assert_eq!(tetraplet_checker.as_ref(), &expected_tetraplet);
+}
+
+#[test]
 fn canon_map_non_existing_index_tetraplet_check() {
     let vm_peer_id_1 = "vm_peer_id_1";
     let arg_tetraplets = Rc::new(RefCell::new(vec![]));
@@ -810,82 +901,6 @@ fn canon_map_non_existing_index_tetraplet_check() {
 
     let expected_trace = ExecutionTrace::from(states_vec.clone());
     let expected_tetraplet = RefCell::new(vec![vec![SecurityTetraplet::new(vm_peer_id_1, "", "", ".$.key")]]);
-
-    assert_eq!(
-        actual_trace, expected_trace,
-        "left {:#?} \n right {:#?}",
-        actual_trace, expected_trace
-    );
-
-    assert_eq!(tetraplet_checker.as_ref(), &expected_tetraplet);
-}
-
-#[test]
-fn canon_map_non_existing_2_indices_tetraplet_check() {
-    let vm_peer_id_1 = "vm_peer_id_1";
-    let arg_tetraplets = Rc::new(RefCell::new(vec![]));
-
-    let echo_call_service: CallServiceClosure = Box::new(move |mut params| -> CallServiceResult {
-        let arg_tetraplets_inner = arg_tetraplets.clone();
-        arg_tetraplets_inner.borrow_mut().push(params.tetraplets.clone());
-        CallServiceResult::ok(params.arguments.remove(0))
-    });
-
-    let (echo_call_service, tetraplet_checker) = tetraplet_host_function(echo_call_service);
-    let mut vm_1 = create_avm(echo_call_service, vm_peer_id_1);
-
-    let script = format!(
-        r#"
-        (seq
-            (seq
-                (ap (42 "value2") %map)
-                (ap (42 "value1") %map)
-            )
-            (seq
-                (canon "{vm_peer_id_1}" %map #%canon_map)
-                (call "{vm_peer_id_1}" ("" "") [#%canon_map.$.[42].[0]] output)
-            )
-        )
-    "#
-    );
-
-    let result = checked_call_vm!(vm_1, <_>::default(), &script, "", "");
-
-    let actual_trace = trace_from_result(&result);
-
-    let mut cid_state: ExecutionCidState = ExecutionCidState::new();
-    let map_value1 = json!({"key": 42, "value": "value2"});
-    let call_result = json!("value2");
-
-    let tetraplet = json!({"function_name": "", "json_path": "", "peer_pk": "vm_peer_id_1", "service_id": ""});
-    let empty_tetraplet = json!({"function_name": "", "json_path": "", "peer_pk": "", "service_id": ""});
-
-    let states_vec = vec![
-        executed_state::ap(0),
-        executed_state::ap(0),
-        canon_tracked(
-            json!({"tetraplet": tetraplet,
-            "values": [
-                {
-                "result": map_value1,
-                "tetraplet": empty_tetraplet,
-                "provenance": Provenance::Literal,
-            },
-            ]}),
-            &mut cid_state,
-        ),
-        scalar_tracked!(
-            call_result.clone(),
-            cid_state,
-            peer = vm_peer_id_1,
-            service = "",
-            function = "",
-            args = vec![call_result]
-        ),
-    ];
-
-    let expected_trace = ExecutionTrace::from(states_vec.clone());
-    let expected_tetraplet = RefCell::new(vec![vec![SecurityTetraplet::new(vm_peer_id_1, "", "", ".$.[42].[0]")]]);
 
     assert_eq!(
         actual_trace, expected_trace,


### PR DESCRIPTION
Previously `#%canon_map.$.[key]` returned FWW value from an underlying stream.