### PR TITLE
feat(execution-engine)!: `fail :error:` now bubbles the original error up [fixes VM-342]

### DIFF
--- a/air/src/execution_step/errors/catchable_errors.rs
+++ b/air/src/execution_step/errors/catchable_errors.rs
@@ -32,7 +32,7 @@ use std::rc::Rc;
 /// Catchable errors arisen during AIR script execution. Catchable here means that these errors
 /// could be handled by a xor instruction and their error_code could be used in a match
 /// instruction.
-#[derive(ThisError, EnumDiscriminants, Debug)]
+#[derive(ThisError, EnumDiscriminants, Debug, Clone)]
 #[strum_discriminants(derive(EnumIter))]
 pub enum CatchableError {
     /// An error is occurred while calling local service via call_service.

--- a/air/src/execution_step/execution_context/context.rs
+++ b/air/src/execution_step/execution_context/context.rs
@@ -193,8 +193,14 @@ impl ExecutionCtx<'_> {
             None
         };
 
+        let original_error_object = self.error_descriptor.original_error_object().clone();
+
         self.error_descriptor
             .try_to_set_error_from_exec_error(error, instruction, peer_id, tetraplet.clone());
+
+        if let Some(error_object) = original_error_object {
+            self.error_descriptor.set_both_error_objects(&error_object);
+        }
     }
 }
 

--- a/air/src/execution_step/execution_context/instruction_error/errors_utils.rs
+++ b/air/src/execution_step/execution_context/instruction_error/errors_utils.rs
@@ -65,9 +65,13 @@ pub(crate) fn get_instruction_error_from_error_object(
     tetraplet: Option<RcSecurityTetraplet>,
     provenance: Provenance,
 ) -> InstructionError {
+    let orig_catchable = None;
+    let orig_error_object = Some(error.clone());
     InstructionError {
         error,
         tetraplet,
         provenance,
+        orig_catchable,
+        orig_error_object,
     }
 }

--- a/air/src/execution_step/execution_context/instruction_error/instruction_error_definition.rs
+++ b/air/src/execution_step/execution_context/instruction_error/instruction_error_definition.rs
@@ -16,11 +16,10 @@
 
 use super::ErrorObjectError;
 use crate::execution_step::RcSecurityTetraplet;
+use crate::CatchableError;
 use crate::JValue;
 
 use air_interpreter_data::Provenance;
-use serde::Deserialize;
-use serde::Serialize;
 use serde_json::json;
 
 use std::rc::Rc;
@@ -37,7 +36,7 @@ pub const NO_ERROR_ERROR_CODE: i64 = 0;
 /// There are some differences b/w mentioned errors and an ordinary scalar:
 ///  - they are set to not-an-error value by default
 ///  - these are global scalars, meaning that fold and new scopes do not apply for it
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct InstructionError {
     /// Error object that represents the last occurred error.
     pub error: Rc<JValue>,
@@ -45,8 +44,16 @@ pub struct InstructionError {
     /// Tetraplet that identify host where the error occurred.
     pub tetraplet: Option<RcSecurityTetraplet>,
 
-    /// Value provenance
+    /// Value provenance.
     pub provenance: Provenance,
+
+    /// This is an original Catchable that is used to bubble an original error up,
+    /// when `fail :error:` is called in the right branch of `xor`.
+    pub orig_catchable: Option<CatchableError>,
+
+    /// This is an original error object that is used to bubble an original error up.
+    /// It is set in ExecCtx::set_errors and reset in execute! macro.
+    pub orig_error_object: Option<Rc<JValue>>,
 }
 
 pub(crate) fn error_from_raw_fields_w_peerid(
@@ -146,5 +153,7 @@ pub fn no_error() -> InstructionError {
         error: Rc::new(no_error_object()),
         tetraplet: None,
         provenance: Provenance::literal(),
+        orig_catchable: None,
+        orig_error_object: None,
     }
 }

--- a/air/src/execution_step/instructions/mod.rs
+++ b/air/src/execution_step/instructions/mod.rs
@@ -57,7 +57,10 @@ macro_rules! execute {
                 $exec_ctx.set_errors(&e, &$instr.to_string(), None, $instr.log_errors_with_peer_id());
                 Err(e)
             }
-            v => v,
+            v => {
+                $exec_ctx.error_descriptor.clear_original_error_object();
+                v
+            }
         }
     }};
 }

--- a/air/src/execution_step/instructions/xor.rs
+++ b/air/src/execution_step/instructions/xor.rs
@@ -33,12 +33,13 @@ impl<'i> super::ExecutableInstruction<'i> for Xor<'i> {
 
                 exec_ctx.flush_subgraph_completeness();
                 exec_ctx.last_error_descriptor.meet_xor_right_branch();
+                exec_ctx.error_descriptor.set_original_execution_error(&e);
 
                 let right_subgraph_result = self.1.execute(exec_ctx, trace_ctx);
                 // This sets :error: to a no-error state.
                 // Please note the right_subgraph_result might be an Error that bubbles up to an :error:
                 // above this execute().
-                exec_ctx.error_descriptor.clear_error();
+                exec_ctx.error_descriptor.clear_error_object();
                 right_subgraph_result
             }
             res => res,

--- a/air/src/execution_step/resolver/resolvable_impl.rs
+++ b/air/src/execution_step/resolver/resolvable_impl.rs
@@ -74,6 +74,7 @@ fn resolve_errors(
         error,
         tetraplet,
         provenance,
+        ..
     } = instruction_error;
 
     let jvalue = match lens {

--- a/air/tests/test_module/features/errors/error.rs
+++ b/air/tests/test_module/features/errors/error.rs
@@ -44,9 +44,9 @@ fn fail_with_rebubble_error() {
     let mut cid_tracker: ExecutionCidState = ExecutionCidState::new();
     let expected_error_json = {
         json!({
-          "error_code": 10006,
-          "instruction": "xor",
-          "message": "fail with '{\"error_code\":10001,\"instruction\":\"match 1 2\",\"message\":\"compared values do not match\"}' is used without corresponding xor"
+          "error_code": 10001,
+          "instruction": "match 1 2",
+          "message": "compared values do not match"
         })
     };
 

--- a/air/tests/test_module/instructions/fail.rs
+++ b/air/tests/test_module/instructions/fail.rs
@@ -62,15 +62,9 @@ fn fail_with_error() {
     );
 
     let result = call_vm!(vm, <_>::default(), script, "", "");
+    let err_message = r#""failed result from fallible_call_service""#.to_string();
+    let expected_error = CatchableError::LocalServiceError(1i32, err_message.into());
 
-    let expected_error = CatchableError::UserError {
-        error: rc!(json!({
-            "error_code": 10000i64,
-            "instruction": r#"call "local_peer_id" ("service_id_1" "local_fn_name") [] result_1"#,
-            "message": r#"Local service error, ret_code is 1, error message is '"failed result from fallible_call_service"'"#,
-            "peer_id": "local_peer_id",
-        })),
-    };
     assert!(check_error(&result, expected_error));
 }
 


### PR DESCRIPTION
AquaVM wraps an original error with Catchable::UserError for every xor with fail used. This patch bubbles up an original error with the corresponding error_object. 