### PR TITLE
feat(air-interpreter)!: enable signature generation and verification features

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,6 +83,7 @@ jobs:
           RUST_TEST_THREADS: 1
         run: |
           # The `memory` sanitizer on cargo test has false positive even on empty project.
+          # It shouldn't have `--no-default-features`, but it has until legacy tests will work with signatures enabled.
           for san in address leak; do
             RUSTFLAGS="$RUSTFLAGS -Z sanitizer=$san" cargo test --no-default-features --features test_with_native_code --target x86_64-unknown-linux-gnu
           done
@@ -90,7 +91,7 @@ jobs:
         env:
           RUST_TEST_THREADS: 1
         run: |
-          # Temporary solution until signatures works: it depends on other PRs
+          # Temporary solution until legacy tests work with signatures.
           cargo test --features test_with_native_code,gen_signatures,check_signatures --target x86_64-unknown-linux-gnu features::signatures
 
       - name: Check native aquavm-air-cli

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,7 +84,7 @@ jobs:
         run: |
           # The `memory` sanitizer on cargo test has false positive even on empty project.
           for san in address leak; do
-            RUSTFLAGS="$RUSTFLAGS -Z sanitizer=$san" cargo test --features test_with_native_code --target x86_64-unknown-linux-gnu
+            RUSTFLAGS="$RUSTFLAGS -Z sanitizer=$san" cargo test --no-default-features --features test_with_native_code --target x86_64-unknown-linux-gnu
           done
       - name: Run signature tests with test_with_native_code
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Run cargo nextest
         # It should have "--all-features", but it is temporarly disabled because of the signature-related feature flags
-        run: cargo llvm-cov nextest --features test_with_native_code --release --profile ci --lcov --output-path lcov.info
+        run: cargo llvm-cov nextest --no-default-features --features test_with_native_code --release --profile ci --lcov --output-path lcov.info
 
       - name: Coveralls upload
         if: inputs.cargo-dependencies == 'null'

--- a/air-interpreter/Cargo.toml
+++ b/air-interpreter/Cargo.toml
@@ -40,3 +40,4 @@ marine = []
 gen_signatures = ["aquavm-air/gen_signatures"]
 check_signatures = ["aquavm-air/check_signatures"]
 
+default = ["check_signatures", "gen_signatures"]


### PR DESCRIPTION
Make `gen_signatures` and `check_signature` features defaults.