### PR TITLE
fix(air-interpreter): enable multiple invoke_tracing calls for air-interpreter

### DIFF
--- a/air-interpreter/src/logger.rs
+++ b/air-interpreter/src/logger.rs
@@ -32,18 +32,6 @@ pub fn init_logger(default_level: Option<LevelFilter>) {
 }
 
 #[allow(dead_code)]
-// TODO it worth moving it to marine_rs_sdk
-pub fn init_tracing(tracing_params: String, trace_mode: u8) {
-    use tracing_subscriber::fmt::format::FmtSpan;
-
-    let builder = tracing_subscriber::fmt()
-        .with_env_filter(tracing_params)
-        .with_span_events(FmtSpan::ENTER | FmtSpan::CLOSE)
-        .with_writer(std::io::stderr);
-    if trace_mode == 0 {
-        builder.json().init();
-    } else {
-        // Human-readable output.
-        builder.init();
-    }
+pub fn json_output_mode(trace_mode: u8) -> bool {
+    trace_mode == 0
 }

--- a/air-interpreter/src/marine.rs
+++ b/air-interpreter/src/marine.rs
@@ -37,6 +37,8 @@ use marine_rs_sdk::module_manifest;
 
 module_manifest!();
 
+static mut TRACING_IS_INITED: bool = false;
+
 pub fn main() {
     logger::init_logger(None);
 }
@@ -63,7 +65,12 @@ pub fn invoke_tracing(
     tracing_params: String,
     tracing_output_mode: u8,
 ) -> InterpreterOutcome {
-    logger::init_tracing(tracing_params, tracing_output_mode);
+    if unsafe { !TRACING_IS_INITED } {
+        logger::init_tracing(tracing_params, tracing_output_mode);
+        unsafe {
+            TRACING_IS_INITED = true;
+        }
+    }
     execute_air(air, prev_data, data, params, call_results)
 }
 

--- a/air-interpreter/src/marine.rs
+++ b/air-interpreter/src/marine.rs
@@ -37,8 +37,6 @@ use marine_rs_sdk::module_manifest;
 
 module_manifest!();
 
-static mut TRACING_IS_INITED: bool = false;
-
 pub fn main() {
     logger::init_logger(None);
 }
@@ -65,13 +63,21 @@ pub fn invoke_tracing(
     tracing_params: String,
     tracing_output_mode: u8,
 ) -> InterpreterOutcome {
-    if unsafe { !TRACING_IS_INITED } {
-        logger::init_tracing(tracing_params, tracing_output_mode);
-        unsafe {
-            TRACING_IS_INITED = true;
-        }
+    use tracing_subscriber::fmt::format::FmtSpan;
+
+    let builder = tracing_subscriber::fmt()
+        .with_env_filter(tracing_params)
+        .with_span_events(FmtSpan::ENTER | FmtSpan::CLOSE)
+        .with_writer(std::io::stderr);
+
+    if logger::json_output_mode(tracing_output_mode) {
+        let subscriber = builder.json().finish();
+        tracing::subscriber::with_default(subscriber, || execute_air(air, prev_data, data, params, call_results))
+    } else {
+        // Human-readable output.
+        let subscriber = builder.finish();
+        tracing::subscriber::with_default(subscriber, || execute_air(air, prev_data, data, params, call_results))
     }
-    execute_air(air, prev_data, data, params, call_results)
 }
 
 #[marine]


### PR DESCRIPTION
A hacky way to prevent multiple initialization of a tracing subscruber.
This is a prerequisite to add benchmarking tests for nox. 