### PR TITLE
feat(air-parser)!: optimize Instruction type layout

### DIFF
--- a/air/src/lib.rs
+++ b/air/src/lib.rs
@@ -70,7 +70,7 @@ pub mod parser {
     pub use air_parser::ast::Instruction;
 
     /// Parse an AIR script to AST.
-    pub fn parse(script: &str) -> Result<Box<Instruction<'_>>, String> {
+    pub fn parse(script: &str) -> Result<Instruction<'_>, String> {
         air_parser::parse(script)
     }
 }

--- a/air/src/preparation_step/preparation.rs
+++ b/air/src/preparation_step/preparation.rs
@@ -68,7 +68,7 @@ pub(crate) fn prepare<'i>(
     run_parameters: RunParameters,
     signature_store: SignatureStore,
 ) -> PreparationResult<PreparationDescriptor<'static, 'i>> {
-    let air: Instruction<'i> = *air_parser::parse(raw_air).map_err(PreparationError::AIRParseError)?;
+    let air: Instruction<'i> = air_parser::parse(raw_air).map_err(PreparationError::AIRParseError)?;
 
     let prev_ingredients = ExecCtxIngredients {
         last_call_request_id: prev_data.last_call_request_id,

--- a/benches/PERFORMANCE.json
+++ b/benches/PERFORMANCE.json
@@ -2383,39 +2383,39 @@
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "5.24ms",
+                "duration": "5.31ms",
                 "nested": {
-                  "from_slice": "5.18ms"
+                  "from_slice": "5.26ms"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "173.00µs",
+                "duration": "182.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "22.00µs",
-                  "air_parser::parser::air_parser::parse": "30.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "28.00µs",
+                  "air_parser::parser::air_parser::parse": "33.00µs"
                 }
               },
-              "runner::execute": "13.00µs",
+              "runner::execute": "9.00µs",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "3.27ms",
+                "duration": "3.29ms",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "3.25ms",
+                    "duration": "3.27ms",
                     "nested": {
-                      "populate_outcome_from_contexts": "3.22ms"
+                      "populate_outcome_from_contexts": "3.23ms"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "99.00µs",
+              "signing_step::sign_produced_cids": "102.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "4.03ms",
+                "duration": "3.98ms",
                 "nested": {
-                  "verify": "3.67ms"
+                  "verify": "3.62ms"
                 }
               }
             }
@@ -2432,24 +2432,24 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "25.80ms",
+            "duration": "25.90ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "146.00µs",
+                "duration": "147.00µs",
                 "nested": {
-                  "from_slice": "106.00µs"
+                  "from_slice": "101.00µs"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "253.00µs",
+                "duration": "254.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "47.00µs",
-                  "air_parser::parser::air_parser::parse": "78.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "52.00µs",
+                  "air_parser::parser::air_parser::parse": "76.00µs"
                 }
               },
-              "runner::execute": "19.89ms",
+              "runner::execute": "20.00ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
                 "duration": "5.15ms",
@@ -2463,18 +2463,18 @@
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "105.00µs",
+              "signing_step::sign_produced_cids": "106.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "80.00µs",
+                "duration": "76.00µs",
                 "nested": {
-                  "verify": "12.00µs"
+                  "verify": "9.00µs"
                 }
               }
             }
           }
         },
-        "total_time": "25.80ms"
+        "total_time": "25.90ms"
       },
       "call-results500": {
         "comment": "multiple call results",
@@ -2485,27 +2485,27 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "15.60ms",
+            "duration": "15.70ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
                 "duration": "621.00µs",
                 "nested": {
-                  "from_slice": "579.00µs"
+                  "from_slice": "577.00µs"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "1.00ms",
+                "duration": "1.01ms",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "803.00µs",
-                  "air_parser::parser::air_parser::parse": "73.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "812.00µs",
+                  "air_parser::parser::air_parser::parse": "72.00µs"
                 }
               },
-              "runner::execute": "11.60ms",
+              "runner::execute": "11.70ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "1.80ms",
+                "duration": "1.81ms",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
@@ -2516,18 +2516,18 @@
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "290.00µs",
+              "signing_step::sign_produced_cids": "289.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "95.00µs",
+                "duration": "90.00µs",
                 "nested": {
-                  "verify": "12.00µs"
+                  "verify": "9.00µs"
                 }
               }
             }
           }
         },
-        "total_time": "15.60ms"
+        "total_time": "15.70ms"
       },
       "canon-map-key-by-lens": {
         "comment": "benchmarking a map insert operation",
@@ -2538,49 +2538,49 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "10.82ms",
+            "duration": "10.84ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "3.15ms",
+                "duration": "3.17ms",
                 "nested": {
-                  "from_slice": "3.10ms"
+                  "from_slice": "3.13ms"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "385.00µs",
+                "duration": "396.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "187.00µs",
-                  "air_parser::parser::air_parser::parse": "77.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "192.00µs",
+                  "air_parser::parser::air_parser::parse": "79.00µs"
                 }
               },
-              "runner::execute": "1.96ms",
+              "runner::execute": "1.95ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "1.87ms",
+                "duration": "1.88ms",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "1.84ms",
+                    "duration": "1.86ms",
                     "nested": {
                       "populate_outcome_from_contexts": "1.49ms"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "100.00µs",
+              "signing_step::sign_produced_cids": "102.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "3.18ms",
+                "duration": "3.17ms",
                 "nested": {
-                  "verify": "2.82ms"
+                  "verify": "2.80ms"
                 }
               }
             }
           }
         },
-        "total_time": "10.82ms"
+        "total_time": "10.84ms"
       },
       "canon-map-key-element-by-lens": {
         "comment": "benchmarking a map insert operation",
@@ -2591,49 +2591,49 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "10.75ms",
+            "duration": "10.80ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "3.13ms",
+                "duration": "3.16ms",
                 "nested": {
-                  "from_slice": "3.08ms"
+                  "from_slice": "3.12ms"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "382.00µs",
+                "duration": "395.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "187.00µs",
-                  "air_parser::parser::air_parser::parse": "77.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "192.00µs",
+                  "air_parser::parser::air_parser::parse": "82.00µs"
                 }
               },
-              "runner::execute": "1.92ms",
+              "runner::execute": "1.93ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "1.85ms",
+                "duration": "1.87ms",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "1.83ms",
+                    "duration": "1.85ms",
                     "nested": {
-                      "populate_outcome_from_contexts": "1.49ms"
+                      "populate_outcome_from_contexts": "1.51ms"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "100.00µs",
+              "signing_step::sign_produced_cids": "101.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "3.17ms",
+                "duration": "3.16ms",
                 "nested": {
-                  "verify": "2.81ms"
+                  "verify": "2.80ms"
                 }
               }
             }
           }
         },
-        "total_time": "10.75ms"
+        "total_time": "10.80ms"
       },
       "canon-map-multiple-keys": {
         "comment": "benchmarking a map insert operation",
@@ -2644,24 +2644,24 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "8.96ms",
+            "duration": "8.97ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "417.00µs",
+                "duration": "423.00µs",
                 "nested": {
-                  "from_slice": "370.00µs"
+                  "from_slice": "377.00µs"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "201.00µs",
+                "duration": "209.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "18.00µs",
+                  "air::preparation_step::preparation::make_exec_ctx": "23.00µs",
                   "air_parser::parser::air_parser::parse": "66.00µs"
                 }
               },
-              "runner::execute": "6.02ms",
+              "runner::execute": "6.04ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
                 "duration": "1.63ms",
@@ -2678,15 +2678,15 @@
               "signing_step::sign_produced_cids": "100.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "403.00µs",
+                "duration": "401.00µs",
                 "nested": {
-                  "verify": "40.00µs"
+                  "verify": "35.00µs"
                 }
               }
             }
           }
         },
-        "total_time": "8.96ms"
+        "total_time": "8.97ms"
       },
       "canon-map-scalar-multiple-keys": {
         "comment": "benchmarking a map insert operation",
@@ -2697,49 +2697,49 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "4.08ms",
+            "duration": "4.11ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "418.00µs",
+                "duration": "430.00µs",
                 "nested": {
-                  "from_slice": "370.00µs"
+                  "from_slice": "385.00µs"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "197.00µs",
+                "duration": "213.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "18.00µs",
-                  "air_parser::parser::air_parser::parse": "62.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "24.00µs",
+                  "air_parser::parser::air_parser::parse": "69.00µs"
                 }
               },
-              "runner::execute": "2.43ms",
+              "runner::execute": "2.44ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "345.00µs",
+                "duration": "352.00µs",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "325.00µs",
+                    "duration": "332.00µs",
                     "nested": {
-                      "populate_outcome_from_contexts": "289.00µs"
+                      "populate_outcome_from_contexts": "294.00µs"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "98.00µs",
+              "signing_step::sign_produced_cids": "101.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "405.00µs",
+                "duration": "404.00µs",
                 "nested": {
-                  "verify": "40.00µs"
+                  "verify": "34.00µs"
                 }
               }
             }
           }
         },
-        "total_time": "4.08ms"
+        "total_time": "4.11ms"
       },
       "canon-map-scalar-single-key": {
         "comment": "benchmarking a map insert operation",
@@ -2750,33 +2750,33 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "3.29ms",
+            "duration": "3.28ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
                 "duration": "427.00µs",
                 "nested": {
-                  "from_slice": "380.00µs"
+                  "from_slice": "379.00µs"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "200.00µs",
+                "duration": "205.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "18.00µs",
+                  "air::preparation_step::preparation::make_exec_ctx": "23.00µs",
                   "air_parser::parser::air_parser::parse": "62.00µs"
                 }
               },
               "runner::execute": "1.58ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "354.00µs",
+                "duration": "362.00µs",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "334.00µs",
+                    "duration": "343.00µs",
                     "nested": {
-                      "populate_outcome_from_contexts": "282.00µs"
+                      "populate_outcome_from_contexts": "287.00µs"
                     }
                   }
                 }
@@ -2784,15 +2784,15 @@
               "signing_step::sign_produced_cids": "101.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "437.00µs",
+                "duration": "432.00µs",
                 "nested": {
-                  "verify": "75.00µs"
+                  "verify": "70.00µs"
                 }
               }
             }
           }
         },
-        "total_time": "3.29ms"
+        "total_time": "3.28ms"
       },
       "canon-map-single-key": {
         "comment": "benchmarking a map insert operation",
@@ -2807,17 +2807,17 @@
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "426.00µs",
+                "duration": "429.00µs",
                 "nested": {
-                  "from_slice": "378.00µs"
+                  "from_slice": "383.00µs"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "196.00µs",
+                "duration": "204.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "18.00µs",
-                  "air_parser::parser::air_parser::parse": "60.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "23.00µs",
+                  "air_parser::parser::air_parser::parse": "62.00µs"
                 }
               },
               "runner::execute": "4.45ms",
@@ -2834,12 +2834,12 @@
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "99.00µs",
+              "signing_step::sign_produced_cids": "101.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "434.00µs",
+                "duration": "430.00µs",
                 "nested": {
-                  "verify": "74.00µs"
+                  "verify": "69.00µs"
                 }
               }
             }
@@ -2856,49 +2856,49 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "5.70ms",
+            "duration": "5.73ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "1.02ms",
+                "duration": "1.01ms",
                 "nested": {
-                  "from_slice": "960.00µs"
+                  "from_slice": "954.00µs"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "320.00µs",
+                "duration": "326.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "34.00µs",
-                  "air_parser::parser::air_parser::parse": "167.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "38.00µs",
+                  "air_parser::parser::air_parser::parse": "168.00µs"
                 }
               },
-              "runner::execute": "750.00µs",
+              "runner::execute": "766.00µs",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "463.00µs",
+                "duration": "468.00µs",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "443.00µs",
+                    "duration": "446.00µs",
                     "nested": {
                       "populate_outcome_from_contexts": "402.00µs"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "102.00µs",
+              "signing_step::sign_produced_cids": "103.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "2.87ms",
+                "duration": "2.89ms",
                 "nested": {
-                  "verify": "158.00µs"
+                  "verify": "151.00µs"
                 }
               }
             }
           }
         },
-        "total_time": "5.70ms"
+        "total_time": "5.73ms"
       },
       "long-data": {
         "comment": "Long data trace",
@@ -2909,49 +2909,49 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "4.96ms",
+            "duration": "4.98ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "1.89ms",
+                "duration": "1.91ms",
                 "nested": {
-                  "from_slice": "1.84ms"
+                  "from_slice": "1.86ms"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "183.00µs",
+                "duration": "191.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "35.00µs",
-                  "air_parser::parser::air_parser::parse": "28.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "40.00µs",
+                  "air_parser::parser::air_parser::parse": "31.00µs"
                 }
               },
-              "runner::execute": "12.00µs",
+              "runner::execute": "8.00µs",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "888.00µs",
+                "duration": "907.00µs",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "868.00µs",
+                    "duration": "887.00µs",
                     "nested": {
-                      "populate_outcome_from_contexts": "836.00µs"
+                      "populate_outcome_from_contexts": "849.00µs"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "99.00µs",
+              "signing_step::sign_produced_cids": "101.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
                 "duration": "1.71ms",
                 "nested": {
-                  "verify": "664.00µs"
+                  "verify": "659.00µs"
                 }
               }
             }
           }
         },
-        "total_time": "4.96ms"
+        "total_time": "4.98ms"
       },
       "multiple-cids10": {
         "comment": "verifying multiple CIDs for single peer",
@@ -2962,49 +2962,49 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "2.54ms",
+            "duration": "2.53ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "434.00µs",
+                "duration": "435.00µs",
                 "nested": {
                   "from_slice": "381.00µs"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "206.00µs",
+                "duration": "210.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "27.00µs",
+                  "air::preparation_step::preparation::make_exec_ctx": "31.00µs",
                   "air_parser::parser::air_parser::parse": "61.00µs"
                 }
               },
-              "runner::execute": "408.00µs",
+              "runner::execute": "414.00µs",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "318.00µs",
+                "duration": "326.00µs",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "298.00µs",
+                    "duration": "306.00µs",
                     "nested": {
-                      "populate_outcome_from_contexts": "251.00µs"
+                      "populate_outcome_from_contexts": "255.00µs"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "100.00µs",
+              "signing_step::sign_produced_cids": "102.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "896.00µs",
+                "duration": "882.00µs",
                 "nested": {
-                  "verify": "182.00µs"
+                  "verify": "176.00µs"
                 }
               }
             }
           }
         },
-        "total_time": "2.54ms"
+        "total_time": "2.53ms"
       },
       "multiple-peers8": {
         "comment": "verifying many CIDs for many peers",
@@ -3015,49 +3015,49 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "9.38ms",
+            "duration": "9.40ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "1.37ms",
+                "duration": "1.38ms",
                 "nested": {
-                  "from_slice": "1.31ms"
+                  "from_slice": "1.32ms"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "257.00µs",
+                "duration": "265.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "72.00µs",
-                  "air_parser::parser::air_parser::parse": "68.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "79.00µs",
+                  "air_parser::parser::air_parser::parse": "67.00µs"
                 }
               },
-              "runner::execute": "2.64ms",
+              "runner::execute": "2.65ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "900.00µs",
+                "duration": "914.00µs",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "880.00µs",
+                    "duration": "894.00µs",
                     "nested": {
-                      "populate_outcome_from_contexts": "783.00µs"
+                      "populate_outcome_from_contexts": "791.00µs"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "100.00µs",
+              "signing_step::sign_produced_cids": "101.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "3.94ms",
+                "duration": "3.92ms",
                 "nested": {
-                  "verify": "743.00µs"
+                  "verify": "734.00µs"
                 }
               }
             }
           }
         },
-        "total_time": "9.38ms"
+        "total_time": "9.40ms"
       },
       "multiple-sigs30": {
         "comment": "signing multiple CIDs",
@@ -3068,38 +3068,38 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "17.44ms",
+            "duration": "17.54ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "3.91ms",
+                "duration": "3.96ms",
                 "nested": {
-                  "from_slice": "3.85ms"
+                  "from_slice": "3.90ms"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "334.00µs",
+                "duration": "344.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "150.00µs",
-                  "air_parser::parser::air_parser::parse": "66.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "156.00µs",
+                  "air_parser::parser::air_parser::parse": "67.00µs"
                 }
               },
-              "runner::execute": "7.01ms",
+              "runner::execute": "7.06ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "2.56ms",
+                "duration": "2.57ms",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "2.54ms",
+                    "duration": "2.55ms",
                     "nested": {
                       "populate_outcome_from_contexts": "2.37ms"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "447.00µs",
+              "signing_step::sign_produced_cids": "445.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
                 "duration": "2.98ms",
@@ -3110,7 +3110,7 @@
             }
           }
         },
-        "total_time": "17.44ms"
+        "total_time": "17.54ms"
       },
       "network-explore": {
         "comment": "5 peers of network are discovered",
@@ -3121,49 +3121,49 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "3.08ms",
+            "duration": "3.07ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "498.00µs",
+                "duration": "494.00µs",
                 "nested": {
-                  "from_slice": "442.00µs"
+                  "from_slice": "439.00µs"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "220.00µs",
+                "duration": "228.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "21.00µs",
+                  "air::preparation_step::preparation::make_exec_ctx": "26.00µs",
                   "air_parser::parser::air_parser::parse": "81.00µs"
                 }
               },
-              "runner::execute": "139.00µs",
+              "runner::execute": "145.00µs",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "253.00µs",
+                "duration": "257.00µs",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "233.00µs",
+                    "duration": "238.00µs",
                     "nested": {
-                      "populate_outcome_from_contexts": "197.00µs"
+                      "populate_outcome_from_contexts": "199.00µs"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "104.00µs",
+              "signing_step::sign_produced_cids": "103.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "1.69ms",
+                "duration": "1.68ms",
                 "nested": {
-                  "verify": "64.00µs"
+                  "verify": "60.00µs"
                 }
               }
             }
           }
         },
-        "total_time": "3.08ms"
+        "total_time": "3.07ms"
       },
       "null": {
         "comment": "Empty data and null script",
@@ -3174,65 +3174,65 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "757.00µs",
+            "duration": "741.00µs",
             "nested": {
-              "preparation_step::preparation::parse_data": "31.00µs",
+              "preparation_step::preparation::parse_data": "30.00µs",
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "193.00µs",
+                "duration": "198.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "21.00µs",
-                  "air_parser::parser::air_parser::parse": "34.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "27.00µs",
+                  "air_parser::parser::air_parser::parse": "37.00µs"
                 }
               },
-              "runner::execute": "11.00µs",
+              "runner::execute": "8.00µs",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "181.00µs",
+                "duration": "183.00µs",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "161.00µs",
+                    "duration": "164.00µs",
                     "nested": {
-                      "populate_outcome_from_contexts": "125.00µs"
+                      "populate_outcome_from_contexts": "128.00µs"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "108.00µs",
+              "signing_step::sign_produced_cids": "104.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "44.00µs",
+                "duration": "38.00µs",
                 "nested": {
-                  "verify": "12.00µs"
+                  "verify": "10.00µs"
                 }
               }
             }
           }
         },
-        "total_time": "757.00µs"
+        "total_time": "741.00µs"
       },
       "parser-10000-100": {
         "comment": "long air script with lot of variable assignments",
         "memory_sizes": [
-          "57.688 MiB",
-          "57.688 MiB"
+          "54.938 MiB",
+          "54.938 MiB"
         ],
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "23.45ms",
+            "duration": "23.04ms",
             "nested": {
-              "preparation_step::preparation::parse_data": "30.00µs",
+              "preparation_step::preparation::parse_data": "29.00µs",
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "21.84ms",
+                "duration": "21.53ms",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "20.00µs",
-                  "air_parser::parser::air_parser::parse": "21.66ms"
+                  "air::preparation_step::preparation::make_exec_ctx": "31.00µs",
+                  "air_parser::parser::air_parser::parse": "21.35ms"
                 }
               },
-              "runner::execute": "45.00µs",
+              "runner::execute": "46.00µs",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
                 "duration": "188.00µs",
@@ -3241,23 +3241,23 @@
                     "common_prefix": "air::farewell_step::outcome",
                     "duration": "168.00µs",
                     "nested": {
-                      "populate_outcome_from_contexts": "128.00µs"
+                      "populate_outcome_from_contexts": "132.00µs"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "110.00µs",
+              "signing_step::sign_produced_cids": "105.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "43.00µs",
+                "duration": "40.00µs",
                 "nested": {
-                  "verify": "12.00µs"
+                  "verify": "9.00µs"
                 }
               }
             }
           }
         },
-        "total_time": "23.45ms"
+        "total_time": "23.04ms"
       },
       "populate-map-multiple-keys": {
         "comment": "benchmarking a map insert operation",
@@ -3272,39 +3272,39 @@
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "167.00µs",
+                "duration": "168.00µs",
                 "nested": {
-                  "from_slice": "120.00µs"
+                  "from_slice": "122.00µs"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "201.00µs",
+                "duration": "209.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "18.00µs",
-                  "air_parser::parser::air_parser::parse": "65.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "23.00µs",
+                  "air_parser::parser::air_parser::parse": "66.00µs"
                 }
               },
-              "runner::execute": "2.10ms",
+              "runner::execute": "2.11ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "291.00µs",
+                "duration": "295.00µs",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "271.00µs",
+                    "duration": "275.00µs",
                     "nested": {
-                      "populate_outcome_from_contexts": "235.00µs"
+                      "populate_outcome_from_contexts": "236.00µs"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "98.00µs",
+              "signing_step::sign_produced_cids": "100.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "394.00µs",
+                "duration": "386.00µs",
                 "nested": {
-                  "verify": "41.00µs"
+                  "verify": "36.00µs"
                 }
               }
             }
@@ -3332,32 +3332,32 @@
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "198.00µs",
+                "duration": "207.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "18.00µs",
-                  "air_parser::parser::air_parser::parse": "63.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "23.00µs",
+                  "air_parser::parser::air_parser::parse": "65.00µs"
                 }
               },
               "runner::execute": "1.30ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "311.00µs",
+                "duration": "317.00µs",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "290.00µs",
+                    "duration": "297.00µs",
                     "nested": {
-                      "populate_outcome_from_contexts": "235.00µs"
+                      "populate_outcome_from_contexts": "240.00µs"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "99.00µs",
+              "signing_step::sign_produced_cids": "100.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "426.00µs",
+                "duration": "419.00µs",
                 "nested": {
-                  "verify": "75.00µs"
+                  "verify": "69.00µs"
                 }
               }
             }
@@ -3366,9 +3366,9 @@
         "total_time": "2.74ms"
       }
     },
-    "datetime": "2023-11-30 15:45:29.190158+00:00",
+    "datetime": "2023-12-08 15:19:32.841413+00:00",
     "features": "check_signatures,gen_signatures",
-    "platform": "macOS-14.1.1-arm64-arm-64bit",
+    "platform": "macOS-14.1.2-arm64-arm-64bit",
     "version": "0.54.0"
   },
   "e536f8eaae8c978493a773ba566ae3393e2e6240d6ea8e05b5ca1b8f77e9c441": {

--- a/benches/PERFORMANCE.json
+++ b/benches/PERFORMANCE.json
@@ -2379,24 +2379,24 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "13.01ms",
+            "duration": "13.10ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "5.31ms",
+                "duration": "5.36ms",
                 "nested": {
-                  "from_slice": "5.26ms"
+                  "from_slice": "5.30ms"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "182.00µs",
+                "duration": "170.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "28.00µs",
-                  "air_parser::parser::air_parser::parse": "33.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "22.00µs",
+                  "air_parser::parser::air_parser::parse": "32.00µs"
                 }
               },
-              "runner::execute": "9.00µs",
+              "runner::execute": "8.00µs",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
                 "duration": "3.29ms",
@@ -2410,18 +2410,18 @@
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "102.00µs",
+              "signing_step::sign_produced_cids": "100.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "3.98ms",
+                "duration": "3.99ms",
                 "nested": {
-                  "verify": "3.62ms"
+                  "verify": "3.63ms"
                 }
               }
             }
           }
         },
-        "total_time": "13.01ms"
+        "total_time": "13.10ms"
       },
       "call-requests500": {
         "comment": "multiple call requests",
@@ -2432,41 +2432,41 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "25.90ms",
+            "duration": "26.11ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "147.00µs",
+                "duration": "134.00µs",
                 "nested": {
-                  "from_slice": "101.00µs"
+                  "from_slice": "97.00µs"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "254.00µs",
+                "duration": "238.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "52.00µs",
-                  "air_parser::parser::air_parser::parse": "76.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "48.00µs",
+                  "air_parser::parser::air_parser::parse": "68.00µs"
                 }
               },
-              "runner::execute": "20.00ms",
+              "runner::execute": "20.23ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "5.15ms",
+                "duration": "5.16ms",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "5.13ms",
+                    "duration": "5.14ms",
                     "nested": {
-                      "populate_outcome_from_contexts": "5.02ms"
+                      "populate_outcome_from_contexts": "5.04ms"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "106.00µs",
+              "signing_step::sign_produced_cids": "107.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "76.00µs",
+                "duration": "75.00µs",
                 "nested": {
                   "verify": "9.00µs"
                 }
@@ -2474,7 +2474,7 @@
             }
           }
         },
-        "total_time": "25.90ms"
+        "total_time": "26.11ms"
       },
       "call-results500": {
         "comment": "multiple call results",
@@ -2485,41 +2485,41 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "15.70ms",
+            "duration": "15.96ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "621.00µs",
+                "duration": "624.00µs",
                 "nested": {
-                  "from_slice": "577.00µs"
+                  "from_slice": "581.00µs"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "1.01ms",
+                "duration": "1.00ms",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "812.00µs",
-                  "air_parser::parser::air_parser::parse": "72.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "810.00µs",
+                  "air_parser::parser::air_parser::parse": "67.00µs"
                 }
               },
-              "runner::execute": "11.70ms",
+              "runner::execute": "11.94ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "1.81ms",
+                "duration": "1.82ms",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "1.78ms",
+                    "duration": "1.79ms",
                     "nested": {
-                      "populate_outcome_from_contexts": "1.33ms"
+                      "populate_outcome_from_contexts": "1.35ms"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "289.00µs",
+              "signing_step::sign_produced_cids": "292.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "90.00µs",
+                "duration": "92.00µs",
                 "nested": {
                   "verify": "9.00µs"
                 }
@@ -2527,7 +2527,7 @@
             }
           }
         },
-        "total_time": "15.70ms"
+        "total_time": "15.96ms"
       },
       "canon-map-key-by-lens": {
         "comment": "benchmarking a map insert operation",
@@ -2538,49 +2538,49 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "10.84ms",
+            "duration": "10.80ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "3.17ms",
+                "duration": "3.18ms",
                 "nested": {
                   "from_slice": "3.13ms"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "396.00µs",
+                "duration": "378.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "192.00µs",
-                  "air_parser::parser::air_parser::parse": "79.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "189.00µs",
+                  "air_parser::parser::air_parser::parse": "73.00µs"
                 }
               },
-              "runner::execute": "1.95ms",
+              "runner::execute": "1.94ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "1.88ms",
+                "duration": "1.87ms",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "1.86ms",
+                    "duration": "1.85ms",
                     "nested": {
                       "populate_outcome_from_contexts": "1.49ms"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "102.00µs",
+              "signing_step::sign_produced_cids": "99.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "3.17ms",
+                "duration": "3.15ms",
                 "nested": {
-                  "verify": "2.80ms"
+                  "verify": "2.79ms"
                 }
               }
             }
           }
         },
-        "total_time": "10.84ms"
+        "total_time": "10.80ms"
       },
       "canon-map-key-element-by-lens": {
         "comment": "benchmarking a map insert operation",
@@ -2595,39 +2595,39 @@
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "3.16ms",
+                "duration": "3.18ms",
                 "nested": {
-                  "from_slice": "3.12ms"
+                  "from_slice": "3.13ms"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "395.00µs",
+                "duration": "387.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "192.00µs",
-                  "air_parser::parser::air_parser::parse": "82.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "194.00µs",
+                  "air_parser::parser::air_parser::parse": "75.00µs"
                 }
               },
               "runner::execute": "1.93ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "1.87ms",
+                "duration": "1.86ms",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "1.85ms",
+                    "duration": "1.84ms",
                     "nested": {
-                      "populate_outcome_from_contexts": "1.51ms"
+                      "populate_outcome_from_contexts": "1.50ms"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "101.00µs",
+              "signing_step::sign_produced_cids": "99.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "3.16ms",
+                "duration": "3.15ms",
                 "nested": {
-                  "verify": "2.80ms"
+                  "verify": "2.79ms"
                 }
               }
             }
@@ -2648,27 +2648,27 @@
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "423.00µs",
+                "duration": "410.00µs",
                 "nested": {
-                  "from_slice": "377.00µs"
+                  "from_slice": "363.00µs"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "209.00µs",
+                "duration": "196.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "23.00µs",
-                  "air_parser::parser::air_parser::parse": "66.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "20.00µs",
+                  "air_parser::parser::air_parser::parse": "59.00µs"
                 }
               },
-              "runner::execute": "6.04ms",
+              "runner::execute": "6.05ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
                 "duration": "1.63ms",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "1.61ms",
+                    "duration": "1.60ms",
                     "nested": {
                       "populate_outcome_from_contexts": "1.32ms"
                     }
@@ -2678,9 +2678,9 @@
               "signing_step::sign_produced_cids": "100.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "401.00µs",
+                "duration": "406.00µs",
                 "nested": {
-                  "verify": "35.00µs"
+                  "verify": "39.00µs"
                 }
               }
             }
@@ -2697,49 +2697,49 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "4.11ms",
+            "duration": "4.10ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "430.00µs",
+                "duration": "420.00µs",
                 "nested": {
-                  "from_slice": "385.00µs"
+                  "from_slice": "369.00µs"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "213.00µs",
+                "duration": "195.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "24.00µs",
-                  "air_parser::parser::air_parser::parse": "69.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "20.00µs",
+                  "air_parser::parser::air_parser::parse": "59.00µs"
                 }
               },
-              "runner::execute": "2.44ms",
+              "runner::execute": "2.45ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "352.00µs",
+                "duration": "349.00µs",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "332.00µs",
+                    "duration": "329.00µs",
                     "nested": {
-                      "populate_outcome_from_contexts": "294.00µs"
+                      "populate_outcome_from_contexts": "292.00µs"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "101.00µs",
+              "signing_step::sign_produced_cids": "99.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "404.00µs",
+                "duration": "406.00µs",
                 "nested": {
-                  "verify": "34.00µs"
+                  "verify": "40.00µs"
                 }
               }
             }
           }
         },
-        "total_time": "4.11ms"
+        "total_time": "4.10ms"
       },
       "canon-map-scalar-single-key": {
         "comment": "benchmarking a map insert operation",
@@ -2750,49 +2750,49 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "3.28ms",
+            "duration": "3.26ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "427.00µs",
+                "duration": "423.00µs",
                 "nested": {
-                  "from_slice": "379.00µs"
+                  "from_slice": "375.00µs"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "205.00µs",
+                "duration": "192.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "23.00µs",
-                  "air_parser::parser::air_parser::parse": "62.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "19.00µs",
+                  "air_parser::parser::air_parser::parse": "56.00µs"
                 }
               },
-              "runner::execute": "1.58ms",
+              "runner::execute": "1.57ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "362.00µs",
+                "duration": "359.00µs",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "343.00µs",
+                    "duration": "339.00µs",
                     "nested": {
-                      "populate_outcome_from_contexts": "287.00µs"
+                      "populate_outcome_from_contexts": "284.00µs"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "101.00µs",
+              "signing_step::sign_produced_cids": "99.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "432.00µs",
+                "duration": "435.00µs",
                 "nested": {
-                  "verify": "70.00µs"
+                  "verify": "73.00µs"
                 }
               }
             }
           }
         },
-        "total_time": "3.28ms"
+        "total_time": "3.26ms"
       },
       "canon-map-single-key": {
         "comment": "benchmarking a map insert operation",
@@ -2803,49 +2803,49 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "7.51ms",
+            "duration": "7.48ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "429.00µs",
+                "duration": "421.00µs",
                 "nested": {
-                  "from_slice": "383.00µs"
+                  "from_slice": "373.00µs"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "204.00µs",
+                "duration": "192.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "23.00µs",
-                  "air_parser::parser::air_parser::parse": "62.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "20.00µs",
+                  "air_parser::parser::air_parser::parse": "56.00µs"
                 }
               },
-              "runner::execute": "4.45ms",
+              "runner::execute": "4.44ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "1.73ms",
+                "duration": "1.72ms",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "1.71ms",
+                    "duration": "1.70ms",
                     "nested": {
                       "populate_outcome_from_contexts": "1.46ms"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "101.00µs",
+              "signing_step::sign_produced_cids": "99.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "430.00µs",
+                "duration": "434.00µs",
                 "nested": {
-                  "verify": "69.00µs"
+                  "verify": "72.00µs"
                 }
               }
             }
           }
         },
-        "total_time": "7.51ms"
+        "total_time": "7.48ms"
       },
       "dashboard": {
         "comment": "big dashboard test",
@@ -2856,49 +2856,49 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "5.73ms",
+            "duration": "5.69ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
                 "duration": "1.01ms",
                 "nested": {
-                  "from_slice": "954.00µs"
+                  "from_slice": "955.00µs"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "326.00µs",
+                "duration": "313.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "38.00µs",
-                  "air_parser::parser::air_parser::parse": "168.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "36.00µs",
+                  "air_parser::parser::air_parser::parse": "160.00µs"
                 }
               },
-              "runner::execute": "766.00µs",
+              "runner::execute": "759.00µs",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "468.00µs",
+                "duration": "461.00µs",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "446.00µs",
+                    "duration": "441.00µs",
                     "nested": {
-                      "populate_outcome_from_contexts": "402.00µs"
+                      "populate_outcome_from_contexts": "398.00µs"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "103.00µs",
+              "signing_step::sign_produced_cids": "101.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "2.89ms",
+                "duration": "2.87ms",
                 "nested": {
-                  "verify": "151.00µs"
+                  "verify": "157.00µs"
                 }
               }
             }
           }
         },
-        "total_time": "5.73ms"
+        "total_time": "5.69ms"
       },
       "long-data": {
         "comment": "Long data trace",
@@ -2909,49 +2909,49 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "4.98ms",
+            "duration": "5.01ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "1.91ms",
+                "duration": "1.95ms",
                 "nested": {
-                  "from_slice": "1.86ms"
+                  "from_slice": "1.89ms"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "191.00µs",
+                "duration": "182.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "40.00µs",
+                  "air::preparation_step::preparation::make_exec_ctx": "34.00µs",
                   "air_parser::parser::air_parser::parse": "31.00µs"
                 }
               },
               "runner::execute": "8.00µs",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "907.00µs",
+                "duration": "895.00µs",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "887.00µs",
+                    "duration": "876.00µs",
                     "nested": {
-                      "populate_outcome_from_contexts": "849.00µs"
+                      "populate_outcome_from_contexts": "838.00µs"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "101.00µs",
+              "signing_step::sign_produced_cids": "98.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
                 "duration": "1.71ms",
                 "nested": {
-                  "verify": "659.00µs"
+                  "verify": "662.00µs"
                 }
               }
             }
           }
         },
-        "total_time": "4.98ms"
+        "total_time": "5.01ms"
       },
       "multiple-cids10": {
         "comment": "verifying multiple CIDs for single peer",
@@ -2966,39 +2966,39 @@
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "435.00µs",
+                "duration": "425.00µs",
                 "nested": {
-                  "from_slice": "381.00µs"
+                  "from_slice": "371.00µs"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "210.00µs",
+                "duration": "206.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "31.00µs",
-                  "air_parser::parser::air_parser::parse": "61.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "30.00µs",
+                  "air_parser::parser::air_parser::parse": "60.00µs"
                 }
               },
-              "runner::execute": "414.00µs",
+              "runner::execute": "418.00µs",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "326.00µs",
+                "duration": "320.00µs",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "306.00µs",
+                    "duration": "299.00µs",
                     "nested": {
-                      "populate_outcome_from_contexts": "255.00µs"
+                      "populate_outcome_from_contexts": "249.00µs"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "102.00µs",
+              "signing_step::sign_produced_cids": "99.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "882.00µs",
+                "duration": "890.00µs",
                 "nested": {
-                  "verify": "176.00µs"
+                  "verify": "180.00µs"
                 }
               }
             }
@@ -3015,49 +3015,49 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "9.40ms",
+            "duration": "9.43ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
                 "duration": "1.38ms",
                 "nested": {
-                  "from_slice": "1.32ms"
+                  "from_slice": "1.33ms"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "265.00µs",
+                "duration": "258.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "79.00µs",
-                  "air_parser::parser::air_parser::parse": "67.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "78.00µs",
+                  "air_parser::parser::air_parser::parse": "64.00µs"
                 }
               },
-              "runner::execute": "2.65ms",
+              "runner::execute": "2.68ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "914.00µs",
+                "duration": "896.00µs",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "894.00µs",
+                    "duration": "875.00µs",
                     "nested": {
-                      "populate_outcome_from_contexts": "791.00µs"
+                      "populate_outcome_from_contexts": "774.00µs"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "101.00µs",
+              "signing_step::sign_produced_cids": "99.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "3.92ms",
+                "duration": "3.93ms",
                 "nested": {
-                  "verify": "734.00µs"
+                  "verify": "733.00µs"
                 }
               }
             }
           }
         },
-        "total_time": "9.40ms"
+        "total_time": "9.43ms"
       },
       "multiple-sigs30": {
         "comment": "signing multiple CIDs",
@@ -3068,7 +3068,7 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "17.54ms",
+            "duration": "17.47ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
@@ -3079,38 +3079,38 @@
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "344.00µs",
+                "duration": "330.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "156.00µs",
-                  "air_parser::parser::air_parser::parse": "67.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "151.00µs",
+                  "air_parser::parser::air_parser::parse": "63.00µs"
                 }
               },
-              "runner::execute": "7.06ms",
+              "runner::execute": "7.04ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "2.57ms",
+                "duration": "2.55ms",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "2.55ms",
+                    "duration": "2.53ms",
                     "nested": {
-                      "populate_outcome_from_contexts": "2.37ms"
+                      "populate_outcome_from_contexts": "2.35ms"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "445.00µs",
+              "signing_step::sign_produced_cids": "443.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "2.98ms",
+                "duration": "2.96ms",
                 "nested": {
-                  "verify": "1.27ms"
+                  "verify": "1.26ms"
                 }
               }
             }
           }
         },
-        "total_time": "17.54ms"
+        "total_time": "17.47ms"
       },
       "network-explore": {
         "comment": "5 peers of network are discovered",
@@ -3125,39 +3125,39 @@
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "494.00µs",
+                "duration": "490.00µs",
                 "nested": {
-                  "from_slice": "439.00µs"
+                  "from_slice": "434.00µs"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "228.00µs",
+                "duration": "219.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "26.00µs",
-                  "air_parser::parser::air_parser::parse": "81.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "25.00µs",
+                  "air_parser::parser::air_parser::parse": "78.00µs"
                 }
               },
-              "runner::execute": "145.00µs",
+              "runner::execute": "144.00µs",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "257.00µs",
+                "duration": "251.00µs",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "238.00µs",
+                    "duration": "231.00µs",
                     "nested": {
-                      "populate_outcome_from_contexts": "199.00µs"
+                      "populate_outcome_from_contexts": "193.00µs"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "103.00µs",
+              "signing_step::sign_produced_cids": "100.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "1.68ms",
+                "duration": "1.69ms",
                 "nested": {
-                  "verify": "60.00µs"
+                  "verify": "65.00µs"
                 }
               }
             }
@@ -3174,121 +3174,27 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "741.00µs",
+            "duration": "737.00µs",
             "nested": {
-              "preparation_step::preparation::parse_data": "30.00µs",
+              "preparation_step::preparation::parse_data": "23.00µs",
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "198.00µs",
+                "duration": "190.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "27.00µs",
-                  "air_parser::parser::air_parser::parse": "37.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "23.00µs",
+                  "air_parser::parser::air_parser::parse": "34.00µs"
                 }
               },
               "runner::execute": "8.00µs",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "183.00µs",
+                "duration": "184.00µs",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "164.00µs",
+                    "duration": "165.00µs",
                     "nested": {
-                      "populate_outcome_from_contexts": "128.00µs"
-                    }
-                  }
-                }
-              },
-              "signing_step::sign_produced_cids": "104.00µs",
-              "verification_step::verify": {
-                "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "38.00µs",
-                "nested": {
-                  "verify": "10.00µs"
-                }
-              }
-            }
-          }
-        },
-        "total_time": "741.00µs"
-      },
-      "parser-10000-100": {
-        "comment": "long air script with lot of variable assignments",
-        "memory_sizes": [
-          "54.938 MiB",
-          "54.938 MiB"
-        ],
-        "stats": {
-          "air::runner::execute_air": {
-            "common_prefix": "air",
-            "duration": "23.04ms",
-            "nested": {
-              "preparation_step::preparation::parse_data": "29.00µs",
-              "preparation_step::preparation::prepare": {
-                "common_prefix": "",
-                "duration": "21.53ms",
-                "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "31.00µs",
-                  "air_parser::parser::air_parser::parse": "21.35ms"
-                }
-              },
-              "runner::execute": "46.00µs",
-              "runner::farewell": {
-                "common_prefix": "air::farewell_step::outcome",
-                "duration": "188.00µs",
-                "nested": {
-                  "from_success_result": {
-                    "common_prefix": "air::farewell_step::outcome",
-                    "duration": "168.00µs",
-                    "nested": {
-                      "populate_outcome_from_contexts": "132.00µs"
-                    }
-                  }
-                }
-              },
-              "signing_step::sign_produced_cids": "105.00µs",
-              "verification_step::verify": {
-                "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "40.00µs",
-                "nested": {
-                  "verify": "9.00µs"
-                }
-              }
-            }
-          }
-        },
-        "total_time": "23.04ms"
-      },
-      "parser-calls-10000-100": {
-        "comment": "multiple calls parser benchmark",
-        "memory_sizes": [
-          "54.500 MiB",
-          "54.500 MiB"
-        ],
-        "stats": {
-          "air::runner::execute_air": {
-            "common_prefix": "air",
-            "duration": "22.76ms",
-            "nested": {
-              "preparation_step::preparation::parse_data": "28.00µs",
-              "preparation_step::preparation::prepare": {
-                "common_prefix": "",
-                "duration": "21.04ms",
-                "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "28.00µs",
-                  "air_parser::parser::air_parser::parse": "20.87ms"
-                }
-              },
-              "runner::execute": "47.00µs",
-              "runner::farewell": {
-                "common_prefix": "air::farewell_step::outcome",
-                "duration": "188.00µs",
-                "nested": {
-                  "from_success_result": {
-                    "common_prefix": "air::farewell_step::outcome",
-                    "duration": "167.00µs",
-                    "nested": {
-                      "populate_outcome_from_contexts": "131.00µs"
+                      "populate_outcome_from_contexts": "125.00µs"
                     }
                   }
                 }
@@ -3296,15 +3202,109 @@
               "signing_step::sign_produced_cids": "106.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "39.00µs",
+                "duration": "44.00µs",
                 "nested": {
-                  "verify": "9.00µs"
+                  "verify": "10.00µs"
                 }
               }
             }
           }
         },
-        "total_time": "22.76ms"
+        "total_time": "737.00µs"
+      },
+      "parser-10000-100": {
+        "comment": "long air script with lot of variable assignments",
+        "memory_sizes": [
+          "54.625 MiB",
+          "54.625 MiB"
+        ],
+        "stats": {
+          "air::runner::execute_air": {
+            "common_prefix": "air",
+            "duration": "22.89ms",
+            "nested": {
+              "preparation_step::preparation::parse_data": "25.00µs",
+              "preparation_step::preparation::prepare": {
+                "common_prefix": "",
+                "duration": "21.40ms",
+                "nested": {
+                  "air::preparation_step::preparation::make_exec_ctx": "23.00µs",
+                  "air_parser::parser::air_parser::parse": "21.25ms"
+                }
+              },
+              "runner::execute": "39.00µs",
+              "runner::farewell": {
+                "common_prefix": "air::farewell_step::outcome",
+                "duration": "187.00µs",
+                "nested": {
+                  "from_success_result": {
+                    "common_prefix": "air::farewell_step::outcome",
+                    "duration": "168.00µs",
+                    "nested": {
+                      "populate_outcome_from_contexts": "131.00µs"
+                    }
+                  }
+                }
+              },
+              "signing_step::sign_produced_cids": "107.00µs",
+              "verification_step::verify": {
+                "common_prefix": "air_interpreter_data::cid_info",
+                "duration": "45.00µs",
+                "nested": {
+                  "verify": "11.00µs"
+                }
+              }
+            }
+          }
+        },
+        "total_time": "22.89ms"
+      },
+      "parser-calls-10000-100": {
+        "comment": "multiple calls parser benchmark",
+        "memory_sizes": [
+          "54.375 MiB",
+          "54.375 MiB"
+        ],
+        "stats": {
+          "air::runner::execute_air": {
+            "common_prefix": "air",
+            "duration": "22.65ms",
+            "nested": {
+              "preparation_step::preparation::parse_data": "25.00µs",
+              "preparation_step::preparation::prepare": {
+                "common_prefix": "",
+                "duration": "21.00ms",
+                "nested": {
+                  "air::preparation_step::preparation::make_exec_ctx": "25.00µs",
+                  "air_parser::parser::air_parser::parse": "20.84ms"
+                }
+              },
+              "runner::execute": "39.00µs",
+              "runner::farewell": {
+                "common_prefix": "air::farewell_step::outcome",
+                "duration": "187.00µs",
+                "nested": {
+                  "from_success_result": {
+                    "common_prefix": "air::farewell_step::outcome",
+                    "duration": "168.00µs",
+                    "nested": {
+                      "populate_outcome_from_contexts": "130.00µs"
+                    }
+                  }
+                }
+              },
+              "signing_step::sign_produced_cids": "107.00µs",
+              "verification_step::verify": {
+                "common_prefix": "air_interpreter_data::cid_info",
+                "duration": "42.00µs",
+                "nested": {
+                  "verify": "10.00µs"
+                }
+              }
+            }
+          }
+        },
+        "total_time": "22.65ms"
       },
       "populate-map-multiple-keys": {
         "comment": "benchmarking a map insert operation",
@@ -3315,33 +3315,33 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "3.44ms",
+            "duration": "3.45ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "168.00µs",
+                "duration": "162.00µs",
                 "nested": {
-                  "from_slice": "122.00µs"
+                  "from_slice": "113.00µs"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "209.00µs",
+                "duration": "196.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "23.00µs",
-                  "air_parser::parser::air_parser::parse": "66.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "19.00µs",
+                  "air_parser::parser::air_parser::parse": "60.00µs"
                 }
               },
-              "runner::execute": "2.11ms",
+              "runner::execute": "2.14ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "295.00µs",
+                "duration": "285.00µs",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "275.00µs",
+                    "duration": "266.00µs",
                     "nested": {
-                      "populate_outcome_from_contexts": "236.00µs"
+                      "populate_outcome_from_contexts": "231.00µs"
                     }
                   }
                 }
@@ -3349,15 +3349,15 @@
               "signing_step::sign_produced_cids": "100.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "386.00µs",
+                "duration": "392.00µs",
                 "nested": {
-                  "verify": "36.00µs"
+                  "verify": "39.00µs"
                 }
               }
             }
           }
         },
-        "total_time": "3.44ms"
+        "total_time": "3.45ms"
       },
       "populate-map-single-key": {
         "comment": "benchmarking a map insert operation",
@@ -3368,52 +3368,52 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "2.74ms",
+            "duration": "2.73ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "223.00µs",
+                "duration": "215.00µs",
                 "nested": {
-                  "from_slice": "176.00µs"
+                  "from_slice": "168.00µs"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "207.00µs",
+                "duration": "195.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "23.00µs",
-                  "air_parser::parser::air_parser::parse": "65.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "20.00µs",
+                  "air_parser::parser::air_parser::parse": "60.00µs"
                 }
               },
               "runner::execute": "1.30ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "317.00µs",
+                "duration": "308.00µs",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "297.00µs",
+                    "duration": "289.00µs",
                     "nested": {
-                      "populate_outcome_from_contexts": "240.00µs"
+                      "populate_outcome_from_contexts": "235.00µs"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "100.00µs",
+              "signing_step::sign_produced_cids": "99.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "419.00µs",
+                "duration": "425.00µs",
                 "nested": {
-                  "verify": "69.00µs"
+                  "verify": "74.00µs"
                 }
               }
             }
           }
         },
-        "total_time": "2.74ms"
+        "total_time": "2.73ms"
       }
     },
-    "datetime": "2023-12-11 13:56:25.495152+00:00",
+    "datetime": "2023-12-12 10:20:35.572977+00:00",
     "features": "check_signatures,gen_signatures",
     "platform": "macOS-14.1.2-arm64-arm-64bit",
     "version": "0.54.0"

--- a/benches/PERFORMANCE.json
+++ b/benches/PERFORMANCE.json
@@ -3259,6 +3259,53 @@
         },
         "total_time": "23.04ms"
       },
+      "parser-calls-10000-100": {
+        "comment": "multiple calls parser benchmark",
+        "memory_sizes": [
+          "54.500 MiB",
+          "54.500 MiB"
+        ],
+        "stats": {
+          "air::runner::execute_air": {
+            "common_prefix": "air",
+            "duration": "22.76ms",
+            "nested": {
+              "preparation_step::preparation::parse_data": "28.00µs",
+              "preparation_step::preparation::prepare": {
+                "common_prefix": "",
+                "duration": "21.04ms",
+                "nested": {
+                  "air::preparation_step::preparation::make_exec_ctx": "28.00µs",
+                  "air_parser::parser::air_parser::parse": "20.87ms"
+                }
+              },
+              "runner::execute": "47.00µs",
+              "runner::farewell": {
+                "common_prefix": "air::farewell_step::outcome",
+                "duration": "188.00µs",
+                "nested": {
+                  "from_success_result": {
+                    "common_prefix": "air::farewell_step::outcome",
+                    "duration": "167.00µs",
+                    "nested": {
+                      "populate_outcome_from_contexts": "131.00µs"
+                    }
+                  }
+                }
+              },
+              "signing_step::sign_produced_cids": "106.00µs",
+              "verification_step::verify": {
+                "common_prefix": "air_interpreter_data::cid_info",
+                "duration": "39.00µs",
+                "nested": {
+                  "verify": "9.00µs"
+                }
+              }
+            }
+          }
+        },
+        "total_time": "22.76ms"
+      },
       "populate-map-multiple-keys": {
         "comment": "benchmarking a map insert operation",
         "memory_sizes": [
@@ -3366,7 +3413,7 @@
         "total_time": "2.74ms"
       }
     },
-    "datetime": "2023-12-08 15:19:32.841413+00:00",
+    "datetime": "2023-12-11 13:56:25.495152+00:00",
     "features": "check_signatures,gen_signatures",
     "platform": "macOS-14.1.2-arm64-arm-64bit",
     "version": "0.54.0"

--- a/benches/PERFORMANCE.json
+++ b/benches/PERFORMANCE.json
@@ -3429,49 +3429,49 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "17.65ms",
+            "duration": "17.84ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "7.03ms",
+                "duration": "7.24ms",
                 "nested": {
-                  "from_slice": "6.98ms"
+                  "from_slice": "7.19ms"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "214.00µs",
+                "duration": "222.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "20.00µs",
-                  "air_parser::parser::air_parser::parse": "18.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "21.00µs",
+                  "air_parser::parser::air_parser::parse": "19.00µs"
                 }
               },
-              "runner::execute": "9.00µs",
+              "runner::execute": "10.00µs",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "4.71ms",
+                "duration": "4.70ms",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "4.68ms",
+                    "duration": "4.67ms",
                     "nested": {
-                      "populate_outcome_from_contexts": "4.63ms"
+                      "populate_outcome_from_contexts": "4.61ms"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "155.00µs",
+              "signing_step::sign_produced_cids": "158.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "5.40ms",
+                "duration": "5.35ms",
                 "nested": {
-                  "verify": "4.87ms"
+                  "verify": "4.81ms"
                 }
               }
             }
           }
         },
-        "total_time": "17.65ms"
+        "total_time": "17.84ms"
       },
       "call-requests500": {
         "comment": "multiple call requests",
@@ -3482,24 +3482,24 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "35.31ms",
+            "duration": "35.41ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "116.00µs",
+                "duration": "112.00µs",
                 "nested": {
-                  "from_slice": "80.00µs"
+                  "from_slice": "76.00µs"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "276.00µs",
+                "duration": "270.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "38.00µs",
-                  "air_parser::parser::air_parser::parse": "50.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "40.00µs",
+                  "air_parser::parser::air_parser::parse": "48.00µs"
                 }
               },
-              "runner::execute": "25.24ms",
+              "runner::execute": "25.35ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
                 "duration": "9.31ms",
@@ -3513,10 +3513,10 @@
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "161.00µs",
+              "signing_step::sign_produced_cids": "165.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "78.00µs",
+                "duration": "77.00µs",
                 "nested": {
                   "verify": "10.00µs"
                 }
@@ -3524,7 +3524,7 @@
             }
           }
         },
-        "total_time": "35.31ms"
+        "total_time": "35.41ms"
       },
       "call-results500": {
         "comment": "multiple call results",
@@ -3535,24 +3535,24 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "19.65ms",
+            "duration": "19.57ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "676.00µs",
+                "duration": "667.00µs",
                 "nested": {
-                  "from_slice": "636.00µs"
+                  "from_slice": "627.00µs"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "930.00µs",
+                "duration": "931.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "687.00µs",
+                  "air::preparation_step::preparation::make_exec_ctx": "694.00µs",
                   "air_parser::parser::air_parser::parse": "50.00µs"
                 }
               },
-              "runner::execute": "15.19ms",
+              "runner::execute": "15.12ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
                 "duration": "2.20ms",
@@ -3561,7 +3561,7 @@
                     "common_prefix": "air::farewell_step::outcome",
                     "duration": "2.17ms",
                     "nested": {
-                      "populate_outcome_from_contexts": "1.74ms"
+                      "populate_outcome_from_contexts": "1.75ms"
                     }
                   }
                 }
@@ -3569,7 +3569,7 @@
               "signing_step::sign_produced_cids": "432.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "83.00µs",
+                "duration": "82.00µs",
                 "nested": {
                   "verify": "10.00µs"
                 }
@@ -3577,7 +3577,7 @@
             }
           }
         },
-        "total_time": "19.65ms"
+        "total_time": "19.57ms"
       },
       "canon-map-key-by-lens": {
         "comment": "benchmarking a map insert operation",
@@ -3588,60 +3588,7 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "14.99ms",
-            "nested": {
-              "preparation_step::preparation::parse_data": {
-                "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "4.07ms",
-                "nested": {
-                  "from_slice": "4.02ms"
-                }
-              },
-              "preparation_step::preparation::prepare": {
-                "common_prefix": "",
-                "duration": "526.00µs",
-                "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "286.00µs",
-                  "air_parser::parser::air_parser::parse": "56.00µs"
-                }
-              },
-              "runner::execute": "2.76ms",
-              "runner::farewell": {
-                "common_prefix": "air::farewell_step::outcome",
-                "duration": "2.77ms",
-                "nested": {
-                  "from_success_result": {
-                    "common_prefix": "air::farewell_step::outcome",
-                    "duration": "2.75ms",
-                    "nested": {
-                      "populate_outcome_from_contexts": "2.38ms"
-                    }
-                  }
-                }
-              },
-              "signing_step::sign_produced_cids": "160.00µs",
-              "verification_step::verify": {
-                "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "4.55ms",
-                "nested": {
-                  "verify": "4.02ms"
-                }
-              }
-            }
-          }
-        },
-        "total_time": "14.99ms"
-      },
-      "canon-map-key-element-by-lens": {
-        "comment": "benchmarking a map insert operation",
-        "memory_sizes": [
-          "56.625 MiB",
-          "56.625 MiB"
-        ],
-        "stats": {
-          "air::runner::execute_air": {
-            "common_prefix": "air",
-            "duration": "14.93ms",
+            "duration": "14.97ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
@@ -3652,30 +3599,30 @@
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "527.00µs",
+                "duration": "530.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "290.00µs",
-                  "air_parser::parser::air_parser::parse": "58.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "289.00µs",
+                  "air_parser::parser::air_parser::parse": "57.00µs"
                 }
               },
-              "runner::execute": "2.76ms",
+              "runner::execute": "2.75ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "2.74ms",
+                "duration": "2.78ms",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "2.72ms",
+                    "duration": "2.76ms",
                     "nested": {
-                      "populate_outcome_from_contexts": "2.36ms"
+                      "populate_outcome_from_contexts": "2.39ms"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "158.00µs",
+              "signing_step::sign_produced_cids": "160.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "4.51ms",
+                "duration": "4.52ms",
                 "nested": {
                   "verify": "3.98ms"
                 }
@@ -3683,7 +3630,60 @@
             }
           }
         },
-        "total_time": "14.93ms"
+        "total_time": "14.97ms"
+      },
+      "canon-map-key-element-by-lens": {
+        "comment": "benchmarking a map insert operation",
+        "memory_sizes": [
+          "56.625 MiB",
+          "56.625 MiB"
+        ],
+        "stats": {
+          "air::runner::execute_air": {
+            "common_prefix": "air",
+            "duration": "14.92ms",
+            "nested": {
+              "preparation_step::preparation::parse_data": {
+                "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
+                "duration": "4.09ms",
+                "nested": {
+                  "from_slice": "4.04ms"
+                }
+              },
+              "preparation_step::preparation::prepare": {
+                "common_prefix": "",
+                "duration": "526.00µs",
+                "nested": {
+                  "air::preparation_step::preparation::make_exec_ctx": "285.00µs",
+                  "air_parser::parser::air_parser::parse": "58.00µs"
+                }
+              },
+              "runner::execute": "2.73ms",
+              "runner::farewell": {
+                "common_prefix": "air::farewell_step::outcome",
+                "duration": "2.78ms",
+                "nested": {
+                  "from_success_result": {
+                    "common_prefix": "air::farewell_step::outcome",
+                    "duration": "2.75ms",
+                    "nested": {
+                      "populate_outcome_from_contexts": "2.40ms"
+                    }
+                  }
+                }
+              },
+              "signing_step::sign_produced_cids": "161.00µs",
+              "verification_step::verify": {
+                "common_prefix": "air_interpreter_data::cid_info",
+                "duration": "4.51ms",
+                "nested": {
+                  "verify": "3.97ms"
+                }
+              }
+            }
+          }
+        },
+        "total_time": "14.92ms"
       },
       "canon-map-multiple-keys": {
         "comment": "benchmarking a map insert operation",
@@ -3694,41 +3694,41 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "12.56ms",
+            "duration": "12.43ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "356.00µs",
+                "duration": "355.00µs",
                 "nested": {
-                  "from_slice": "315.00µs"
+                  "from_slice": "313.00µs"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "248.00µs",
+                "duration": "247.00µs",
                 "nested": {
                   "air::preparation_step::preparation::make_exec_ctx": "18.00µs",
                   "air_parser::parser::air_parser::parse": "46.00µs"
                 }
               },
-              "runner::execute": "8.75ms",
+              "runner::execute": "8.64ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
                 "duration": "2.31ms",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "2.29ms",
+                    "duration": "2.28ms",
                     "nested": {
                       "populate_outcome_from_contexts": "1.99ms"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "171.00µs",
+              "signing_step::sign_produced_cids": "164.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "580.00µs",
+                "duration": "566.00µs",
                 "nested": {
                   "verify": "28.00µs"
                 }
@@ -3736,7 +3736,7 @@
             }
           }
         },
-        "total_time": "12.56ms"
+        "total_time": "12.43ms"
       },
       "canon-map-scalar-multiple-keys": {
         "comment": "benchmarking a map insert operation",
@@ -3751,39 +3751,39 @@
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "360.00µs",
+                "duration": "358.00µs",
                 "nested": {
-                  "from_slice": "317.00µs"
+                  "from_slice": "316.00µs"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "261.00µs",
+                "duration": "244.00µs",
                 "nested": {
                   "air::preparation_step::preparation::make_exec_ctx": "18.00µs",
-                  "air_parser::parser::air_parser::parse": "46.00µs"
+                  "air_parser::parser::air_parser::parse": "45.00µs"
                 }
               },
-              "runner::execute": "3.34ms",
+              "runner::execute": "3.40ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "449.00µs",
+                "duration": "460.00µs",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "425.00µs",
+                    "duration": "438.00µs",
                     "nested": {
-                      "populate_outcome_from_contexts": "383.00µs"
+                      "populate_outcome_from_contexts": "394.00µs"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "162.00µs",
+              "signing_step::sign_produced_cids": "161.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "620.00µs",
+                "duration": "576.00µs",
                 "nested": {
-                  "verify": "28.00µs"
+                  "verify": "27.00µs"
                 }
               }
             }
@@ -3800,49 +3800,49 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "4.39ms",
+            "duration": "4.35ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "391.00µs",
+                "duration": "387.00µs",
                 "nested": {
-                  "from_slice": "347.00µs"
+                  "from_slice": "342.00µs"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "258.00µs",
+                "duration": "244.00µs",
                 "nested": {
                   "air::preparation_step::preparation::make_exec_ctx": "18.00µs",
-                  "air_parser::parser::air_parser::parse": "44.00µs"
+                  "air_parser::parser::air_parser::parse": "43.00µs"
                 }
               },
               "runner::execute": "2.35ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "443.00µs",
+                "duration": "462.00µs",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "420.00µs",
+                    "duration": "438.00µs",
                     "nested": {
-                      "populate_outcome_from_contexts": "365.00µs"
+                      "populate_outcome_from_contexts": "380.00µs"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "159.00µs",
+              "signing_step::sign_produced_cids": "165.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "650.00µs",
+                "duration": "599.00µs",
                 "nested": {
-                  "verify": "65.00µs"
+                  "verify": "62.00µs"
                 }
               }
             }
           }
         },
-        "total_time": "4.39ms"
+        "total_time": "4.35ms"
       },
       "canon-map-single-key": {
         "comment": "benchmarking a map insert operation",
@@ -3853,49 +3853,49 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "10.82ms",
+            "duration": "10.81ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "383.00µs",
+                "duration": "381.00µs",
                 "nested": {
-                  "from_slice": "343.00µs"
+                  "from_slice": "340.00µs"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "250.00µs",
+                "duration": "239.00µs",
                 "nested": {
                   "air::preparation_step::preparation::make_exec_ctx": "18.00µs",
-                  "air_parser::parser::air_parser::parse": "41.00µs"
+                  "air_parser::parser::air_parser::parse": "43.00µs"
                 }
               },
-              "runner::execute": "6.60ms",
+              "runner::execute": "6.62ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "2.61ms",
+                "duration": "2.68ms",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "2.59ms",
+                    "duration": "2.66ms",
                     "nested": {
-                      "populate_outcome_from_contexts": "2.34ms"
+                      "populate_outcome_from_contexts": "2.40ms"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "166.00µs",
+              "signing_step::sign_produced_cids": "160.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "672.00µs",
+                "duration": "590.00µs",
                 "nested": {
-                  "verify": "63.00µs"
+                  "verify": "61.00µs"
                 }
               }
             }
           }
         },
-        "total_time": "10.82ms"
+        "total_time": "10.81ms"
       },
       "dashboard": {
         "comment": "big dashboard test",
@@ -3906,49 +3906,49 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "8.62ms",
+            "duration": "8.65ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "1.36ms",
+                "duration": "1.32ms",
                 "nested": {
-                  "from_slice": "1.30ms"
+                  "from_slice": "1.26ms"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "356.00µs",
+                "duration": "360.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "42.00µs",
-                  "air_parser::parser::air_parser::parse": "133.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "41.00µs",
+                  "air_parser::parser::air_parser::parse": "132.00µs"
                 }
               },
-              "runner::execute": "1.10ms",
+              "runner::execute": "1.08ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "656.00µs",
+                "duration": "674.00µs",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "633.00µs",
+                    "duration": "650.00µs",
                     "nested": {
-                      "populate_outcome_from_contexts": "580.00µs"
+                      "populate_outcome_from_contexts": "596.00µs"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "161.00µs",
+              "signing_step::sign_produced_cids": "172.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "4.85ms",
+                "duration": "4.89ms",
                 "nested": {
-                  "verify": "200.00µs"
+                  "verify": "198.00µs"
                 }
               }
             }
           }
         },
-        "total_time": "8.62ms"
+        "total_time": "8.65ms"
       },
       "long-data": {
         "comment": "Long data trace",
@@ -3959,49 +3959,49 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "6.47ms",
+            "duration": "6.29ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "2.43ms",
+                "duration": "2.44ms",
                 "nested": {
-                  "from_slice": "2.38ms"
+                  "from_slice": "2.40ms"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "247.00µs",
+                "duration": "239.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "40.00µs",
-                  "air_parser::parser::air_parser::parse": "19.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "41.00µs",
+                  "air_parser::parser::air_parser::parse": "18.00µs"
                 }
               },
               "runner::execute": "9.00µs",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "1.11ms",
+                "duration": "1.09ms",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "1.09ms",
+                    "duration": "1.07ms",
                     "nested": {
-                      "populate_outcome_from_contexts": "1.05ms"
+                      "populate_outcome_from_contexts": "1.03ms"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "170.00µs",
+              "signing_step::sign_produced_cids": "160.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "2.38ms",
+                "duration": "2.23ms",
                 "nested": {
-                  "verify": "844.00µs"
+                  "verify": "838.00µs"
                 }
               }
             }
           }
         },
-        "total_time": "6.47ms"
+        "total_time": "6.29ms"
       },
       "multiple-cids10": {
         "comment": "verifying multiple CIDs for single peer",
@@ -4012,49 +4012,49 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "3.42ms",
+            "duration": "3.43ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "482.00µs",
+                "duration": "478.00µs",
                 "nested": {
-                  "from_slice": "424.00µs"
+                  "from_slice": "423.00µs"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "261.00µs",
+                "duration": "260.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "33.00µs",
+                  "air::preparation_step::preparation::make_exec_ctx": "32.00µs",
                   "air_parser::parser::air_parser::parse": "45.00µs"
                 }
               },
-              "runner::execute": "570.00µs",
+              "runner::execute": "572.00µs",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "455.00µs",
+                "duration": "464.00µs",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "430.00µs",
+                    "duration": "441.00µs",
                     "nested": {
-                      "populate_outcome_from_contexts": "370.00µs"
+                      "populate_outcome_from_contexts": "383.00µs"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "158.00µs",
+              "signing_step::sign_produced_cids": "162.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "1.35ms",
+                "duration": "1.36ms",
                 "nested": {
-                  "verify": "238.00µs"
+                  "verify": "233.00µs"
                 }
               }
             }
           }
         },
-        "total_time": "3.42ms"
+        "total_time": "3.43ms"
       },
       "multiple-peers8": {
         "comment": "verifying many CIDs for many peers",
@@ -4065,49 +4065,49 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "14.23ms",
+            "duration": "13.67ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "1.82ms",
+                "duration": "1.77ms",
                 "nested": {
-                  "from_slice": "1.77ms"
+                  "from_slice": "1.71ms"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "349.00µs",
+                "duration": "338.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "105.00µs",
-                  "air_parser::parser::air_parser::parse": "49.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "104.00µs",
+                  "air_parser::parser::air_parser::parse": "51.00µs"
                 }
               },
-              "runner::execute": "3.70ms",
+              "runner::execute": "3.68ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "1.29ms",
+                "duration": "1.30ms",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "1.27ms",
+                    "duration": "1.28ms",
                     "nested": {
-                      "populate_outcome_from_contexts": "1.16ms"
+                      "populate_outcome_from_contexts": "1.17ms"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "158.00µs",
+              "signing_step::sign_produced_cids": "162.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "6.80ms",
+                "duration": "6.26ms",
                 "nested": {
-                  "verify": "1.05ms"
+                  "verify": "1.04ms"
                 }
               }
             }
           }
         },
-        "total_time": "14.23ms"
+        "total_time": "13.67ms"
       },
       "multiple-sigs30": {
         "comment": "signing multiple CIDs",
@@ -4118,49 +4118,49 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "24.93ms",
+            "duration": "24.71ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "5.02ms",
+                "duration": "5.05ms",
                 "nested": {
-                  "from_slice": "4.96ms"
+                  "from_slice": "4.98ms"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "443.00µs",
+                "duration": "444.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "217.00µs",
+                  "air::preparation_step::preparation::make_exec_ctx": "208.00µs",
                   "air_parser::parser::air_parser::parse": "49.00µs"
                 }
               },
-              "runner::execute": "10.60ms",
+              "runner::execute": "10.47ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
                 "duration": "3.69ms",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "3.67ms",
+                    "duration": "3.66ms",
                     "nested": {
-                      "populate_outcome_from_contexts": "3.49ms"
+                      "populate_outcome_from_contexts": "3.48ms"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "667.00µs",
+              "signing_step::sign_produced_cids": "654.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "4.35ms",
+                "duration": "4.27ms",
                 "nested": {
-                  "verify": "1.83ms"
+                  "verify": "1.80ms"
                 }
               }
             }
           }
         },
-        "total_time": "24.93ms"
+        "total_time": "24.71ms"
       },
       "network-explore": {
         "comment": "5 peers of network are discovered",
@@ -4171,41 +4171,41 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "4.36ms",
+            "duration": "4.40ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
                 "duration": "587.00µs",
                 "nested": {
-                  "from_slice": "532.00µs"
+                  "from_slice": "531.00µs"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "270.00µs",
+                "duration": "273.00µs",
                 "nested": {
                   "air::preparation_step::preparation::make_exec_ctx": "23.00µs",
-                  "air_parser::parser::air_parser::parse": "67.00µs"
+                  "air_parser::parser::air_parser::parse": "68.00µs"
                 }
               },
-              "runner::execute": "166.00µs",
+              "runner::execute": "159.00µs",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "366.00µs",
+                "duration": "369.00µs",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "344.00µs",
+                    "duration": "346.00µs",
                     "nested": {
-                      "populate_outcome_from_contexts": "299.00µs"
+                      "populate_outcome_from_contexts": "301.00µs"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "160.00µs",
+              "signing_step::sign_produced_cids": "162.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "2.68ms",
+                "duration": "2.72ms",
                 "nested": {
                   "verify": "64.00µs"
                 }
@@ -4213,7 +4213,7 @@
             }
           }
         },
-        "total_time": "4.36ms"
+        "total_time": "4.40ms"
       },
       "null": {
         "comment": "Empty data and null script",
@@ -4224,79 +4224,79 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "888.00µs",
+            "duration": "834.00µs",
             "nested": {
-              "preparation_step::preparation::parse_data": "22.00µs",
+              "preparation_step::preparation::parse_data": "19.00µs",
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "238.00µs",
+                "duration": "224.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "16.00µs",
+                  "air::preparation_step::preparation::make_exec_ctx": "15.00µs",
                   "air_parser::parser::air_parser::parse": "19.00µs"
                 }
               },
               "runner::execute": "9.00µs",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "270.00µs",
+                "duration": "256.00µs",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "248.00µs",
+                    "duration": "235.00µs",
                     "nested": {
-                      "populate_outcome_from_contexts": "209.00µs"
+                      "populate_outcome_from_contexts": "195.00µs"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "177.00µs",
+              "signing_step::sign_produced_cids": "161.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "37.00µs",
+                "duration": "35.00µs",
                 "nested": {
-                  "verify": "12.00µs"
+                  "verify": "10.00µs"
                 }
               }
             }
           }
         },
-        "total_time": "888.00µs"
+        "total_time": "834.00µs"
       },
       "parser-10000-100": {
         "comment": "long air script with lot of variable assignments",
         "memory_sizes": [
-          "54.938 MiB",
-          "54.938 MiB"
+          "54.625 MiB",
+          "54.625 MiB"
         ],
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "28.81ms",
+            "duration": "28.73ms",
             "nested": {
-              "preparation_step::preparation::parse_data": "19.00µs",
+              "preparation_step::preparation::parse_data": "20.00µs",
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "27.56ms",
+                "duration": "27.47ms",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "16.00µs",
-                  "air_parser::parser::air_parser::parse": "27.34ms"
+                  "air::preparation_step::preparation::make_exec_ctx": "17.00µs",
+                  "air_parser::parser::air_parser::parse": "27.23ms"
                 }
               },
-              "runner::execute": "29.00µs",
+              "runner::execute": "27.00µs",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "254.00µs",
+                "duration": "263.00µs",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "231.00µs",
+                    "duration": "240.00µs",
                     "nested": {
-                      "populate_outcome_from_contexts": "192.00µs"
+                      "populate_outcome_from_contexts": "201.00µs"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "158.00µs",
+              "signing_step::sign_produced_cids": "162.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
                 "duration": "36.00µs",
@@ -4307,7 +4307,54 @@
             }
           }
         },
-        "total_time": "28.81ms"
+        "total_time": "28.73ms"
+      },
+      "parser-calls-10000-100": {
+        "comment": "multiple calls parser benchmark",
+        "memory_sizes": [
+          "54.375 MiB",
+          "54.375 MiB"
+        ],
+        "stats": {
+          "air::runner::execute_air": {
+            "common_prefix": "air",
+            "duration": "25.94ms",
+            "nested": {
+              "preparation_step::preparation::parse_data": "18.00µs",
+              "preparation_step::preparation::prepare": {
+                "common_prefix": "",
+                "duration": "24.66ms",
+                "nested": {
+                  "air::preparation_step::preparation::make_exec_ctx": "15.00µs",
+                  "air_parser::parser::air_parser::parse": "24.46ms"
+                }
+              },
+              "runner::execute": "28.00µs",
+              "runner::farewell": {
+                "common_prefix": "air::farewell_step::outcome",
+                "duration": "255.00µs",
+                "nested": {
+                  "from_success_result": {
+                    "common_prefix": "air::farewell_step::outcome",
+                    "duration": "233.00µs",
+                    "nested": {
+                      "populate_outcome_from_contexts": "195.00µs"
+                    }
+                  }
+                }
+              },
+              "signing_step::sign_produced_cids": "160.00µs",
+              "verification_step::verify": {
+                "common_prefix": "air_interpreter_data::cid_info",
+                "duration": "36.00µs",
+                "nested": {
+                  "verify": "10.00µs"
+                }
+              }
+            }
+          }
+        },
+        "total_time": "25.94ms"
       },
       "populate-map-multiple-keys": {
         "comment": "benchmarking a map insert operation",
@@ -4318,49 +4365,49 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "4.54ms",
+            "duration": "4.40ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "140.00µs",
+                "duration": "131.00µs",
                 "nested": {
-                  "from_slice": "96.00µs"
+                  "from_slice": "91.00µs"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "258.00µs",
+                "duration": "243.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "19.00µs",
-                  "air_parser::parser::air_parser::parse": "49.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "17.00µs",
+                  "air_parser::parser::air_parser::parse": "48.00µs"
                 }
               },
-              "runner::execute": "2.85ms",
+              "runner::execute": "2.80ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "394.00µs",
+                "duration": "383.00µs",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "370.00µs",
+                    "duration": "361.00µs",
                     "nested": {
-                      "populate_outcome_from_contexts": "328.00µs"
+                      "populate_outcome_from_contexts": "321.00µs"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "167.00µs",
+              "signing_step::sign_produced_cids": "158.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "588.00µs",
+                "duration": "557.00µs",
                 "nested": {
-                  "verify": "29.00µs"
+                  "verify": "27.00µs"
                 }
               }
             }
           }
         },
-        "total_time": "4.54ms"
+        "total_time": "4.40ms"
       },
       "populate-map-single-key": {
         "comment": "benchmarking a map insert operation",
@@ -4371,52 +4418,52 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "3.71ms",
+            "duration": "3.62ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "206.00µs",
+                "duration": "200.00µs",
                 "nested": {
-                  "from_slice": "162.00µs"
+                  "from_slice": "159.00µs"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "255.00µs",
+                "duration": "244.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "20.00µs",
+                  "air::preparation_step::preparation::make_exec_ctx": "17.00µs",
                   "air_parser::parser::air_parser::parse": "45.00µs"
                 }
               },
-              "runner::execute": "1.94ms",
+              "runner::execute": "1.89ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "400.00µs",
+                "duration": "403.00µs",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "377.00µs",
+                    "duration": "381.00µs",
                     "nested": {
-                      "populate_outcome_from_contexts": "322.00µs"
+                      "populate_outcome_from_contexts": "325.00µs"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "157.00µs",
+              "signing_step::sign_produced_cids": "160.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "614.00µs",
+                "duration": "586.00µs",
                 "nested": {
-                  "verify": "64.00µs"
+                  "verify": "60.00µs"
                 }
               }
             }
           }
         },
-        "total_time": "3.71ms"
+        "total_time": "3.62ms"
       }
     },
-    "datetime": "2023-12-08 16:06:36.836015+00:00",
+    "datetime": "2023-12-12 12:01:06.070549+00:00",
     "features": "check_signatures,gen_signatures",
     "platform": "Linux-5.15.0-76-generic-x86_64-with-glibc2.29",
     "version": "0.54.0"

--- a/benches/PERFORMANCE.json
+++ b/benches/PERFORMANCE.json
@@ -3382,49 +3382,49 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "17.72ms",
+            "duration": "17.65ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "7.12ms",
+                "duration": "7.03ms",
                 "nested": {
-                  "from_slice": "7.06ms"
+                  "from_slice": "6.98ms"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "224.00µs",
+                "duration": "214.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "22.00µs",
-                  "air_parser::parser::air_parser::parse": "20.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "20.00µs",
+                  "air_parser::parser::air_parser::parse": "18.00µs"
                 }
               },
-              "runner::execute": "10.00µs",
+              "runner::execute": "9.00µs",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "4.72ms",
+                "duration": "4.71ms",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "4.70ms",
+                    "duration": "4.68ms",
                     "nested": {
-                      "populate_outcome_from_contexts": "4.64ms"
+                      "populate_outcome_from_contexts": "4.63ms"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "162.00µs",
+              "signing_step::sign_produced_cids": "155.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "5.34ms",
+                "duration": "5.40ms",
                 "nested": {
-                  "verify": "4.80ms"
+                  "verify": "4.87ms"
                 }
               }
             }
           }
         },
-        "total_time": "17.72ms"
+        "total_time": "17.65ms"
       },
       "call-requests500": {
         "comment": "multiple call requests",
@@ -3435,41 +3435,41 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "35.01ms",
+            "duration": "35.31ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
                 "duration": "116.00µs",
                 "nested": {
-                  "from_slice": "78.00µs"
+                  "from_slice": "80.00µs"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "273.00µs",
+                "duration": "276.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "39.00µs",
-                  "air_parser::parser::air_parser::parse": "49.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "38.00µs",
+                  "air_parser::parser::air_parser::parse": "50.00µs"
                 }
               },
-              "runner::execute": "24.69ms",
+              "runner::execute": "25.24ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "9.56ms",
+                "duration": "9.31ms",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "9.54ms",
+                    "duration": "9.29ms",
                     "nested": {
-                      "populate_outcome_from_contexts": "9.38ms"
+                      "populate_outcome_from_contexts": "9.14ms"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "164.00µs",
+              "signing_step::sign_produced_cids": "161.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "77.00µs",
+                "duration": "78.00µs",
                 "nested": {
                   "verify": "10.00µs"
                 }
@@ -3477,7 +3477,7 @@
             }
           }
         },
-        "total_time": "35.01ms"
+        "total_time": "35.31ms"
       },
       "call-results500": {
         "comment": "multiple call results",
@@ -3488,41 +3488,41 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "19.19ms",
+            "duration": "19.65ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "657.00µs",
+                "duration": "676.00µs",
                 "nested": {
-                  "from_slice": "618.00µs"
+                  "from_slice": "636.00µs"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "925.00µs",
+                "duration": "930.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "688.00µs",
+                  "air::preparation_step::preparation::make_exec_ctx": "687.00µs",
                   "air_parser::parser::air_parser::parse": "50.00µs"
                 }
               },
-              "runner::execute": "14.78ms",
+              "runner::execute": "15.19ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "2.17ms",
+                "duration": "2.20ms",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "2.15ms",
+                    "duration": "2.17ms",
                     "nested": {
-                      "populate_outcome_from_contexts": "1.77ms"
+                      "populate_outcome_from_contexts": "1.74ms"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "435.00µs",
+              "signing_step::sign_produced_cids": "432.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "81.00µs",
+                "duration": "83.00µs",
                 "nested": {
                   "verify": "10.00µs"
                 }
@@ -3530,7 +3530,7 @@
             }
           }
         },
-        "total_time": "19.19ms"
+        "total_time": "19.65ms"
       },
       "canon-map-key-by-lens": {
         "comment": "benchmarking a map insert operation",
@@ -3541,49 +3541,49 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "14.88ms",
+            "duration": "14.99ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "4.04ms",
+                "duration": "4.07ms",
                 "nested": {
-                  "from_slice": "3.99ms"
+                  "from_slice": "4.02ms"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "530.00µs",
+                "duration": "526.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "288.00µs",
-                  "air_parser::parser::air_parser::parse": "57.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "286.00µs",
+                  "air_parser::parser::air_parser::parse": "56.00µs"
                 }
               },
               "runner::execute": "2.76ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "2.78ms",
+                "duration": "2.77ms",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
                     "duration": "2.75ms",
                     "nested": {
-                      "populate_outcome_from_contexts": "2.40ms"
+                      "populate_outcome_from_contexts": "2.38ms"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "159.00µs",
+              "signing_step::sign_produced_cids": "160.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "4.48ms",
+                "duration": "4.55ms",
                 "nested": {
-                  "verify": "3.95ms"
+                  "verify": "4.02ms"
                 }
               }
             }
           }
         },
-        "total_time": "14.88ms"
+        "total_time": "14.99ms"
       },
       "canon-map-key-element-by-lens": {
         "comment": "benchmarking a map insert operation",
@@ -3594,49 +3594,49 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "14.80ms",
+            "duration": "14.93ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "4.03ms",
+                "duration": "4.08ms",
                 "nested": {
-                  "from_slice": "3.99ms"
+                  "from_slice": "4.03ms"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "535.00µs",
+                "duration": "527.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "293.00µs",
-                  "air_parser::parser::air_parser::parse": "59.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "290.00µs",
+                  "air_parser::parser::air_parser::parse": "58.00µs"
                 }
               },
-              "runner::execute": "2.69ms",
+              "runner::execute": "2.76ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "2.76ms",
+                "duration": "2.74ms",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "2.74ms",
+                    "duration": "2.72ms",
                     "nested": {
-                      "populate_outcome_from_contexts": "2.40ms"
+                      "populate_outcome_from_contexts": "2.36ms"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "159.00µs",
+              "signing_step::sign_produced_cids": "158.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "4.48ms",
+                "duration": "4.51ms",
                 "nested": {
-                  "verify": "3.96ms"
+                  "verify": "3.98ms"
                 }
               }
             }
           }
         },
-        "total_time": "14.80ms"
+        "total_time": "14.93ms"
       },
       "canon-map-multiple-keys": {
         "comment": "benchmarking a map insert operation",
@@ -3647,24 +3647,24 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "12.47ms",
+            "duration": "12.56ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "357.00µs",
+                "duration": "356.00µs",
                 "nested": {
-                  "from_slice": "317.00µs"
+                  "from_slice": "315.00µs"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
                 "duration": "248.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "19.00µs",
-                  "air_parser::parser::air_parser::parse": "47.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "18.00µs",
+                  "air_parser::parser::air_parser::parse": "46.00µs"
                 }
               },
-              "runner::execute": "8.71ms",
+              "runner::execute": "8.75ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
                 "duration": "2.31ms",
@@ -3673,15 +3673,15 @@
                     "common_prefix": "air::farewell_step::outcome",
                     "duration": "2.29ms",
                     "nested": {
-                      "populate_outcome_from_contexts": "2.00ms"
+                      "populate_outcome_from_contexts": "1.99ms"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "161.00µs",
+              "signing_step::sign_produced_cids": "171.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "554.00µs",
+                "duration": "580.00µs",
                 "nested": {
                   "verify": "28.00µs"
                 }
@@ -3689,7 +3689,7 @@
             }
           }
         },
-        "total_time": "12.47ms"
+        "total_time": "12.56ms"
       },
       "canon-map-scalar-multiple-keys": {
         "comment": "benchmarking a map insert operation",
@@ -3700,41 +3700,41 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "5.18ms",
+            "duration": "5.33ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "359.00µs",
+                "duration": "360.00µs",
                 "nested": {
-                  "from_slice": "319.00µs"
+                  "from_slice": "317.00µs"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "243.00µs",
+                "duration": "261.00µs",
                 "nested": {
                   "air::preparation_step::preparation::make_exec_ctx": "18.00µs",
                   "air_parser::parser::air_parser::parse": "46.00µs"
                 }
               },
-              "runner::execute": "3.28ms",
+              "runner::execute": "3.34ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "462.00µs",
+                "duration": "449.00µs",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "440.00µs",
+                    "duration": "425.00µs",
                     "nested": {
-                      "populate_outcome_from_contexts": "397.00µs"
+                      "populate_outcome_from_contexts": "383.00µs"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "159.00µs",
+              "signing_step::sign_produced_cids": "162.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "554.00µs",
+                "duration": "620.00µs",
                 "nested": {
                   "verify": "28.00µs"
                 }
@@ -3742,7 +3742,7 @@
             }
           }
         },
-        "total_time": "5.18ms"
+        "total_time": "5.33ms"
       },
       "canon-map-scalar-single-key": {
         "comment": "benchmarking a map insert operation",
@@ -3753,49 +3753,49 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "4.27ms",
+            "duration": "4.39ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "382.00µs",
+                "duration": "391.00µs",
                 "nested": {
-                  "from_slice": "342.00µs"
+                  "from_slice": "347.00µs"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "241.00µs",
+                "duration": "258.00µs",
                 "nested": {
                   "air::preparation_step::preparation::make_exec_ctx": "18.00µs",
-                  "air_parser::parser::air_parser::parse": "43.00µs"
+                  "air_parser::parser::air_parser::parse": "44.00µs"
                 }
               },
-              "runner::execute": "2.31ms",
+              "runner::execute": "2.35ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "454.00µs",
+                "duration": "443.00µs",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "432.00µs",
+                    "duration": "420.00µs",
                     "nested": {
-                      "populate_outcome_from_contexts": "379.00µs"
+                      "populate_outcome_from_contexts": "365.00µs"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "160.00µs",
+              "signing_step::sign_produced_cids": "159.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "588.00µs",
+                "duration": "650.00µs",
                 "nested": {
-                  "verify": "61.00µs"
+                  "verify": "65.00µs"
                 }
               }
             }
           }
         },
-        "total_time": "4.27ms"
+        "total_time": "4.39ms"
       },
       "canon-map-single-key": {
         "comment": "benchmarking a map insert operation",
@@ -3806,49 +3806,49 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "10.90ms",
+            "duration": "10.82ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "381.00µs",
+                "duration": "383.00µs",
                 "nested": {
-                  "from_slice": "340.00µs"
+                  "from_slice": "343.00µs"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "244.00µs",
+                "duration": "250.00µs",
                 "nested": {
                   "air::preparation_step::preparation::make_exec_ctx": "18.00µs",
-                  "air_parser::parser::air_parser::parse": "44.00µs"
+                  "air_parser::parser::air_parser::parse": "41.00µs"
                 }
               },
-              "runner::execute": "6.73ms",
+              "runner::execute": "6.60ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "2.64ms",
+                "duration": "2.61ms",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "2.62ms",
+                    "duration": "2.59ms",
                     "nested": {
-                      "populate_outcome_from_contexts": "2.36ms"
+                      "populate_outcome_from_contexts": "2.34ms"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "168.00µs",
+              "signing_step::sign_produced_cids": "166.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "596.00µs",
+                "duration": "672.00µs",
                 "nested": {
-                  "verify": "62.00µs"
+                  "verify": "63.00µs"
                 }
               }
             }
           }
         },
-        "total_time": "10.90ms"
+        "total_time": "10.82ms"
       },
       "dashboard": {
         "comment": "big dashboard test",
@@ -3859,49 +3859,49 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "8.22ms",
+            "duration": "8.62ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "1.28ms",
+                "duration": "1.36ms",
                 "nested": {
-                  "from_slice": "1.23ms"
+                  "from_slice": "1.30ms"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "350.00µs",
+                "duration": "356.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "41.00µs",
-                  "air_parser::parser::air_parser::parse": "131.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "42.00µs",
+                  "air_parser::parser::air_parser::parse": "133.00µs"
                 }
               },
-              "runner::execute": "1.08ms",
+              "runner::execute": "1.10ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
                 "duration": "656.00µs",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "634.00µs",
+                    "duration": "633.00µs",
                     "nested": {
-                      "populate_outcome_from_contexts": "584.00µs"
+                      "populate_outcome_from_contexts": "580.00µs"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "162.00µs",
+              "signing_step::sign_produced_cids": "161.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "4.55ms",
+                "duration": "4.85ms",
                 "nested": {
-                  "verify": "195.00µs"
+                  "verify": "200.00µs"
                 }
               }
             }
           }
         },
-        "total_time": "8.22ms"
+        "total_time": "8.62ms"
       },
       "long-data": {
         "comment": "Long data trace",
@@ -3912,49 +3912,49 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "6.32ms",
+            "duration": "6.47ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "2.39ms",
+                "duration": "2.43ms",
                 "nested": {
-                  "from_slice": "2.35ms"
+                  "from_slice": "2.38ms"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "238.00µs",
+                "duration": "247.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "41.00µs",
-                  "air_parser::parser::air_parser::parse": "18.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "40.00µs",
+                  "air_parser::parser::air_parser::parse": "19.00µs"
                 }
               },
               "runner::execute": "9.00µs",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "1.07ms",
+                "duration": "1.11ms",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "1.05ms",
+                    "duration": "1.09ms",
                     "nested": {
-                      "populate_outcome_from_contexts": "1.01ms"
+                      "populate_outcome_from_contexts": "1.05ms"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "158.00µs",
+              "signing_step::sign_produced_cids": "170.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "2.33ms",
+                "duration": "2.38ms",
                 "nested": {
-                  "verify": "841.00µs"
+                  "verify": "844.00µs"
                 }
               }
             }
           }
         },
-        "total_time": "6.32ms"
+        "total_time": "6.47ms"
       },
       "multiple-cids10": {
         "comment": "verifying multiple CIDs for single peer",
@@ -3965,49 +3965,49 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "3.37ms",
+            "duration": "3.42ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "467.00µs",
+                "duration": "482.00µs",
                 "nested": {
-                  "from_slice": "414.00µs"
+                  "from_slice": "424.00µs"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "256.00µs",
+                "duration": "261.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "32.00µs",
-                  "air_parser::parser::air_parser::parse": "44.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "33.00µs",
+                  "air_parser::parser::air_parser::parse": "45.00µs"
                 }
               },
-              "runner::execute": "568.00µs",
+              "runner::execute": "570.00µs",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "456.00µs",
+                "duration": "455.00µs",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "434.00µs",
+                    "duration": "430.00µs",
                     "nested": {
-                      "populate_outcome_from_contexts": "375.00µs"
+                      "populate_outcome_from_contexts": "370.00µs"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "159.00µs",
+              "signing_step::sign_produced_cids": "158.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "1.34ms",
+                "duration": "1.35ms",
                 "nested": {
-                  "verify": "230.00µs"
+                  "verify": "238.00µs"
                 }
               }
             }
           }
         },
-        "total_time": "3.37ms"
+        "total_time": "3.42ms"
       },
       "multiple-peers8": {
         "comment": "verifying many CIDs for many peers",
@@ -4018,49 +4018,49 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "13.47ms",
+            "duration": "14.23ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "1.74ms",
+                "duration": "1.82ms",
                 "nested": {
-                  "from_slice": "1.68ms"
+                  "from_slice": "1.77ms"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "334.00µs",
+                "duration": "349.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "103.00µs",
-                  "air_parser::parser::air_parser::parse": "51.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "105.00µs",
+                  "air_parser::parser::air_parser::parse": "49.00µs"
                 }
               },
-              "runner::execute": "3.63ms",
+              "runner::execute": "3.70ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "1.30ms",
+                "duration": "1.29ms",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "1.28ms",
+                    "duration": "1.27ms",
                     "nested": {
-                      "populate_outcome_from_contexts": "1.17ms"
+                      "populate_outcome_from_contexts": "1.16ms"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "159.00µs",
+              "signing_step::sign_produced_cids": "158.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "6.18ms",
+                "duration": "6.80ms",
                 "nested": {
-                  "verify": "1.03ms"
+                  "verify": "1.05ms"
                 }
               }
             }
           }
         },
-        "total_time": "13.47ms"
+        "total_time": "14.23ms"
       },
       "multiple-sigs30": {
         "comment": "signing multiple CIDs",
@@ -4071,49 +4071,49 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "24.67ms",
+            "duration": "24.93ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "4.93ms",
+                "duration": "5.02ms",
                 "nested": {
-                  "from_slice": "4.87ms"
+                  "from_slice": "4.96ms"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "446.00µs",
+                "duration": "443.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "215.00µs",
+                  "air::preparation_step::preparation::make_exec_ctx": "217.00µs",
                   "air_parser::parser::air_parser::parse": "49.00µs"
                 }
               },
-              "runner::execute": "10.49ms",
+              "runner::execute": "10.60ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "3.70ms",
+                "duration": "3.69ms",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "3.68ms",
+                    "duration": "3.67ms",
                     "nested": {
-                      "populate_outcome_from_contexts": "3.50ms"
+                      "populate_outcome_from_contexts": "3.49ms"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "668.00µs",
+              "signing_step::sign_produced_cids": "667.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "4.30ms",
+                "duration": "4.35ms",
                 "nested": {
-                  "verify": "1.81ms"
+                  "verify": "1.83ms"
                 }
               }
             }
           }
         },
-        "total_time": "24.67ms"
+        "total_time": "24.93ms"
       },
       "network-explore": {
         "comment": "5 peers of network are discovered",
@@ -4124,33 +4124,33 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "4.35ms",
+            "duration": "4.36ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "582.00µs",
+                "duration": "587.00µs",
                 "nested": {
-                  "from_slice": "525.00µs"
+                  "from_slice": "532.00µs"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "267.00µs",
+                "duration": "270.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "22.00µs",
+                  "air::preparation_step::preparation::make_exec_ctx": "23.00µs",
                   "air_parser::parser::air_parser::parse": "67.00µs"
                 }
               },
-              "runner::execute": "163.00µs",
+              "runner::execute": "166.00µs",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "363.00µs",
+                "duration": "366.00µs",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "342.00µs",
+                    "duration": "344.00µs",
                     "nested": {
-                      "populate_outcome_from_contexts": "298.00µs"
+                      "populate_outcome_from_contexts": "299.00µs"
                     }
                   }
                 }
@@ -4158,7 +4158,7 @@
               "signing_step::sign_produced_cids": "160.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "2.69ms",
+                "duration": "2.68ms",
                 "nested": {
                   "verify": "64.00µs"
                 }
@@ -4166,7 +4166,7 @@
             }
           }
         },
-        "total_time": "4.35ms"
+        "total_time": "4.36ms"
       },
       "null": {
         "comment": "Empty data and null script",
@@ -4177,12 +4177,12 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "848.00µs",
+            "duration": "888.00µs",
             "nested": {
-              "preparation_step::preparation::parse_data": "18.00µs",
+              "preparation_step::preparation::parse_data": "22.00µs",
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "224.00µs",
+                "duration": "238.00µs",
                 "nested": {
                   "air::preparation_step::preparation::make_exec_ctx": "16.00µs",
                   "air_parser::parser::air_parser::parse": "19.00µs"
@@ -4191,21 +4191,21 @@
               "runner::execute": "9.00µs",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "257.00µs",
+                "duration": "270.00µs",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "234.00µs",
+                    "duration": "248.00µs",
                     "nested": {
-                      "populate_outcome_from_contexts": "194.00µs"
+                      "populate_outcome_from_contexts": "209.00µs"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "162.00µs",
+              "signing_step::sign_produced_cids": "177.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "39.00µs",
+                "duration": "37.00µs",
                 "nested": {
                   "verify": "12.00µs"
                 }
@@ -4213,46 +4213,46 @@
             }
           }
         },
-        "total_time": "848.00µs"
+        "total_time": "888.00µs"
       },
       "parser-10000-100": {
         "comment": "long air script with lot of variable assignments",
         "memory_sizes": [
-          "57.688 MiB",
-          "57.688 MiB"
+          "54.938 MiB",
+          "54.938 MiB"
         ],
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "29.56ms",
+            "duration": "28.81ms",
             "nested": {
-              "preparation_step::preparation::parse_data": "20.00µs",
+              "preparation_step::preparation::parse_data": "19.00µs",
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "27.87ms",
+                "duration": "27.56ms",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "18.00µs",
-                  "air_parser::parser::air_parser::parse": "27.63ms"
+                  "air::preparation_step::preparation::make_exec_ctx": "16.00µs",
+                  "air_parser::parser::air_parser::parse": "27.34ms"
                 }
               },
-              "runner::execute": "30.00µs",
+              "runner::execute": "29.00µs",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "257.00µs",
+                "duration": "254.00µs",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "235.00µs",
+                    "duration": "231.00µs",
                     "nested": {
-                      "populate_outcome_from_contexts": "196.00µs"
+                      "populate_outcome_from_contexts": "192.00µs"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "161.00µs",
+              "signing_step::sign_produced_cids": "158.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "34.00µs",
+                "duration": "36.00µs",
                 "nested": {
                   "verify": "10.00µs"
                 }
@@ -4260,7 +4260,7 @@
             }
           }
         },
-        "total_time": "29.56ms"
+        "total_time": "28.81ms"
       },
       "populate-map-multiple-keys": {
         "comment": "benchmarking a map insert operation",
@@ -4271,49 +4271,49 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "4.37ms",
+            "duration": "4.54ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "130.00µs",
+                "duration": "140.00µs",
                 "nested": {
-                  "from_slice": "91.00µs"
+                  "from_slice": "96.00µs"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "246.00µs",
+                "duration": "258.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "18.00µs",
+                  "air::preparation_step::preparation::make_exec_ctx": "19.00µs",
                   "air_parser::parser::air_parser::parse": "49.00µs"
                 }
               },
-              "runner::execute": "2.77ms",
+              "runner::execute": "2.85ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
-                "duration": "387.00µs",
+                "duration": "394.00µs",
                 "nested": {
                   "from_success_result": {
                     "common_prefix": "air::farewell_step::outcome",
-                    "duration": "365.00µs",
+                    "duration": "370.00µs",
                     "nested": {
-                      "populate_outcome_from_contexts": "325.00µs"
+                      "populate_outcome_from_contexts": "328.00µs"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "158.00µs",
+              "signing_step::sign_produced_cids": "167.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "549.00µs",
+                "duration": "588.00µs",
                 "nested": {
-                  "verify": "27.00µs"
+                  "verify": "29.00µs"
                 }
               }
             }
           }
         },
-        "total_time": "4.37ms"
+        "total_time": "4.54ms"
       },
       "populate-map-single-key": {
         "comment": "benchmarking a map insert operation",
@@ -4324,24 +4324,24 @@
         "stats": {
           "air::runner::execute_air": {
             "common_prefix": "air",
-            "duration": "3.62ms",
+            "duration": "3.71ms",
             "nested": {
               "preparation_step::preparation::parse_data": {
                 "common_prefix": "air_interpreter_data::interpreter_data::serde_json",
-                "duration": "199.00µs",
+                "duration": "206.00µs",
                 "nested": {
-                  "from_slice": "159.00µs"
+                  "from_slice": "162.00µs"
                 }
               },
               "preparation_step::preparation::prepare": {
                 "common_prefix": "",
-                "duration": "243.00µs",
+                "duration": "255.00µs",
                 "nested": {
-                  "air::preparation_step::preparation::make_exec_ctx": "18.00µs",
-                  "air_parser::parser::air_parser::parse": "46.00µs"
+                  "air::preparation_step::preparation::make_exec_ctx": "20.00µs",
+                  "air_parser::parser::air_parser::parse": "45.00µs"
                 }
               },
-              "runner::execute": "1.91ms",
+              "runner::execute": "1.94ms",
               "runner::farewell": {
                 "common_prefix": "air::farewell_step::outcome",
                 "duration": "400.00µs",
@@ -4350,26 +4350,26 @@
                     "common_prefix": "air::farewell_step::outcome",
                     "duration": "377.00µs",
                     "nested": {
-                      "populate_outcome_from_contexts": "324.00µs"
+                      "populate_outcome_from_contexts": "322.00µs"
                     }
                   }
                 }
               },
-              "signing_step::sign_produced_cids": "160.00µs",
+              "signing_step::sign_produced_cids": "157.00µs",
               "verification_step::verify": {
                 "common_prefix": "air_interpreter_data::cid_info",
-                "duration": "586.00µs",
+                "duration": "614.00µs",
                 "nested": {
-                  "verify": "61.00µs"
+                  "verify": "64.00µs"
                 }
               }
             }
           }
         },
-        "total_time": "3.62ms"
+        "total_time": "3.71ms"
       }
     },
-    "datetime": "2023-11-30 15:54:57.248575+00:00",
+    "datetime": "2023-12-08 16:06:36.836015+00:00",
     "features": "check_signatures,gen_signatures",
     "platform": "Linux-5.15.0-76-generic-x86_64-with-glibc2.29",
     "version": "0.54.0"

--- a/benches/PERFORMANCE.txt
+++ b/benches/PERFORMANCE.txt
@@ -926,271 +926,284 @@ Machine d77ebe8481884bc3b2778c8083f1bf459e548e929edd87041beb14f6b868d35f:
           verify: 74.00µs
 Machine e536f8eaae8c978493a773ba566ae3393e2e6240d6ea8e05b5ca1b8f77e9c441:
   Platform: Linux-5.15.0-76-generic-x86_64-with-glibc2.29
-  Timestamp: 2023-12-08 16:06:36.836015+00:00
+  Timestamp: 2023-12-12 12:01:06.070549+00:00
   AquaVM version: 0.54.0
   Benches:
   Features: check_signatures,gen_signatures
-    big-values-data (17.65ms; 59.000 MiB, 59.000 MiB): Loading a trace with huge values
-      air::runner::execute_air: 17.65ms
-        preparation_step::preparation::parse_data: 7.03ms
-          from_slice: 6.98ms
-        preparation_step::preparation::prepare: 214.00µs
-          air::preparation_step::preparation::make_exec_ctx: 20.00µs
-          air_parser::parser::air_parser::parse: 18.00µs
-        runner::execute: 9.00µs
-        runner::farewell: 4.71ms
-          from_success_result: 4.68ms
-            populate_outcome_from_contexts: 4.63ms
-        signing_step::sign_produced_cids: 155.00µs
-        verification_step::verify: 5.40ms
-          verify: 4.87ms
-    call-requests500 (35.31ms; 58.562 MiB, 58.562 MiB): multiple call requests
-      air::runner::execute_air: 35.31ms
-        preparation_step::preparation::parse_data: 116.00µs
-          from_slice: 80.00µs
-        preparation_step::preparation::prepare: 276.00µs
-          air::preparation_step::preparation::make_exec_ctx: 38.00µs
-          air_parser::parser::air_parser::parse: 50.00µs
-        runner::execute: 25.24ms
+    big-values-data (17.84ms; 59.000 MiB, 59.000 MiB): Loading a trace with huge values
+      air::runner::execute_air: 17.84ms
+        preparation_step::preparation::parse_data: 7.24ms
+          from_slice: 7.19ms
+        preparation_step::preparation::prepare: 222.00µs
+          air::preparation_step::preparation::make_exec_ctx: 21.00µs
+          air_parser::parser::air_parser::parse: 19.00µs
+        runner::execute: 10.00µs
+        runner::farewell: 4.70ms
+          from_success_result: 4.67ms
+            populate_outcome_from_contexts: 4.61ms
+        signing_step::sign_produced_cids: 158.00µs
+        verification_step::verify: 5.35ms
+          verify: 4.81ms
+    call-requests500 (35.41ms; 58.562 MiB, 58.562 MiB): multiple call requests
+      air::runner::execute_air: 35.41ms
+        preparation_step::preparation::parse_data: 112.00µs
+          from_slice: 76.00µs
+        preparation_step::preparation::prepare: 270.00µs
+          air::preparation_step::preparation::make_exec_ctx: 40.00µs
+          air_parser::parser::air_parser::parse: 48.00µs
+        runner::execute: 25.35ms
         runner::farewell: 9.31ms
           from_success_result: 9.29ms
             populate_outcome_from_contexts: 9.14ms
-        signing_step::sign_produced_cids: 161.00µs
-        verification_step::verify: 78.00µs
+        signing_step::sign_produced_cids: 165.00µs
+        verification_step::verify: 77.00µs
           verify: 10.00µs
-    call-results500 (19.65ms; 54.438 MiB, 54.438 MiB): multiple call results
-      air::runner::execute_air: 19.65ms
-        preparation_step::preparation::parse_data: 676.00µs
-          from_slice: 636.00µs
-        preparation_step::preparation::prepare: 930.00µs
-          air::preparation_step::preparation::make_exec_ctx: 687.00µs
+    call-results500 (19.57ms; 54.438 MiB, 54.438 MiB): multiple call results
+      air::runner::execute_air: 19.57ms
+        preparation_step::preparation::parse_data: 667.00µs
+          from_slice: 627.00µs
+        preparation_step::preparation::prepare: 931.00µs
+          air::preparation_step::preparation::make_exec_ctx: 694.00µs
           air_parser::parser::air_parser::parse: 50.00µs
-        runner::execute: 15.19ms
+        runner::execute: 15.12ms
         runner::farewell: 2.20ms
           from_success_result: 2.17ms
-            populate_outcome_from_contexts: 1.74ms
+            populate_outcome_from_contexts: 1.75ms
         signing_step::sign_produced_cids: 432.00µs
-        verification_step::verify: 83.00µs
+        verification_step::verify: 82.00µs
           verify: 10.00µs
-    canon-map-key-by-lens (14.99ms; 56.625 MiB, 56.625 MiB): benchmarking a map insert operation
-      air::runner::execute_air: 14.99ms
-        preparation_step::preparation::parse_data: 4.07ms
-          from_slice: 4.02ms
-        preparation_step::preparation::prepare: 526.00µs
-          air::preparation_step::preparation::make_exec_ctx: 286.00µs
-          air_parser::parser::air_parser::parse: 56.00µs
-        runner::execute: 2.76ms
-        runner::farewell: 2.77ms
-          from_success_result: 2.75ms
-            populate_outcome_from_contexts: 2.38ms
-        signing_step::sign_produced_cids: 160.00µs
-        verification_step::verify: 4.55ms
-          verify: 4.02ms
-    canon-map-key-element-by-lens (14.93ms; 56.625 MiB, 56.625 MiB): benchmarking a map insert operation
-      air::runner::execute_air: 14.93ms
+    canon-map-key-by-lens (14.97ms; 56.625 MiB, 56.625 MiB): benchmarking a map insert operation
+      air::runner::execute_air: 14.97ms
         preparation_step::preparation::parse_data: 4.08ms
           from_slice: 4.03ms
-        preparation_step::preparation::prepare: 527.00µs
-          air::preparation_step::preparation::make_exec_ctx: 290.00µs
-          air_parser::parser::air_parser::parse: 58.00µs
-        runner::execute: 2.76ms
-        runner::farewell: 2.74ms
-          from_success_result: 2.72ms
-            populate_outcome_from_contexts: 2.36ms
-        signing_step::sign_produced_cids: 158.00µs
-        verification_step::verify: 4.51ms
+        preparation_step::preparation::prepare: 530.00µs
+          air::preparation_step::preparation::make_exec_ctx: 289.00µs
+          air_parser::parser::air_parser::parse: 57.00µs
+        runner::execute: 2.75ms
+        runner::farewell: 2.78ms
+          from_success_result: 2.76ms
+            populate_outcome_from_contexts: 2.39ms
+        signing_step::sign_produced_cids: 160.00µs
+        verification_step::verify: 4.52ms
           verify: 3.98ms
-    canon-map-multiple-keys (12.56ms; 54.500 MiB, 54.500 MiB): benchmarking a map insert operation
-      air::runner::execute_air: 12.56ms
-        preparation_step::preparation::parse_data: 356.00µs
-          from_slice: 315.00µs
-        preparation_step::preparation::prepare: 248.00µs
+    canon-map-key-element-by-lens (14.92ms; 56.625 MiB, 56.625 MiB): benchmarking a map insert operation
+      air::runner::execute_air: 14.92ms
+        preparation_step::preparation::parse_data: 4.09ms
+          from_slice: 4.04ms
+        preparation_step::preparation::prepare: 526.00µs
+          air::preparation_step::preparation::make_exec_ctx: 285.00µs
+          air_parser::parser::air_parser::parse: 58.00µs
+        runner::execute: 2.73ms
+        runner::farewell: 2.78ms
+          from_success_result: 2.75ms
+            populate_outcome_from_contexts: 2.40ms
+        signing_step::sign_produced_cids: 161.00µs
+        verification_step::verify: 4.51ms
+          verify: 3.97ms
+    canon-map-multiple-keys (12.43ms; 54.500 MiB, 54.500 MiB): benchmarking a map insert operation
+      air::runner::execute_air: 12.43ms
+        preparation_step::preparation::parse_data: 355.00µs
+          from_slice: 313.00µs
+        preparation_step::preparation::prepare: 247.00µs
           air::preparation_step::preparation::make_exec_ctx: 18.00µs
           air_parser::parser::air_parser::parse: 46.00µs
-        runner::execute: 8.75ms
+        runner::execute: 8.64ms
         runner::farewell: 2.31ms
-          from_success_result: 2.29ms
+          from_success_result: 2.28ms
             populate_outcome_from_contexts: 1.99ms
-        signing_step::sign_produced_cids: 171.00µs
-        verification_step::verify: 580.00µs
+        signing_step::sign_produced_cids: 164.00µs
+        verification_step::verify: 566.00µs
           verify: 28.00µs
     canon-map-scalar-multiple-keys (5.33ms; 53.125 MiB, 53.125 MiB): benchmarking a map insert operation
       air::runner::execute_air: 5.33ms
-        preparation_step::preparation::parse_data: 360.00µs
-          from_slice: 317.00µs
-        preparation_step::preparation::prepare: 261.00µs
+        preparation_step::preparation::parse_data: 358.00µs
+          from_slice: 316.00µs
+        preparation_step::preparation::prepare: 244.00µs
           air::preparation_step::preparation::make_exec_ctx: 18.00µs
-          air_parser::parser::air_parser::parse: 46.00µs
-        runner::execute: 3.34ms
-        runner::farewell: 449.00µs
-          from_success_result: 425.00µs
+          air_parser::parser::air_parser::parse: 45.00µs
+        runner::execute: 3.40ms
+        runner::farewell: 460.00µs
+          from_success_result: 438.00µs
+            populate_outcome_from_contexts: 394.00µs
+        signing_step::sign_produced_cids: 161.00µs
+        verification_step::verify: 576.00µs
+          verify: 27.00µs
+    canon-map-scalar-single-key (4.35ms; 53.000 MiB, 53.000 MiB): benchmarking a map insert operation
+      air::runner::execute_air: 4.35ms
+        preparation_step::preparation::parse_data: 387.00µs
+          from_slice: 342.00µs
+        preparation_step::preparation::prepare: 244.00µs
+          air::preparation_step::preparation::make_exec_ctx: 18.00µs
+          air_parser::parser::air_parser::parse: 43.00µs
+        runner::execute: 2.35ms
+        runner::farewell: 462.00µs
+          from_success_result: 438.00µs
+            populate_outcome_from_contexts: 380.00µs
+        signing_step::sign_produced_cids: 165.00µs
+        verification_step::verify: 599.00µs
+          verify: 62.00µs
+    canon-map-single-key (10.81ms; 55.312 MiB, 55.312 MiB): benchmarking a map insert operation
+      air::runner::execute_air: 10.81ms
+        preparation_step::preparation::parse_data: 381.00µs
+          from_slice: 340.00µs
+        preparation_step::preparation::prepare: 239.00µs
+          air::preparation_step::preparation::make_exec_ctx: 18.00µs
+          air_parser::parser::air_parser::parse: 43.00µs
+        runner::execute: 6.62ms
+        runner::farewell: 2.68ms
+          from_success_result: 2.66ms
+            populate_outcome_from_contexts: 2.40ms
+        signing_step::sign_produced_cids: 160.00µs
+        verification_step::verify: 590.00µs
+          verify: 61.00µs
+    dashboard (8.65ms; 52.625 MiB, 52.625 MiB): big dashboard test
+      air::runner::execute_air: 8.65ms
+        preparation_step::preparation::parse_data: 1.32ms
+          from_slice: 1.26ms
+        preparation_step::preparation::prepare: 360.00µs
+          air::preparation_step::preparation::make_exec_ctx: 41.00µs
+          air_parser::parser::air_parser::parse: 132.00µs
+        runner::execute: 1.08ms
+        runner::farewell: 674.00µs
+          from_success_result: 650.00µs
+            populate_outcome_from_contexts: 596.00µs
+        signing_step::sign_produced_cids: 172.00µs
+        verification_step::verify: 4.89ms
+          verify: 198.00µs
+    long-data (6.29ms; 53.812 MiB, 53.812 MiB): Long data trace
+      air::runner::execute_air: 6.29ms
+        preparation_step::preparation::parse_data: 2.44ms
+          from_slice: 2.40ms
+        preparation_step::preparation::prepare: 239.00µs
+          air::preparation_step::preparation::make_exec_ctx: 41.00µs
+          air_parser::parser::air_parser::parse: 18.00µs
+        runner::execute: 9.00µs
+        runner::farewell: 1.09ms
+          from_success_result: 1.07ms
+            populate_outcome_from_contexts: 1.03ms
+        signing_step::sign_produced_cids: 160.00µs
+        verification_step::verify: 2.23ms
+          verify: 838.00µs
+    multiple-cids10 (3.43ms; 52.438 MiB, 52.438 MiB): verifying multiple CIDs for single peer
+      air::runner::execute_air: 3.43ms
+        preparation_step::preparation::parse_data: 478.00µs
+          from_slice: 423.00µs
+        preparation_step::preparation::prepare: 260.00µs
+          air::preparation_step::preparation::make_exec_ctx: 32.00µs
+          air_parser::parser::air_parser::parse: 45.00µs
+        runner::execute: 572.00µs
+        runner::farewell: 464.00µs
+          from_success_result: 441.00µs
             populate_outcome_from_contexts: 383.00µs
         signing_step::sign_produced_cids: 162.00µs
-        verification_step::verify: 620.00µs
-          verify: 28.00µs
-    canon-map-scalar-single-key (4.39ms; 53.000 MiB, 53.000 MiB): benchmarking a map insert operation
-      air::runner::execute_air: 4.39ms
-        preparation_step::preparation::parse_data: 391.00µs
-          from_slice: 347.00µs
-        preparation_step::preparation::prepare: 258.00µs
-          air::preparation_step::preparation::make_exec_ctx: 18.00µs
-          air_parser::parser::air_parser::parse: 44.00µs
-        runner::execute: 2.35ms
-        runner::farewell: 443.00µs
-          from_success_result: 420.00µs
-            populate_outcome_from_contexts: 365.00µs
-        signing_step::sign_produced_cids: 159.00µs
-        verification_step::verify: 650.00µs
-          verify: 65.00µs
-    canon-map-single-key (10.82ms; 55.312 MiB, 55.312 MiB): benchmarking a map insert operation
-      air::runner::execute_air: 10.82ms
-        preparation_step::preparation::parse_data: 383.00µs
-          from_slice: 343.00µs
-        preparation_step::preparation::prepare: 250.00µs
-          air::preparation_step::preparation::make_exec_ctx: 18.00µs
-          air_parser::parser::air_parser::parse: 41.00µs
-        runner::execute: 6.60ms
-        runner::farewell: 2.61ms
-          from_success_result: 2.59ms
-            populate_outcome_from_contexts: 2.34ms
-        signing_step::sign_produced_cids: 166.00µs
-        verification_step::verify: 672.00µs
-          verify: 63.00µs
-    dashboard (8.62ms; 52.625 MiB, 52.625 MiB): big dashboard test
-      air::runner::execute_air: 8.62ms
-        preparation_step::preparation::parse_data: 1.36ms
-          from_slice: 1.30ms
-        preparation_step::preparation::prepare: 356.00µs
-          air::preparation_step::preparation::make_exec_ctx: 42.00µs
-          air_parser::parser::air_parser::parse: 133.00µs
-        runner::execute: 1.10ms
-        runner::farewell: 656.00µs
-          from_success_result: 633.00µs
-            populate_outcome_from_contexts: 580.00µs
-        signing_step::sign_produced_cids: 161.00µs
-        verification_step::verify: 4.85ms
-          verify: 200.00µs
-    long-data (6.47ms; 53.812 MiB, 53.812 MiB): Long data trace
-      air::runner::execute_air: 6.47ms
-        preparation_step::preparation::parse_data: 2.43ms
-          from_slice: 2.38ms
-        preparation_step::preparation::prepare: 247.00µs
-          air::preparation_step::preparation::make_exec_ctx: 40.00µs
-          air_parser::parser::air_parser::parse: 19.00µs
-        runner::execute: 9.00µs
-        runner::farewell: 1.11ms
-          from_success_result: 1.09ms
-            populate_outcome_from_contexts: 1.05ms
-        signing_step::sign_produced_cids: 170.00µs
-        verification_step::verify: 2.38ms
-          verify: 844.00µs
-    multiple-cids10 (3.42ms; 52.438 MiB, 52.438 MiB): verifying multiple CIDs for single peer
-      air::runner::execute_air: 3.42ms
-        preparation_step::preparation::parse_data: 482.00µs
-          from_slice: 424.00µs
-        preparation_step::preparation::prepare: 261.00µs
-          air::preparation_step::preparation::make_exec_ctx: 33.00µs
-          air_parser::parser::air_parser::parse: 45.00µs
-        runner::execute: 570.00µs
-        runner::farewell: 455.00µs
-          from_success_result: 430.00µs
-            populate_outcome_from_contexts: 370.00µs
-        signing_step::sign_produced_cids: 158.00µs
-        verification_step::verify: 1.35ms
-          verify: 238.00µs
-    multiple-peers8 (14.23ms; 53.375 MiB, 53.375 MiB): verifying many CIDs for many peers
-      air::runner::execute_air: 14.23ms
-        preparation_step::preparation::parse_data: 1.82ms
-          from_slice: 1.77ms
-        preparation_step::preparation::prepare: 349.00µs
-          air::preparation_step::preparation::make_exec_ctx: 105.00µs
+        verification_step::verify: 1.36ms
+          verify: 233.00µs
+    multiple-peers8 (13.67ms; 53.375 MiB, 53.375 MiB): verifying many CIDs for many peers
+      air::runner::execute_air: 13.67ms
+        preparation_step::preparation::parse_data: 1.77ms
+          from_slice: 1.71ms
+        preparation_step::preparation::prepare: 338.00µs
+          air::preparation_step::preparation::make_exec_ctx: 104.00µs
+          air_parser::parser::air_parser::parse: 51.00µs
+        runner::execute: 3.68ms
+        runner::farewell: 1.30ms
+          from_success_result: 1.28ms
+            populate_outcome_from_contexts: 1.17ms
+        signing_step::sign_produced_cids: 162.00µs
+        verification_step::verify: 6.26ms
+          verify: 1.04ms
+    multiple-sigs30 (24.71ms; 56.188 MiB, 56.188 MiB): signing multiple CIDs
+      air::runner::execute_air: 24.71ms
+        preparation_step::preparation::parse_data: 5.05ms
+          from_slice: 4.98ms
+        preparation_step::preparation::prepare: 444.00µs
+          air::preparation_step::preparation::make_exec_ctx: 208.00µs
           air_parser::parser::air_parser::parse: 49.00µs
-        runner::execute: 3.70ms
-        runner::farewell: 1.29ms
-          from_success_result: 1.27ms
-            populate_outcome_from_contexts: 1.16ms
-        signing_step::sign_produced_cids: 158.00µs
-        verification_step::verify: 6.80ms
-          verify: 1.05ms
-    multiple-sigs30 (24.93ms; 56.188 MiB, 56.188 MiB): signing multiple CIDs
-      air::runner::execute_air: 24.93ms
-        preparation_step::preparation::parse_data: 5.02ms
-          from_slice: 4.96ms
-        preparation_step::preparation::prepare: 443.00µs
-          air::preparation_step::preparation::make_exec_ctx: 217.00µs
-          air_parser::parser::air_parser::parse: 49.00µs
-        runner::execute: 10.60ms
+        runner::execute: 10.47ms
         runner::farewell: 3.69ms
-          from_success_result: 3.67ms
-            populate_outcome_from_contexts: 3.49ms
-        signing_step::sign_produced_cids: 667.00µs
-        verification_step::verify: 4.35ms
-          verify: 1.83ms
-    network-explore (4.36ms; 52.375 MiB, 52.375 MiB): 5 peers of network are discovered
-      air::runner::execute_air: 4.36ms
+          from_success_result: 3.66ms
+            populate_outcome_from_contexts: 3.48ms
+        signing_step::sign_produced_cids: 654.00µs
+        verification_step::verify: 4.27ms
+          verify: 1.80ms
+    network-explore (4.40ms; 52.375 MiB, 52.375 MiB): 5 peers of network are discovered
+      air::runner::execute_air: 4.40ms
         preparation_step::preparation::parse_data: 587.00µs
-          from_slice: 532.00µs
-        preparation_step::preparation::prepare: 270.00µs
+          from_slice: 531.00µs
+        preparation_step::preparation::prepare: 273.00µs
           air::preparation_step::preparation::make_exec_ctx: 23.00µs
-          air_parser::parser::air_parser::parse: 67.00µs
-        runner::execute: 166.00µs
-        runner::farewell: 366.00µs
-          from_success_result: 344.00µs
-            populate_outcome_from_contexts: 299.00µs
-        signing_step::sign_produced_cids: 160.00µs
-        verification_step::verify: 2.68ms
+          air_parser::parser::air_parser::parse: 68.00µs
+        runner::execute: 159.00µs
+        runner::farewell: 369.00µs
+          from_success_result: 346.00µs
+            populate_outcome_from_contexts: 301.00µs
+        signing_step::sign_produced_cids: 162.00µs
+        verification_step::verify: 2.72ms
           verify: 64.00µs
-    null (888.00µs; 52.375 MiB, 52.375 MiB): Empty data and null script
-      air::runner::execute_air: 888.00µs
-        preparation_step::preparation::parse_data: 22.00µs
-        preparation_step::preparation::prepare: 238.00µs
-          air::preparation_step::preparation::make_exec_ctx: 16.00µs
+    null (834.00µs; 52.375 MiB, 52.375 MiB): Empty data and null script
+      air::runner::execute_air: 834.00µs
+        preparation_step::preparation::parse_data: 19.00µs
+        preparation_step::preparation::prepare: 224.00µs
+          air::preparation_step::preparation::make_exec_ctx: 15.00µs
           air_parser::parser::air_parser::parse: 19.00µs
         runner::execute: 9.00µs
-        runner::farewell: 270.00µs
-          from_success_result: 248.00µs
-            populate_outcome_from_contexts: 209.00µs
-        signing_step::sign_produced_cids: 177.00µs
-        verification_step::verify: 37.00µs
-          verify: 12.00µs
-    parser-10000-100 (28.81ms; 54.938 MiB, 54.938 MiB): long air script with lot of variable assignments
-      air::runner::execute_air: 28.81ms
-        preparation_step::preparation::parse_data: 19.00µs
-        preparation_step::preparation::prepare: 27.56ms
-          air::preparation_step::preparation::make_exec_ctx: 16.00µs
-          air_parser::parser::air_parser::parse: 27.34ms
-        runner::execute: 29.00µs
-        runner::farewell: 254.00µs
-          from_success_result: 231.00µs
-            populate_outcome_from_contexts: 192.00µs
-        signing_step::sign_produced_cids: 158.00µs
+        runner::farewell: 256.00µs
+          from_success_result: 235.00µs
+            populate_outcome_from_contexts: 195.00µs
+        signing_step::sign_produced_cids: 161.00µs
+        verification_step::verify: 35.00µs
+          verify: 10.00µs
+    parser-10000-100 (28.73ms; 54.625 MiB, 54.625 MiB): long air script with lot of variable assignments
+      air::runner::execute_air: 28.73ms
+        preparation_step::preparation::parse_data: 20.00µs
+        preparation_step::preparation::prepare: 27.47ms
+          air::preparation_step::preparation::make_exec_ctx: 17.00µs
+          air_parser::parser::air_parser::parse: 27.23ms
+        runner::execute: 27.00µs
+        runner::farewell: 263.00µs
+          from_success_result: 240.00µs
+            populate_outcome_from_contexts: 201.00µs
+        signing_step::sign_produced_cids: 162.00µs
         verification_step::verify: 36.00µs
           verify: 10.00µs
-    populate-map-multiple-keys (4.54ms; 53.000 MiB, 53.000 MiB): benchmarking a map insert operation
-      air::runner::execute_air: 4.54ms
-        preparation_step::preparation::parse_data: 140.00µs
-          from_slice: 96.00µs
-        preparation_step::preparation::prepare: 258.00µs
-          air::preparation_step::preparation::make_exec_ctx: 19.00µs
-          air_parser::parser::air_parser::parse: 49.00µs
-        runner::execute: 2.85ms
-        runner::farewell: 394.00µs
-          from_success_result: 370.00µs
-            populate_outcome_from_contexts: 328.00µs
-        signing_step::sign_produced_cids: 167.00µs
-        verification_step::verify: 588.00µs
-          verify: 29.00µs
-    populate-map-single-key (3.71ms; 52.938 MiB, 52.938 MiB): benchmarking a map insert operation
-      air::runner::execute_air: 3.71ms
-        preparation_step::preparation::parse_data: 206.00µs
-          from_slice: 162.00µs
-        preparation_step::preparation::prepare: 255.00µs
-          air::preparation_step::preparation::make_exec_ctx: 20.00µs
+    parser-calls-10000-100 (25.94ms; 54.375 MiB, 54.375 MiB): multiple calls parser benchmark
+      air::runner::execute_air: 25.94ms
+        preparation_step::preparation::parse_data: 18.00µs
+        preparation_step::preparation::prepare: 24.66ms
+          air::preparation_step::preparation::make_exec_ctx: 15.00µs
+          air_parser::parser::air_parser::parse: 24.46ms
+        runner::execute: 28.00µs
+        runner::farewell: 255.00µs
+          from_success_result: 233.00µs
+            populate_outcome_from_contexts: 195.00µs
+        signing_step::sign_produced_cids: 160.00µs
+        verification_step::verify: 36.00µs
+          verify: 10.00µs
+    populate-map-multiple-keys (4.40ms; 53.000 MiB, 53.000 MiB): benchmarking a map insert operation
+      air::runner::execute_air: 4.40ms
+        preparation_step::preparation::parse_data: 131.00µs
+          from_slice: 91.00µs
+        preparation_step::preparation::prepare: 243.00µs
+          air::preparation_step::preparation::make_exec_ctx: 17.00µs
+          air_parser::parser::air_parser::parse: 48.00µs
+        runner::execute: 2.80ms
+        runner::farewell: 383.00µs
+          from_success_result: 361.00µs
+            populate_outcome_from_contexts: 321.00µs
+        signing_step::sign_produced_cids: 158.00µs
+        verification_step::verify: 557.00µs
+          verify: 27.00µs
+    populate-map-single-key (3.62ms; 52.938 MiB, 52.938 MiB): benchmarking a map insert operation
+      air::runner::execute_air: 3.62ms
+        preparation_step::preparation::parse_data: 200.00µs
+          from_slice: 159.00µs
+        preparation_step::preparation::prepare: 244.00µs
+          air::preparation_step::preparation::make_exec_ctx: 17.00µs
           air_parser::parser::air_parser::parse: 45.00µs
-        runner::execute: 1.94ms
-        runner::farewell: 400.00µs
-          from_success_result: 377.00µs
-            populate_outcome_from_contexts: 322.00µs
-        signing_step::sign_produced_cids: 157.00µs
-        verification_step::verify: 614.00µs
-          verify: 64.00µs
+        runner::execute: 1.89ms
+        runner::farewell: 403.00µs
+          from_success_result: 381.00µs
+            populate_outcome_from_contexts: 325.00µs
+        signing_step::sign_produced_cids: 160.00µs
+        verification_step::verify: 586.00µs
+          verify: 60.00µs

--- a/benches/PERFORMANCE.txt
+++ b/benches/PERFORMANCE.txt
@@ -913,271 +913,271 @@ Machine d77ebe8481884bc3b2778c8083f1bf459e548e929edd87041beb14f6b868d35f:
           verify: 69.00µs
 Machine e536f8eaae8c978493a773ba566ae3393e2e6240d6ea8e05b5ca1b8f77e9c441:
   Platform: Linux-5.15.0-76-generic-x86_64-with-glibc2.29
-  Timestamp: 2023-11-30 15:54:57.248575+00:00
+  Timestamp: 2023-12-08 16:06:36.836015+00:00
   AquaVM version: 0.54.0
   Benches:
   Features: check_signatures,gen_signatures
-    big-values-data (17.72ms; 59.000 MiB, 59.000 MiB): Loading a trace with huge values
-      air::runner::execute_air: 17.72ms
-        preparation_step::preparation::parse_data: 7.12ms
-          from_slice: 7.06ms
-        preparation_step::preparation::prepare: 224.00µs
-          air::preparation_step::preparation::make_exec_ctx: 22.00µs
-          air_parser::parser::air_parser::parse: 20.00µs
-        runner::execute: 10.00µs
-        runner::farewell: 4.72ms
-          from_success_result: 4.70ms
-            populate_outcome_from_contexts: 4.64ms
-        signing_step::sign_produced_cids: 162.00µs
-        verification_step::verify: 5.34ms
-          verify: 4.80ms
-    call-requests500 (35.01ms; 58.562 MiB, 58.562 MiB): multiple call requests
-      air::runner::execute_air: 35.01ms
-        preparation_step::preparation::parse_data: 116.00µs
-          from_slice: 78.00µs
-        preparation_step::preparation::prepare: 273.00µs
-          air::preparation_step::preparation::make_exec_ctx: 39.00µs
-          air_parser::parser::air_parser::parse: 49.00µs
-        runner::execute: 24.69ms
-        runner::farewell: 9.56ms
-          from_success_result: 9.54ms
-            populate_outcome_from_contexts: 9.38ms
-        signing_step::sign_produced_cids: 164.00µs
-        verification_step::verify: 77.00µs
-          verify: 10.00µs
-    call-results500 (19.19ms; 54.438 MiB, 54.438 MiB): multiple call results
-      air::runner::execute_air: 19.19ms
-        preparation_step::preparation::parse_data: 657.00µs
-          from_slice: 618.00µs
-        preparation_step::preparation::prepare: 925.00µs
-          air::preparation_step::preparation::make_exec_ctx: 688.00µs
-          air_parser::parser::air_parser::parse: 50.00µs
-        runner::execute: 14.78ms
-        runner::farewell: 2.17ms
-          from_success_result: 2.15ms
-            populate_outcome_from_contexts: 1.77ms
-        signing_step::sign_produced_cids: 435.00µs
-        verification_step::verify: 81.00µs
-          verify: 10.00µs
-    canon-map-key-by-lens (14.88ms; 56.625 MiB, 56.625 MiB): benchmarking a map insert operation
-      air::runner::execute_air: 14.88ms
-        preparation_step::preparation::parse_data: 4.04ms
-          from_slice: 3.99ms
-        preparation_step::preparation::prepare: 530.00µs
-          air::preparation_step::preparation::make_exec_ctx: 288.00µs
-          air_parser::parser::air_parser::parse: 57.00µs
-        runner::execute: 2.76ms
-        runner::farewell: 2.78ms
-          from_success_result: 2.75ms
-            populate_outcome_from_contexts: 2.40ms
-        signing_step::sign_produced_cids: 159.00µs
-        verification_step::verify: 4.48ms
-          verify: 3.95ms
-    canon-map-key-element-by-lens (14.80ms; 56.625 MiB, 56.625 MiB): benchmarking a map insert operation
-      air::runner::execute_air: 14.80ms
-        preparation_step::preparation::parse_data: 4.03ms
-          from_slice: 3.99ms
-        preparation_step::preparation::prepare: 535.00µs
-          air::preparation_step::preparation::make_exec_ctx: 293.00µs
-          air_parser::parser::air_parser::parse: 59.00µs
-        runner::execute: 2.69ms
-        runner::farewell: 2.76ms
-          from_success_result: 2.74ms
-            populate_outcome_from_contexts: 2.40ms
-        signing_step::sign_produced_cids: 159.00µs
-        verification_step::verify: 4.48ms
-          verify: 3.96ms
-    canon-map-multiple-keys (12.47ms; 54.500 MiB, 54.500 MiB): benchmarking a map insert operation
-      air::runner::execute_air: 12.47ms
-        preparation_step::preparation::parse_data: 357.00µs
-          from_slice: 317.00µs
-        preparation_step::preparation::prepare: 248.00µs
-          air::preparation_step::preparation::make_exec_ctx: 19.00µs
-          air_parser::parser::air_parser::parse: 47.00µs
-        runner::execute: 8.71ms
-        runner::farewell: 2.31ms
-          from_success_result: 2.29ms
-            populate_outcome_from_contexts: 2.00ms
-        signing_step::sign_produced_cids: 161.00µs
-        verification_step::verify: 554.00µs
-          verify: 28.00µs
-    canon-map-scalar-multiple-keys (5.18ms; 53.125 MiB, 53.125 MiB): benchmarking a map insert operation
-      air::runner::execute_air: 5.18ms
-        preparation_step::preparation::parse_data: 359.00µs
-          from_slice: 319.00µs
-        preparation_step::preparation::prepare: 243.00µs
-          air::preparation_step::preparation::make_exec_ctx: 18.00µs
-          air_parser::parser::air_parser::parse: 46.00µs
-        runner::execute: 3.28ms
-        runner::farewell: 462.00µs
-          from_success_result: 440.00µs
-            populate_outcome_from_contexts: 397.00µs
-        signing_step::sign_produced_cids: 159.00µs
-        verification_step::verify: 554.00µs
-          verify: 28.00µs
-    canon-map-scalar-single-key (4.27ms; 53.000 MiB, 53.000 MiB): benchmarking a map insert operation
-      air::runner::execute_air: 4.27ms
-        preparation_step::preparation::parse_data: 382.00µs
-          from_slice: 342.00µs
-        preparation_step::preparation::prepare: 241.00µs
-          air::preparation_step::preparation::make_exec_ctx: 18.00µs
-          air_parser::parser::air_parser::parse: 43.00µs
-        runner::execute: 2.31ms
-        runner::farewell: 454.00µs
-          from_success_result: 432.00µs
-            populate_outcome_from_contexts: 379.00µs
-        signing_step::sign_produced_cids: 160.00µs
-        verification_step::verify: 588.00µs
-          verify: 61.00µs
-    canon-map-single-key (10.90ms; 55.312 MiB, 55.312 MiB): benchmarking a map insert operation
-      air::runner::execute_air: 10.90ms
-        preparation_step::preparation::parse_data: 381.00µs
-          from_slice: 340.00µs
-        preparation_step::preparation::prepare: 244.00µs
-          air::preparation_step::preparation::make_exec_ctx: 18.00µs
-          air_parser::parser::air_parser::parse: 44.00µs
-        runner::execute: 6.73ms
-        runner::farewell: 2.64ms
-          from_success_result: 2.62ms
-            populate_outcome_from_contexts: 2.36ms
-        signing_step::sign_produced_cids: 168.00µs
-        verification_step::verify: 596.00µs
-          verify: 62.00µs
-    dashboard (8.22ms; 52.625 MiB, 52.625 MiB): big dashboard test
-      air::runner::execute_air: 8.22ms
-        preparation_step::preparation::parse_data: 1.28ms
-          from_slice: 1.23ms
-        preparation_step::preparation::prepare: 350.00µs
-          air::preparation_step::preparation::make_exec_ctx: 41.00µs
-          air_parser::parser::air_parser::parse: 131.00µs
-        runner::execute: 1.08ms
-        runner::farewell: 656.00µs
-          from_success_result: 634.00µs
-            populate_outcome_from_contexts: 584.00µs
-        signing_step::sign_produced_cids: 162.00µs
-        verification_step::verify: 4.55ms
-          verify: 195.00µs
-    long-data (6.32ms; 53.812 MiB, 53.812 MiB): Long data trace
-      air::runner::execute_air: 6.32ms
-        preparation_step::preparation::parse_data: 2.39ms
-          from_slice: 2.35ms
-        preparation_step::preparation::prepare: 238.00µs
-          air::preparation_step::preparation::make_exec_ctx: 41.00µs
+    big-values-data (17.65ms; 59.000 MiB, 59.000 MiB): Loading a trace with huge values
+      air::runner::execute_air: 17.65ms
+        preparation_step::preparation::parse_data: 7.03ms
+          from_slice: 6.98ms
+        preparation_step::preparation::prepare: 214.00µs
+          air::preparation_step::preparation::make_exec_ctx: 20.00µs
           air_parser::parser::air_parser::parse: 18.00µs
         runner::execute: 9.00µs
-        runner::farewell: 1.07ms
-          from_success_result: 1.05ms
-            populate_outcome_from_contexts: 1.01ms
-        signing_step::sign_produced_cids: 158.00µs
-        verification_step::verify: 2.33ms
-          verify: 841.00µs
-    multiple-cids10 (3.37ms; 52.438 MiB, 52.438 MiB): verifying multiple CIDs for single peer
-      air::runner::execute_air: 3.37ms
-        preparation_step::preparation::parse_data: 467.00µs
-          from_slice: 414.00µs
-        preparation_step::preparation::prepare: 256.00µs
-          air::preparation_step::preparation::make_exec_ctx: 32.00µs
-          air_parser::parser::air_parser::parse: 44.00µs
-        runner::execute: 568.00µs
-        runner::farewell: 456.00µs
-          from_success_result: 434.00µs
-            populate_outcome_from_contexts: 375.00µs
-        signing_step::sign_produced_cids: 159.00µs
-        verification_step::verify: 1.34ms
-          verify: 230.00µs
-    multiple-peers8 (13.47ms; 53.375 MiB, 53.375 MiB): verifying many CIDs for many peers
-      air::runner::execute_air: 13.47ms
-        preparation_step::preparation::parse_data: 1.74ms
-          from_slice: 1.68ms
-        preparation_step::preparation::prepare: 334.00µs
-          air::preparation_step::preparation::make_exec_ctx: 103.00µs
-          air_parser::parser::air_parser::parse: 51.00µs
-        runner::execute: 3.63ms
-        runner::farewell: 1.30ms
-          from_success_result: 1.28ms
-            populate_outcome_from_contexts: 1.17ms
-        signing_step::sign_produced_cids: 159.00µs
-        verification_step::verify: 6.18ms
-          verify: 1.03ms
-    multiple-sigs30 (24.67ms; 56.188 MiB, 56.188 MiB): signing multiple CIDs
-      air::runner::execute_air: 24.67ms
-        preparation_step::preparation::parse_data: 4.93ms
-          from_slice: 4.87ms
-        preparation_step::preparation::prepare: 446.00µs
-          air::preparation_step::preparation::make_exec_ctx: 215.00µs
-          air_parser::parser::air_parser::parse: 49.00µs
-        runner::execute: 10.49ms
-        runner::farewell: 3.70ms
-          from_success_result: 3.68ms
-            populate_outcome_from_contexts: 3.50ms
-        signing_step::sign_produced_cids: 668.00µs
-        verification_step::verify: 4.30ms
-          verify: 1.81ms
-    network-explore (4.35ms; 52.375 MiB, 52.375 MiB): 5 peers of network are discovered
-      air::runner::execute_air: 4.35ms
-        preparation_step::preparation::parse_data: 582.00µs
-          from_slice: 525.00µs
-        preparation_step::preparation::prepare: 267.00µs
-          air::preparation_step::preparation::make_exec_ctx: 22.00µs
-          air_parser::parser::air_parser::parse: 67.00µs
-        runner::execute: 163.00µs
-        runner::farewell: 363.00µs
-          from_success_result: 342.00µs
-            populate_outcome_from_contexts: 298.00µs
+        runner::farewell: 4.71ms
+          from_success_result: 4.68ms
+            populate_outcome_from_contexts: 4.63ms
+        signing_step::sign_produced_cids: 155.00µs
+        verification_step::verify: 5.40ms
+          verify: 4.87ms
+    call-requests500 (35.31ms; 58.562 MiB, 58.562 MiB): multiple call requests
+      air::runner::execute_air: 35.31ms
+        preparation_step::preparation::parse_data: 116.00µs
+          from_slice: 80.00µs
+        preparation_step::preparation::prepare: 276.00µs
+          air::preparation_step::preparation::make_exec_ctx: 38.00µs
+          air_parser::parser::air_parser::parse: 50.00µs
+        runner::execute: 25.24ms
+        runner::farewell: 9.31ms
+          from_success_result: 9.29ms
+            populate_outcome_from_contexts: 9.14ms
+        signing_step::sign_produced_cids: 161.00µs
+        verification_step::verify: 78.00µs
+          verify: 10.00µs
+    call-results500 (19.65ms; 54.438 MiB, 54.438 MiB): multiple call results
+      air::runner::execute_air: 19.65ms
+        preparation_step::preparation::parse_data: 676.00µs
+          from_slice: 636.00µs
+        preparation_step::preparation::prepare: 930.00µs
+          air::preparation_step::preparation::make_exec_ctx: 687.00µs
+          air_parser::parser::air_parser::parse: 50.00µs
+        runner::execute: 15.19ms
+        runner::farewell: 2.20ms
+          from_success_result: 2.17ms
+            populate_outcome_from_contexts: 1.74ms
+        signing_step::sign_produced_cids: 432.00µs
+        verification_step::verify: 83.00µs
+          verify: 10.00µs
+    canon-map-key-by-lens (14.99ms; 56.625 MiB, 56.625 MiB): benchmarking a map insert operation
+      air::runner::execute_air: 14.99ms
+        preparation_step::preparation::parse_data: 4.07ms
+          from_slice: 4.02ms
+        preparation_step::preparation::prepare: 526.00µs
+          air::preparation_step::preparation::make_exec_ctx: 286.00µs
+          air_parser::parser::air_parser::parse: 56.00µs
+        runner::execute: 2.76ms
+        runner::farewell: 2.77ms
+          from_success_result: 2.75ms
+            populate_outcome_from_contexts: 2.38ms
         signing_step::sign_produced_cids: 160.00µs
-        verification_step::verify: 2.69ms
+        verification_step::verify: 4.55ms
+          verify: 4.02ms
+    canon-map-key-element-by-lens (14.93ms; 56.625 MiB, 56.625 MiB): benchmarking a map insert operation
+      air::runner::execute_air: 14.93ms
+        preparation_step::preparation::parse_data: 4.08ms
+          from_slice: 4.03ms
+        preparation_step::preparation::prepare: 527.00µs
+          air::preparation_step::preparation::make_exec_ctx: 290.00µs
+          air_parser::parser::air_parser::parse: 58.00µs
+        runner::execute: 2.76ms
+        runner::farewell: 2.74ms
+          from_success_result: 2.72ms
+            populate_outcome_from_contexts: 2.36ms
+        signing_step::sign_produced_cids: 158.00µs
+        verification_step::verify: 4.51ms
+          verify: 3.98ms
+    canon-map-multiple-keys (12.56ms; 54.500 MiB, 54.500 MiB): benchmarking a map insert operation
+      air::runner::execute_air: 12.56ms
+        preparation_step::preparation::parse_data: 356.00µs
+          from_slice: 315.00µs
+        preparation_step::preparation::prepare: 248.00µs
+          air::preparation_step::preparation::make_exec_ctx: 18.00µs
+          air_parser::parser::air_parser::parse: 46.00µs
+        runner::execute: 8.75ms
+        runner::farewell: 2.31ms
+          from_success_result: 2.29ms
+            populate_outcome_from_contexts: 1.99ms
+        signing_step::sign_produced_cids: 171.00µs
+        verification_step::verify: 580.00µs
+          verify: 28.00µs
+    canon-map-scalar-multiple-keys (5.33ms; 53.125 MiB, 53.125 MiB): benchmarking a map insert operation
+      air::runner::execute_air: 5.33ms
+        preparation_step::preparation::parse_data: 360.00µs
+          from_slice: 317.00µs
+        preparation_step::preparation::prepare: 261.00µs
+          air::preparation_step::preparation::make_exec_ctx: 18.00µs
+          air_parser::parser::air_parser::parse: 46.00µs
+        runner::execute: 3.34ms
+        runner::farewell: 449.00µs
+          from_success_result: 425.00µs
+            populate_outcome_from_contexts: 383.00µs
+        signing_step::sign_produced_cids: 162.00µs
+        verification_step::verify: 620.00µs
+          verify: 28.00µs
+    canon-map-scalar-single-key (4.39ms; 53.000 MiB, 53.000 MiB): benchmarking a map insert operation
+      air::runner::execute_air: 4.39ms
+        preparation_step::preparation::parse_data: 391.00µs
+          from_slice: 347.00µs
+        preparation_step::preparation::prepare: 258.00µs
+          air::preparation_step::preparation::make_exec_ctx: 18.00µs
+          air_parser::parser::air_parser::parse: 44.00µs
+        runner::execute: 2.35ms
+        runner::farewell: 443.00µs
+          from_success_result: 420.00µs
+            populate_outcome_from_contexts: 365.00µs
+        signing_step::sign_produced_cids: 159.00µs
+        verification_step::verify: 650.00µs
+          verify: 65.00µs
+    canon-map-single-key (10.82ms; 55.312 MiB, 55.312 MiB): benchmarking a map insert operation
+      air::runner::execute_air: 10.82ms
+        preparation_step::preparation::parse_data: 383.00µs
+          from_slice: 343.00µs
+        preparation_step::preparation::prepare: 250.00µs
+          air::preparation_step::preparation::make_exec_ctx: 18.00µs
+          air_parser::parser::air_parser::parse: 41.00µs
+        runner::execute: 6.60ms
+        runner::farewell: 2.61ms
+          from_success_result: 2.59ms
+            populate_outcome_from_contexts: 2.34ms
+        signing_step::sign_produced_cids: 166.00µs
+        verification_step::verify: 672.00µs
+          verify: 63.00µs
+    dashboard (8.62ms; 52.625 MiB, 52.625 MiB): big dashboard test
+      air::runner::execute_air: 8.62ms
+        preparation_step::preparation::parse_data: 1.36ms
+          from_slice: 1.30ms
+        preparation_step::preparation::prepare: 356.00µs
+          air::preparation_step::preparation::make_exec_ctx: 42.00µs
+          air_parser::parser::air_parser::parse: 133.00µs
+        runner::execute: 1.10ms
+        runner::farewell: 656.00µs
+          from_success_result: 633.00µs
+            populate_outcome_from_contexts: 580.00µs
+        signing_step::sign_produced_cids: 161.00µs
+        verification_step::verify: 4.85ms
+          verify: 200.00µs
+    long-data (6.47ms; 53.812 MiB, 53.812 MiB): Long data trace
+      air::runner::execute_air: 6.47ms
+        preparation_step::preparation::parse_data: 2.43ms
+          from_slice: 2.38ms
+        preparation_step::preparation::prepare: 247.00µs
+          air::preparation_step::preparation::make_exec_ctx: 40.00µs
+          air_parser::parser::air_parser::parse: 19.00µs
+        runner::execute: 9.00µs
+        runner::farewell: 1.11ms
+          from_success_result: 1.09ms
+            populate_outcome_from_contexts: 1.05ms
+        signing_step::sign_produced_cids: 170.00µs
+        verification_step::verify: 2.38ms
+          verify: 844.00µs
+    multiple-cids10 (3.42ms; 52.438 MiB, 52.438 MiB): verifying multiple CIDs for single peer
+      air::runner::execute_air: 3.42ms
+        preparation_step::preparation::parse_data: 482.00µs
+          from_slice: 424.00µs
+        preparation_step::preparation::prepare: 261.00µs
+          air::preparation_step::preparation::make_exec_ctx: 33.00µs
+          air_parser::parser::air_parser::parse: 45.00µs
+        runner::execute: 570.00µs
+        runner::farewell: 455.00µs
+          from_success_result: 430.00µs
+            populate_outcome_from_contexts: 370.00µs
+        signing_step::sign_produced_cids: 158.00µs
+        verification_step::verify: 1.35ms
+          verify: 238.00µs
+    multiple-peers8 (14.23ms; 53.375 MiB, 53.375 MiB): verifying many CIDs for many peers
+      air::runner::execute_air: 14.23ms
+        preparation_step::preparation::parse_data: 1.82ms
+          from_slice: 1.77ms
+        preparation_step::preparation::prepare: 349.00µs
+          air::preparation_step::preparation::make_exec_ctx: 105.00µs
+          air_parser::parser::air_parser::parse: 49.00µs
+        runner::execute: 3.70ms
+        runner::farewell: 1.29ms
+          from_success_result: 1.27ms
+            populate_outcome_from_contexts: 1.16ms
+        signing_step::sign_produced_cids: 158.00µs
+        verification_step::verify: 6.80ms
+          verify: 1.05ms
+    multiple-sigs30 (24.93ms; 56.188 MiB, 56.188 MiB): signing multiple CIDs
+      air::runner::execute_air: 24.93ms
+        preparation_step::preparation::parse_data: 5.02ms
+          from_slice: 4.96ms
+        preparation_step::preparation::prepare: 443.00µs
+          air::preparation_step::preparation::make_exec_ctx: 217.00µs
+          air_parser::parser::air_parser::parse: 49.00µs
+        runner::execute: 10.60ms
+        runner::farewell: 3.69ms
+          from_success_result: 3.67ms
+            populate_outcome_from_contexts: 3.49ms
+        signing_step::sign_produced_cids: 667.00µs
+        verification_step::verify: 4.35ms
+          verify: 1.83ms
+    network-explore (4.36ms; 52.375 MiB, 52.375 MiB): 5 peers of network are discovered
+      air::runner::execute_air: 4.36ms
+        preparation_step::preparation::parse_data: 587.00µs
+          from_slice: 532.00µs
+        preparation_step::preparation::prepare: 270.00µs
+          air::preparation_step::preparation::make_exec_ctx: 23.00µs
+          air_parser::parser::air_parser::parse: 67.00µs
+        runner::execute: 166.00µs
+        runner::farewell: 366.00µs
+          from_success_result: 344.00µs
+            populate_outcome_from_contexts: 299.00µs
+        signing_step::sign_produced_cids: 160.00µs
+        verification_step::verify: 2.68ms
           verify: 64.00µs
-    null (848.00µs; 52.375 MiB, 52.375 MiB): Empty data and null script
-      air::runner::execute_air: 848.00µs
-        preparation_step::preparation::parse_data: 18.00µs
-        preparation_step::preparation::prepare: 224.00µs
+    null (888.00µs; 52.375 MiB, 52.375 MiB): Empty data and null script
+      air::runner::execute_air: 888.00µs
+        preparation_step::preparation::parse_data: 22.00µs
+        preparation_step::preparation::prepare: 238.00µs
           air::preparation_step::preparation::make_exec_ctx: 16.00µs
           air_parser::parser::air_parser::parse: 19.00µs
         runner::execute: 9.00µs
-        runner::farewell: 257.00µs
-          from_success_result: 234.00µs
-            populate_outcome_from_contexts: 194.00µs
-        signing_step::sign_produced_cids: 162.00µs
-        verification_step::verify: 39.00µs
+        runner::farewell: 270.00µs
+          from_success_result: 248.00µs
+            populate_outcome_from_contexts: 209.00µs
+        signing_step::sign_produced_cids: 177.00µs
+        verification_step::verify: 37.00µs
           verify: 12.00µs
-    parser-10000-100 (29.56ms; 57.688 MiB, 57.688 MiB): long air script with lot of variable assignments
-      air::runner::execute_air: 29.56ms
-        preparation_step::preparation::parse_data: 20.00µs
-        preparation_step::preparation::prepare: 27.87ms
-          air::preparation_step::preparation::make_exec_ctx: 18.00µs
-          air_parser::parser::air_parser::parse: 27.63ms
-        runner::execute: 30.00µs
-        runner::farewell: 257.00µs
-          from_success_result: 235.00µs
-            populate_outcome_from_contexts: 196.00µs
-        signing_step::sign_produced_cids: 161.00µs
-        verification_step::verify: 34.00µs
-          verify: 10.00µs
-    populate-map-multiple-keys (4.37ms; 53.000 MiB, 53.000 MiB): benchmarking a map insert operation
-      air::runner::execute_air: 4.37ms
-        preparation_step::preparation::parse_data: 130.00µs
-          from_slice: 91.00µs
-        preparation_step::preparation::prepare: 246.00µs
-          air::preparation_step::preparation::make_exec_ctx: 18.00µs
-          air_parser::parser::air_parser::parse: 49.00µs
-        runner::execute: 2.77ms
-        runner::farewell: 387.00µs
-          from_success_result: 365.00µs
-            populate_outcome_from_contexts: 325.00µs
+    parser-10000-100 (28.81ms; 54.938 MiB, 54.938 MiB): long air script with lot of variable assignments
+      air::runner::execute_air: 28.81ms
+        preparation_step::preparation::parse_data: 19.00µs
+        preparation_step::preparation::prepare: 27.56ms
+          air::preparation_step::preparation::make_exec_ctx: 16.00µs
+          air_parser::parser::air_parser::parse: 27.34ms
+        runner::execute: 29.00µs
+        runner::farewell: 254.00µs
+          from_success_result: 231.00µs
+            populate_outcome_from_contexts: 192.00µs
         signing_step::sign_produced_cids: 158.00µs
-        verification_step::verify: 549.00µs
-          verify: 27.00µs
-    populate-map-single-key (3.62ms; 52.938 MiB, 52.938 MiB): benchmarking a map insert operation
-      air::runner::execute_air: 3.62ms
-        preparation_step::preparation::parse_data: 199.00µs
-          from_slice: 159.00µs
-        preparation_step::preparation::prepare: 243.00µs
-          air::preparation_step::preparation::make_exec_ctx: 18.00µs
-          air_parser::parser::air_parser::parse: 46.00µs
-        runner::execute: 1.91ms
+        verification_step::verify: 36.00µs
+          verify: 10.00µs
+    populate-map-multiple-keys (4.54ms; 53.000 MiB, 53.000 MiB): benchmarking a map insert operation
+      air::runner::execute_air: 4.54ms
+        preparation_step::preparation::parse_data: 140.00µs
+          from_slice: 96.00µs
+        preparation_step::preparation::prepare: 258.00µs
+          air::preparation_step::preparation::make_exec_ctx: 19.00µs
+          air_parser::parser::air_parser::parse: 49.00µs
+        runner::execute: 2.85ms
+        runner::farewell: 394.00µs
+          from_success_result: 370.00µs
+            populate_outcome_from_contexts: 328.00µs
+        signing_step::sign_produced_cids: 167.00µs
+        verification_step::verify: 588.00µs
+          verify: 29.00µs
+    populate-map-single-key (3.71ms; 52.938 MiB, 52.938 MiB): benchmarking a map insert operation
+      air::runner::execute_air: 3.71ms
+        preparation_step::preparation::parse_data: 206.00µs
+          from_slice: 162.00µs
+        preparation_step::preparation::prepare: 255.00µs
+          air::preparation_step::preparation::make_exec_ctx: 20.00µs
+          air_parser::parser::air_parser::parse: 45.00µs
+        runner::execute: 1.94ms
         runner::farewell: 400.00µs
           from_success_result: 377.00µs
-            populate_outcome_from_contexts: 324.00µs
-        signing_step::sign_produced_cids: 160.00µs
-        verification_step::verify: 586.00µs
-          verify: 61.00µs
+            populate_outcome_from_contexts: 322.00µs
+        signing_step::sign_produced_cids: 157.00µs
+        verification_step::verify: 614.00µs
+          verify: 64.00µs

--- a/benches/PERFORMANCE.txt
+++ b/benches/PERFORMANCE.txt
@@ -643,287 +643,287 @@ Machine c1f3ea5950db0a10b44da931c25774d64ab25084f47d504f72f311e694550ff1:
             new: 38.00µs
 Machine d77ebe8481884bc3b2778c8083f1bf459e548e929edd87041beb14f6b868d35f:
   Platform: macOS-14.1.2-arm64-arm-64bit
-  Timestamp: 2023-12-11 13:56:25.495152+00:00
+  Timestamp: 2023-12-12 10:20:35.572977+00:00
   AquaVM version: 0.54.0
   Benches:
   Features: check_signatures,gen_signatures
-    big-values-data (13.01ms; 59.000 MiB, 59.000 MiB): Loading a trace with huge values
-      air::runner::execute_air: 13.01ms
-        preparation_step::preparation::parse_data: 5.31ms
-          from_slice: 5.26ms
-        preparation_step::preparation::prepare: 182.00µs
-          air::preparation_step::preparation::make_exec_ctx: 28.00µs
-          air_parser::parser::air_parser::parse: 33.00µs
-        runner::execute: 9.00µs
+    big-values-data (13.10ms; 59.000 MiB, 59.000 MiB): Loading a trace with huge values
+      air::runner::execute_air: 13.10ms
+        preparation_step::preparation::parse_data: 5.36ms
+          from_slice: 5.30ms
+        preparation_step::preparation::prepare: 170.00µs
+          air::preparation_step::preparation::make_exec_ctx: 22.00µs
+          air_parser::parser::air_parser::parse: 32.00µs
+        runner::execute: 8.00µs
         runner::farewell: 3.29ms
           from_success_result: 3.27ms
             populate_outcome_from_contexts: 3.23ms
-        signing_step::sign_produced_cids: 102.00µs
-        verification_step::verify: 3.98ms
-          verify: 3.62ms
-    call-requests500 (25.90ms; 58.562 MiB, 58.562 MiB): multiple call requests
-      air::runner::execute_air: 25.90ms
-        preparation_step::preparation::parse_data: 147.00µs
-          from_slice: 101.00µs
-        preparation_step::preparation::prepare: 254.00µs
-          air::preparation_step::preparation::make_exec_ctx: 52.00µs
-          air_parser::parser::air_parser::parse: 76.00µs
-        runner::execute: 20.00ms
-        runner::farewell: 5.15ms
-          from_success_result: 5.13ms
-            populate_outcome_from_contexts: 5.02ms
-        signing_step::sign_produced_cids: 106.00µs
-        verification_step::verify: 76.00µs
+        signing_step::sign_produced_cids: 100.00µs
+        verification_step::verify: 3.99ms
+          verify: 3.63ms
+    call-requests500 (26.11ms; 58.562 MiB, 58.562 MiB): multiple call requests
+      air::runner::execute_air: 26.11ms
+        preparation_step::preparation::parse_data: 134.00µs
+          from_slice: 97.00µs
+        preparation_step::preparation::prepare: 238.00µs
+          air::preparation_step::preparation::make_exec_ctx: 48.00µs
+          air_parser::parser::air_parser::parse: 68.00µs
+        runner::execute: 20.23ms
+        runner::farewell: 5.16ms
+          from_success_result: 5.14ms
+            populate_outcome_from_contexts: 5.04ms
+        signing_step::sign_produced_cids: 107.00µs
+        verification_step::verify: 75.00µs
           verify: 9.00µs
-    call-results500 (15.70ms; 54.438 MiB, 54.438 MiB): multiple call results
-      air::runner::execute_air: 15.70ms
-        preparation_step::preparation::parse_data: 621.00µs
-          from_slice: 577.00µs
-        preparation_step::preparation::prepare: 1.01ms
-          air::preparation_step::preparation::make_exec_ctx: 812.00µs
-          air_parser::parser::air_parser::parse: 72.00µs
-        runner::execute: 11.70ms
-        runner::farewell: 1.81ms
-          from_success_result: 1.78ms
-            populate_outcome_from_contexts: 1.33ms
-        signing_step::sign_produced_cids: 289.00µs
-        verification_step::verify: 90.00µs
+    call-results500 (15.96ms; 54.438 MiB, 54.438 MiB): multiple call results
+      air::runner::execute_air: 15.96ms
+        preparation_step::preparation::parse_data: 624.00µs
+          from_slice: 581.00µs
+        preparation_step::preparation::prepare: 1.00ms
+          air::preparation_step::preparation::make_exec_ctx: 810.00µs
+          air_parser::parser::air_parser::parse: 67.00µs
+        runner::execute: 11.94ms
+        runner::farewell: 1.82ms
+          from_success_result: 1.79ms
+            populate_outcome_from_contexts: 1.35ms
+        signing_step::sign_produced_cids: 292.00µs
+        verification_step::verify: 92.00µs
           verify: 9.00µs
-    canon-map-key-by-lens (10.84ms; 56.625 MiB, 56.625 MiB): benchmarking a map insert operation
-      air::runner::execute_air: 10.84ms
-        preparation_step::preparation::parse_data: 3.17ms
-          from_slice: 3.13ms
-        preparation_step::preparation::prepare: 396.00µs
-          air::preparation_step::preparation::make_exec_ctx: 192.00µs
-          air_parser::parser::air_parser::parse: 79.00µs
-        runner::execute: 1.95ms
-        runner::farewell: 1.88ms
-          from_success_result: 1.86ms
-            populate_outcome_from_contexts: 1.49ms
-        signing_step::sign_produced_cids: 102.00µs
-        verification_step::verify: 3.17ms
-          verify: 2.80ms
-    canon-map-key-element-by-lens (10.80ms; 56.625 MiB, 56.625 MiB): benchmarking a map insert operation
+    canon-map-key-by-lens (10.80ms; 56.625 MiB, 56.625 MiB): benchmarking a map insert operation
       air::runner::execute_air: 10.80ms
-        preparation_step::preparation::parse_data: 3.16ms
-          from_slice: 3.12ms
-        preparation_step::preparation::prepare: 395.00µs
-          air::preparation_step::preparation::make_exec_ctx: 192.00µs
-          air_parser::parser::air_parser::parse: 82.00µs
-        runner::execute: 1.93ms
+        preparation_step::preparation::parse_data: 3.18ms
+          from_slice: 3.13ms
+        preparation_step::preparation::prepare: 378.00µs
+          air::preparation_step::preparation::make_exec_ctx: 189.00µs
+          air_parser::parser::air_parser::parse: 73.00µs
+        runner::execute: 1.94ms
         runner::farewell: 1.87ms
           from_success_result: 1.85ms
-            populate_outcome_from_contexts: 1.51ms
-        signing_step::sign_produced_cids: 101.00µs
-        verification_step::verify: 3.16ms
-          verify: 2.80ms
+            populate_outcome_from_contexts: 1.49ms
+        signing_step::sign_produced_cids: 99.00µs
+        verification_step::verify: 3.15ms
+          verify: 2.79ms
+    canon-map-key-element-by-lens (10.80ms; 56.625 MiB, 56.625 MiB): benchmarking a map insert operation
+      air::runner::execute_air: 10.80ms
+        preparation_step::preparation::parse_data: 3.18ms
+          from_slice: 3.13ms
+        preparation_step::preparation::prepare: 387.00µs
+          air::preparation_step::preparation::make_exec_ctx: 194.00µs
+          air_parser::parser::air_parser::parse: 75.00µs
+        runner::execute: 1.93ms
+        runner::farewell: 1.86ms
+          from_success_result: 1.84ms
+            populate_outcome_from_contexts: 1.50ms
+        signing_step::sign_produced_cids: 99.00µs
+        verification_step::verify: 3.15ms
+          verify: 2.79ms
     canon-map-multiple-keys (8.97ms; 54.500 MiB, 54.500 MiB): benchmarking a map insert operation
       air::runner::execute_air: 8.97ms
-        preparation_step::preparation::parse_data: 423.00µs
-          from_slice: 377.00µs
-        preparation_step::preparation::prepare: 209.00µs
-          air::preparation_step::preparation::make_exec_ctx: 23.00µs
-          air_parser::parser::air_parser::parse: 66.00µs
-        runner::execute: 6.04ms
+        preparation_step::preparation::parse_data: 410.00µs
+          from_slice: 363.00µs
+        preparation_step::preparation::prepare: 196.00µs
+          air::preparation_step::preparation::make_exec_ctx: 20.00µs
+          air_parser::parser::air_parser::parse: 59.00µs
+        runner::execute: 6.05ms
         runner::farewell: 1.63ms
-          from_success_result: 1.61ms
+          from_success_result: 1.60ms
             populate_outcome_from_contexts: 1.32ms
         signing_step::sign_produced_cids: 100.00µs
-        verification_step::verify: 401.00µs
-          verify: 35.00µs
-    canon-map-scalar-multiple-keys (4.11ms; 53.125 MiB, 53.125 MiB): benchmarking a map insert operation
-      air::runner::execute_air: 4.11ms
-        preparation_step::preparation::parse_data: 430.00µs
-          from_slice: 385.00µs
-        preparation_step::preparation::prepare: 213.00µs
-          air::preparation_step::preparation::make_exec_ctx: 24.00µs
-          air_parser::parser::air_parser::parse: 69.00µs
-        runner::execute: 2.44ms
-        runner::farewell: 352.00µs
-          from_success_result: 332.00µs
-            populate_outcome_from_contexts: 294.00µs
-        signing_step::sign_produced_cids: 101.00µs
-        verification_step::verify: 404.00µs
-          verify: 34.00µs
-    canon-map-scalar-single-key (3.28ms; 53.000 MiB, 53.000 MiB): benchmarking a map insert operation
-      air::runner::execute_air: 3.28ms
-        preparation_step::preparation::parse_data: 427.00µs
-          from_slice: 379.00µs
-        preparation_step::preparation::prepare: 205.00µs
-          air::preparation_step::preparation::make_exec_ctx: 23.00µs
-          air_parser::parser::air_parser::parse: 62.00µs
-        runner::execute: 1.58ms
-        runner::farewell: 362.00µs
-          from_success_result: 343.00µs
-            populate_outcome_from_contexts: 287.00µs
-        signing_step::sign_produced_cids: 101.00µs
-        verification_step::verify: 432.00µs
-          verify: 70.00µs
-    canon-map-single-key (7.51ms; 55.312 MiB, 55.312 MiB): benchmarking a map insert operation
-      air::runner::execute_air: 7.51ms
-        preparation_step::preparation::parse_data: 429.00µs
-          from_slice: 383.00µs
-        preparation_step::preparation::prepare: 204.00µs
-          air::preparation_step::preparation::make_exec_ctx: 23.00µs
-          air_parser::parser::air_parser::parse: 62.00µs
-        runner::execute: 4.45ms
-        runner::farewell: 1.73ms
-          from_success_result: 1.71ms
+        verification_step::verify: 406.00µs
+          verify: 39.00µs
+    canon-map-scalar-multiple-keys (4.10ms; 53.125 MiB, 53.125 MiB): benchmarking a map insert operation
+      air::runner::execute_air: 4.10ms
+        preparation_step::preparation::parse_data: 420.00µs
+          from_slice: 369.00µs
+        preparation_step::preparation::prepare: 195.00µs
+          air::preparation_step::preparation::make_exec_ctx: 20.00µs
+          air_parser::parser::air_parser::parse: 59.00µs
+        runner::execute: 2.45ms
+        runner::farewell: 349.00µs
+          from_success_result: 329.00µs
+            populate_outcome_from_contexts: 292.00µs
+        signing_step::sign_produced_cids: 99.00µs
+        verification_step::verify: 406.00µs
+          verify: 40.00µs
+    canon-map-scalar-single-key (3.26ms; 53.000 MiB, 53.000 MiB): benchmarking a map insert operation
+      air::runner::execute_air: 3.26ms
+        preparation_step::preparation::parse_data: 423.00µs
+          from_slice: 375.00µs
+        preparation_step::preparation::prepare: 192.00µs
+          air::preparation_step::preparation::make_exec_ctx: 19.00µs
+          air_parser::parser::air_parser::parse: 56.00µs
+        runner::execute: 1.57ms
+        runner::farewell: 359.00µs
+          from_success_result: 339.00µs
+            populate_outcome_from_contexts: 284.00µs
+        signing_step::sign_produced_cids: 99.00µs
+        verification_step::verify: 435.00µs
+          verify: 73.00µs
+    canon-map-single-key (7.48ms; 55.312 MiB, 55.312 MiB): benchmarking a map insert operation
+      air::runner::execute_air: 7.48ms
+        preparation_step::preparation::parse_data: 421.00µs
+          from_slice: 373.00µs
+        preparation_step::preparation::prepare: 192.00µs
+          air::preparation_step::preparation::make_exec_ctx: 20.00µs
+          air_parser::parser::air_parser::parse: 56.00µs
+        runner::execute: 4.44ms
+        runner::farewell: 1.72ms
+          from_success_result: 1.70ms
             populate_outcome_from_contexts: 1.46ms
-        signing_step::sign_produced_cids: 101.00µs
-        verification_step::verify: 430.00µs
-          verify: 69.00µs
-    dashboard (5.73ms; 52.625 MiB, 52.625 MiB): big dashboard test
-      air::runner::execute_air: 5.73ms
+        signing_step::sign_produced_cids: 99.00µs
+        verification_step::verify: 434.00µs
+          verify: 72.00µs
+    dashboard (5.69ms; 52.625 MiB, 52.625 MiB): big dashboard test
+      air::runner::execute_air: 5.69ms
         preparation_step::preparation::parse_data: 1.01ms
-          from_slice: 954.00µs
-        preparation_step::preparation::prepare: 326.00µs
-          air::preparation_step::preparation::make_exec_ctx: 38.00µs
-          air_parser::parser::air_parser::parse: 168.00µs
-        runner::execute: 766.00µs
-        runner::farewell: 468.00µs
-          from_success_result: 446.00µs
-            populate_outcome_from_contexts: 402.00µs
-        signing_step::sign_produced_cids: 103.00µs
-        verification_step::verify: 2.89ms
-          verify: 151.00µs
-    long-data (4.98ms; 53.812 MiB, 53.812 MiB): Long data trace
-      air::runner::execute_air: 4.98ms
-        preparation_step::preparation::parse_data: 1.91ms
-          from_slice: 1.86ms
-        preparation_step::preparation::prepare: 191.00µs
-          air::preparation_step::preparation::make_exec_ctx: 40.00µs
+          from_slice: 955.00µs
+        preparation_step::preparation::prepare: 313.00µs
+          air::preparation_step::preparation::make_exec_ctx: 36.00µs
+          air_parser::parser::air_parser::parse: 160.00µs
+        runner::execute: 759.00µs
+        runner::farewell: 461.00µs
+          from_success_result: 441.00µs
+            populate_outcome_from_contexts: 398.00µs
+        signing_step::sign_produced_cids: 101.00µs
+        verification_step::verify: 2.87ms
+          verify: 157.00µs
+    long-data (5.01ms; 53.812 MiB, 53.812 MiB): Long data trace
+      air::runner::execute_air: 5.01ms
+        preparation_step::preparation::parse_data: 1.95ms
+          from_slice: 1.89ms
+        preparation_step::preparation::prepare: 182.00µs
+          air::preparation_step::preparation::make_exec_ctx: 34.00µs
           air_parser::parser::air_parser::parse: 31.00µs
         runner::execute: 8.00µs
-        runner::farewell: 907.00µs
-          from_success_result: 887.00µs
-            populate_outcome_from_contexts: 849.00µs
-        signing_step::sign_produced_cids: 101.00µs
+        runner::farewell: 895.00µs
+          from_success_result: 876.00µs
+            populate_outcome_from_contexts: 838.00µs
+        signing_step::sign_produced_cids: 98.00µs
         verification_step::verify: 1.71ms
-          verify: 659.00µs
+          verify: 662.00µs
     multiple-cids10 (2.53ms; 52.438 MiB, 52.438 MiB): verifying multiple CIDs for single peer
       air::runner::execute_air: 2.53ms
-        preparation_step::preparation::parse_data: 435.00µs
-          from_slice: 381.00µs
-        preparation_step::preparation::prepare: 210.00µs
-          air::preparation_step::preparation::make_exec_ctx: 31.00µs
-          air_parser::parser::air_parser::parse: 61.00µs
-        runner::execute: 414.00µs
-        runner::farewell: 326.00µs
-          from_success_result: 306.00µs
-            populate_outcome_from_contexts: 255.00µs
-        signing_step::sign_produced_cids: 102.00µs
-        verification_step::verify: 882.00µs
-          verify: 176.00µs
-    multiple-peers8 (9.40ms; 53.375 MiB, 53.375 MiB): verifying many CIDs for many peers
-      air::runner::execute_air: 9.40ms
+        preparation_step::preparation::parse_data: 425.00µs
+          from_slice: 371.00µs
+        preparation_step::preparation::prepare: 206.00µs
+          air::preparation_step::preparation::make_exec_ctx: 30.00µs
+          air_parser::parser::air_parser::parse: 60.00µs
+        runner::execute: 418.00µs
+        runner::farewell: 320.00µs
+          from_success_result: 299.00µs
+            populate_outcome_from_contexts: 249.00µs
+        signing_step::sign_produced_cids: 99.00µs
+        verification_step::verify: 890.00µs
+          verify: 180.00µs
+    multiple-peers8 (9.43ms; 53.375 MiB, 53.375 MiB): verifying many CIDs for many peers
+      air::runner::execute_air: 9.43ms
         preparation_step::preparation::parse_data: 1.38ms
-          from_slice: 1.32ms
-        preparation_step::preparation::prepare: 265.00µs
-          air::preparation_step::preparation::make_exec_ctx: 79.00µs
-          air_parser::parser::air_parser::parse: 67.00µs
-        runner::execute: 2.65ms
-        runner::farewell: 914.00µs
-          from_success_result: 894.00µs
-            populate_outcome_from_contexts: 791.00µs
-        signing_step::sign_produced_cids: 101.00µs
-        verification_step::verify: 3.92ms
-          verify: 734.00µs
-    multiple-sigs30 (17.54ms; 56.188 MiB, 56.188 MiB): signing multiple CIDs
-      air::runner::execute_air: 17.54ms
+          from_slice: 1.33ms
+        preparation_step::preparation::prepare: 258.00µs
+          air::preparation_step::preparation::make_exec_ctx: 78.00µs
+          air_parser::parser::air_parser::parse: 64.00µs
+        runner::execute: 2.68ms
+        runner::farewell: 896.00µs
+          from_success_result: 875.00µs
+            populate_outcome_from_contexts: 774.00µs
+        signing_step::sign_produced_cids: 99.00µs
+        verification_step::verify: 3.93ms
+          verify: 733.00µs
+    multiple-sigs30 (17.47ms; 56.188 MiB, 56.188 MiB): signing multiple CIDs
+      air::runner::execute_air: 17.47ms
         preparation_step::preparation::parse_data: 3.96ms
           from_slice: 3.90ms
-        preparation_step::preparation::prepare: 344.00µs
-          air::preparation_step::preparation::make_exec_ctx: 156.00µs
-          air_parser::parser::air_parser::parse: 67.00µs
-        runner::execute: 7.06ms
-        runner::farewell: 2.57ms
-          from_success_result: 2.55ms
-            populate_outcome_from_contexts: 2.37ms
-        signing_step::sign_produced_cids: 445.00µs
-        verification_step::verify: 2.98ms
-          verify: 1.27ms
+        preparation_step::preparation::prepare: 330.00µs
+          air::preparation_step::preparation::make_exec_ctx: 151.00µs
+          air_parser::parser::air_parser::parse: 63.00µs
+        runner::execute: 7.04ms
+        runner::farewell: 2.55ms
+          from_success_result: 2.53ms
+            populate_outcome_from_contexts: 2.35ms
+        signing_step::sign_produced_cids: 443.00µs
+        verification_step::verify: 2.96ms
+          verify: 1.26ms
     network-explore (3.07ms; 52.375 MiB, 52.375 MiB): 5 peers of network are discovered
       air::runner::execute_air: 3.07ms
-        preparation_step::preparation::parse_data: 494.00µs
-          from_slice: 439.00µs
-        preparation_step::preparation::prepare: 228.00µs
-          air::preparation_step::preparation::make_exec_ctx: 26.00µs
-          air_parser::parser::air_parser::parse: 81.00µs
-        runner::execute: 145.00µs
-        runner::farewell: 257.00µs
-          from_success_result: 238.00µs
-            populate_outcome_from_contexts: 199.00µs
-        signing_step::sign_produced_cids: 103.00µs
-        verification_step::verify: 1.68ms
-          verify: 60.00µs
-    null (741.00µs; 52.375 MiB, 52.375 MiB): Empty data and null script
-      air::runner::execute_air: 741.00µs
-        preparation_step::preparation::parse_data: 30.00µs
-        preparation_step::preparation::prepare: 198.00µs
-          air::preparation_step::preparation::make_exec_ctx: 27.00µs
-          air_parser::parser::air_parser::parse: 37.00µs
+        preparation_step::preparation::parse_data: 490.00µs
+          from_slice: 434.00µs
+        preparation_step::preparation::prepare: 219.00µs
+          air::preparation_step::preparation::make_exec_ctx: 25.00µs
+          air_parser::parser::air_parser::parse: 78.00µs
+        runner::execute: 144.00µs
+        runner::farewell: 251.00µs
+          from_success_result: 231.00µs
+            populate_outcome_from_contexts: 193.00µs
+        signing_step::sign_produced_cids: 100.00µs
+        verification_step::verify: 1.69ms
+          verify: 65.00µs
+    null (737.00µs; 52.375 MiB, 52.375 MiB): Empty data and null script
+      air::runner::execute_air: 737.00µs
+        preparation_step::preparation::parse_data: 23.00µs
+        preparation_step::preparation::prepare: 190.00µs
+          air::preparation_step::preparation::make_exec_ctx: 23.00µs
+          air_parser::parser::air_parser::parse: 34.00µs
         runner::execute: 8.00µs
-        runner::farewell: 183.00µs
-          from_success_result: 164.00µs
-            populate_outcome_from_contexts: 128.00µs
-        signing_step::sign_produced_cids: 104.00µs
-        verification_step::verify: 38.00µs
-          verify: 10.00µs
-    parser-10000-100 (23.04ms; 54.938 MiB, 54.938 MiB): long air script with lot of variable assignments
-      air::runner::execute_air: 23.04ms
-        preparation_step::preparation::parse_data: 29.00µs
-        preparation_step::preparation::prepare: 21.53ms
-          air::preparation_step::preparation::make_exec_ctx: 31.00µs
-          air_parser::parser::air_parser::parse: 21.35ms
-        runner::execute: 46.00µs
-        runner::farewell: 188.00µs
-          from_success_result: 168.00µs
-            populate_outcome_from_contexts: 132.00µs
-        signing_step::sign_produced_cids: 105.00µs
-        verification_step::verify: 40.00µs
-          verify: 9.00µs
-    parser-calls-10000-100 (22.76ms; 54.500 MiB, 54.500 MiB): multiple calls parser benchmark
-      air::runner::execute_air: 22.76ms
-        preparation_step::preparation::parse_data: 28.00µs
-        preparation_step::preparation::prepare: 21.04ms
-          air::preparation_step::preparation::make_exec_ctx: 28.00µs
-          air_parser::parser::air_parser::parse: 20.87ms
-        runner::execute: 47.00µs
-        runner::farewell: 188.00µs
-          from_success_result: 167.00µs
-            populate_outcome_from_contexts: 131.00µs
+        runner::farewell: 184.00µs
+          from_success_result: 165.00µs
+            populate_outcome_from_contexts: 125.00µs
         signing_step::sign_produced_cids: 106.00µs
-        verification_step::verify: 39.00µs
-          verify: 9.00µs
-    populate-map-multiple-keys (3.44ms; 53.000 MiB, 53.000 MiB): benchmarking a map insert operation
-      air::runner::execute_air: 3.44ms
-        preparation_step::preparation::parse_data: 168.00µs
-          from_slice: 122.00µs
-        preparation_step::preparation::prepare: 209.00µs
+        verification_step::verify: 44.00µs
+          verify: 10.00µs
+    parser-10000-100 (22.89ms; 54.625 MiB, 54.625 MiB): long air script with lot of variable assignments
+      air::runner::execute_air: 22.89ms
+        preparation_step::preparation::parse_data: 25.00µs
+        preparation_step::preparation::prepare: 21.40ms
           air::preparation_step::preparation::make_exec_ctx: 23.00µs
-          air_parser::parser::air_parser::parse: 66.00µs
-        runner::execute: 2.11ms
-        runner::farewell: 295.00µs
-          from_success_result: 275.00µs
-            populate_outcome_from_contexts: 236.00µs
+          air_parser::parser::air_parser::parse: 21.25ms
+        runner::execute: 39.00µs
+        runner::farewell: 187.00µs
+          from_success_result: 168.00µs
+            populate_outcome_from_contexts: 131.00µs
+        signing_step::sign_produced_cids: 107.00µs
+        verification_step::verify: 45.00µs
+          verify: 11.00µs
+    parser-calls-10000-100 (22.65ms; 54.375 MiB, 54.375 MiB): multiple calls parser benchmark
+      air::runner::execute_air: 22.65ms
+        preparation_step::preparation::parse_data: 25.00µs
+        preparation_step::preparation::prepare: 21.00ms
+          air::preparation_step::preparation::make_exec_ctx: 25.00µs
+          air_parser::parser::air_parser::parse: 20.84ms
+        runner::execute: 39.00µs
+        runner::farewell: 187.00µs
+          from_success_result: 168.00µs
+            populate_outcome_from_contexts: 130.00µs
+        signing_step::sign_produced_cids: 107.00µs
+        verification_step::verify: 42.00µs
+          verify: 10.00µs
+    populate-map-multiple-keys (3.45ms; 53.000 MiB, 53.000 MiB): benchmarking a map insert operation
+      air::runner::execute_air: 3.45ms
+        preparation_step::preparation::parse_data: 162.00µs
+          from_slice: 113.00µs
+        preparation_step::preparation::prepare: 196.00µs
+          air::preparation_step::preparation::make_exec_ctx: 19.00µs
+          air_parser::parser::air_parser::parse: 60.00µs
+        runner::execute: 2.14ms
+        runner::farewell: 285.00µs
+          from_success_result: 266.00µs
+            populate_outcome_from_contexts: 231.00µs
         signing_step::sign_produced_cids: 100.00µs
-        verification_step::verify: 386.00µs
-          verify: 36.00µs
-    populate-map-single-key (2.74ms; 52.938 MiB, 52.938 MiB): benchmarking a map insert operation
-      air::runner::execute_air: 2.74ms
-        preparation_step::preparation::parse_data: 223.00µs
-          from_slice: 176.00µs
-        preparation_step::preparation::prepare: 207.00µs
-          air::preparation_step::preparation::make_exec_ctx: 23.00µs
-          air_parser::parser::air_parser::parse: 65.00µs
+        verification_step::verify: 392.00µs
+          verify: 39.00µs
+    populate-map-single-key (2.73ms; 52.938 MiB, 52.938 MiB): benchmarking a map insert operation
+      air::runner::execute_air: 2.73ms
+        preparation_step::preparation::parse_data: 215.00µs
+          from_slice: 168.00µs
+        preparation_step::preparation::prepare: 195.00µs
+          air::preparation_step::preparation::make_exec_ctx: 20.00µs
+          air_parser::parser::air_parser::parse: 60.00µs
         runner::execute: 1.30ms
-        runner::farewell: 317.00µs
-          from_success_result: 297.00µs
-            populate_outcome_from_contexts: 240.00µs
-        signing_step::sign_produced_cids: 100.00µs
-        verification_step::verify: 419.00µs
-          verify: 69.00µs
+        runner::farewell: 308.00µs
+          from_success_result: 289.00µs
+            populate_outcome_from_contexts: 235.00µs
+        signing_step::sign_produced_cids: 99.00µs
+        verification_step::verify: 425.00µs
+          verify: 74.00µs
 Machine e536f8eaae8c978493a773ba566ae3393e2e6240d6ea8e05b5ca1b8f77e9c441:
   Platform: Linux-5.15.0-76-generic-x86_64-with-glibc2.29
   Timestamp: 2023-12-08 16:06:36.836015+00:00

--- a/benches/PERFORMANCE.txt
+++ b/benches/PERFORMANCE.txt
@@ -642,278 +642,278 @@ Machine c1f3ea5950db0a10b44da931c25774d64ab25084f47d504f72f311e694550ff1:
             execute: 29.00µs
             new: 38.00µs
 Machine d77ebe8481884bc3b2778c8083f1bf459e548e929edd87041beb14f6b868d35f:
-  Platform: macOS-14.1.1-arm64-arm-64bit
-  Timestamp: 2023-11-30 15:45:29.190158+00:00
+  Platform: macOS-14.1.2-arm64-arm-64bit
+  Timestamp: 2023-12-08 15:19:32.841413+00:00
   AquaVM version: 0.54.0
   Benches:
   Features: check_signatures,gen_signatures
     big-values-data (13.01ms; 59.000 MiB, 59.000 MiB): Loading a trace with huge values
       air::runner::execute_air: 13.01ms
-        preparation_step::preparation::parse_data: 5.24ms
-          from_slice: 5.18ms
-        preparation_step::preparation::prepare: 173.00µs
-          air::preparation_step::preparation::make_exec_ctx: 22.00µs
-          air_parser::parser::air_parser::parse: 30.00µs
-        runner::execute: 13.00µs
-        runner::farewell: 3.27ms
-          from_success_result: 3.25ms
-            populate_outcome_from_contexts: 3.22ms
-        signing_step::sign_produced_cids: 99.00µs
-        verification_step::verify: 4.03ms
-          verify: 3.67ms
-    call-requests500 (25.80ms; 58.562 MiB, 58.562 MiB): multiple call requests
-      air::runner::execute_air: 25.80ms
-        preparation_step::preparation::parse_data: 146.00µs
-          from_slice: 106.00µs
-        preparation_step::preparation::prepare: 253.00µs
-          air::preparation_step::preparation::make_exec_ctx: 47.00µs
-          air_parser::parser::air_parser::parse: 78.00µs
-        runner::execute: 19.89ms
+        preparation_step::preparation::parse_data: 5.31ms
+          from_slice: 5.26ms
+        preparation_step::preparation::prepare: 182.00µs
+          air::preparation_step::preparation::make_exec_ctx: 28.00µs
+          air_parser::parser::air_parser::parse: 33.00µs
+        runner::execute: 9.00µs
+        runner::farewell: 3.29ms
+          from_success_result: 3.27ms
+            populate_outcome_from_contexts: 3.23ms
+        signing_step::sign_produced_cids: 102.00µs
+        verification_step::verify: 3.98ms
+          verify: 3.62ms
+    call-requests500 (25.90ms; 58.562 MiB, 58.562 MiB): multiple call requests
+      air::runner::execute_air: 25.90ms
+        preparation_step::preparation::parse_data: 147.00µs
+          from_slice: 101.00µs
+        preparation_step::preparation::prepare: 254.00µs
+          air::preparation_step::preparation::make_exec_ctx: 52.00µs
+          air_parser::parser::air_parser::parse: 76.00µs
+        runner::execute: 20.00ms
         runner::farewell: 5.15ms
           from_success_result: 5.13ms
             populate_outcome_from_contexts: 5.02ms
-        signing_step::sign_produced_cids: 105.00µs
-        verification_step::verify: 80.00µs
-          verify: 12.00µs
-    call-results500 (15.60ms; 54.438 MiB, 54.438 MiB): multiple call results
-      air::runner::execute_air: 15.60ms
+        signing_step::sign_produced_cids: 106.00µs
+        verification_step::verify: 76.00µs
+          verify: 9.00µs
+    call-results500 (15.70ms; 54.438 MiB, 54.438 MiB): multiple call results
+      air::runner::execute_air: 15.70ms
         preparation_step::preparation::parse_data: 621.00µs
-          from_slice: 579.00µs
-        preparation_step::preparation::prepare: 1.00ms
-          air::preparation_step::preparation::make_exec_ctx: 803.00µs
-          air_parser::parser::air_parser::parse: 73.00µs
-        runner::execute: 11.60ms
-        runner::farewell: 1.80ms
+          from_slice: 577.00µs
+        preparation_step::preparation::prepare: 1.01ms
+          air::preparation_step::preparation::make_exec_ctx: 812.00µs
+          air_parser::parser::air_parser::parse: 72.00µs
+        runner::execute: 11.70ms
+        runner::farewell: 1.81ms
           from_success_result: 1.78ms
             populate_outcome_from_contexts: 1.33ms
-        signing_step::sign_produced_cids: 290.00µs
-        verification_step::verify: 95.00µs
-          verify: 12.00µs
-    canon-map-key-by-lens (10.82ms; 56.625 MiB, 56.625 MiB): benchmarking a map insert operation
-      air::runner::execute_air: 10.82ms
-        preparation_step::preparation::parse_data: 3.15ms
-          from_slice: 3.10ms
-        preparation_step::preparation::prepare: 385.00µs
-          air::preparation_step::preparation::make_exec_ctx: 187.00µs
-          air_parser::parser::air_parser::parse: 77.00µs
-        runner::execute: 1.96ms
-        runner::farewell: 1.87ms
-          from_success_result: 1.84ms
+        signing_step::sign_produced_cids: 289.00µs
+        verification_step::verify: 90.00µs
+          verify: 9.00µs
+    canon-map-key-by-lens (10.84ms; 56.625 MiB, 56.625 MiB): benchmarking a map insert operation
+      air::runner::execute_air: 10.84ms
+        preparation_step::preparation::parse_data: 3.17ms
+          from_slice: 3.13ms
+        preparation_step::preparation::prepare: 396.00µs
+          air::preparation_step::preparation::make_exec_ctx: 192.00µs
+          air_parser::parser::air_parser::parse: 79.00µs
+        runner::execute: 1.95ms
+        runner::farewell: 1.88ms
+          from_success_result: 1.86ms
             populate_outcome_from_contexts: 1.49ms
-        signing_step::sign_produced_cids: 100.00µs
-        verification_step::verify: 3.18ms
-          verify: 2.82ms
-    canon-map-key-element-by-lens (10.75ms; 56.625 MiB, 56.625 MiB): benchmarking a map insert operation
-      air::runner::execute_air: 10.75ms
-        preparation_step::preparation::parse_data: 3.13ms
-          from_slice: 3.08ms
-        preparation_step::preparation::prepare: 382.00µs
-          air::preparation_step::preparation::make_exec_ctx: 187.00µs
-          air_parser::parser::air_parser::parse: 77.00µs
-        runner::execute: 1.92ms
-        runner::farewell: 1.85ms
-          from_success_result: 1.83ms
-            populate_outcome_from_contexts: 1.49ms
-        signing_step::sign_produced_cids: 100.00µs
+        signing_step::sign_produced_cids: 102.00µs
         verification_step::verify: 3.17ms
-          verify: 2.81ms
-    canon-map-multiple-keys (8.96ms; 54.500 MiB, 54.500 MiB): benchmarking a map insert operation
-      air::runner::execute_air: 8.96ms
-        preparation_step::preparation::parse_data: 417.00µs
-          from_slice: 370.00µs
-        preparation_step::preparation::prepare: 201.00µs
-          air::preparation_step::preparation::make_exec_ctx: 18.00µs
+          verify: 2.80ms
+    canon-map-key-element-by-lens (10.80ms; 56.625 MiB, 56.625 MiB): benchmarking a map insert operation
+      air::runner::execute_air: 10.80ms
+        preparation_step::preparation::parse_data: 3.16ms
+          from_slice: 3.12ms
+        preparation_step::preparation::prepare: 395.00µs
+          air::preparation_step::preparation::make_exec_ctx: 192.00µs
+          air_parser::parser::air_parser::parse: 82.00µs
+        runner::execute: 1.93ms
+        runner::farewell: 1.87ms
+          from_success_result: 1.85ms
+            populate_outcome_from_contexts: 1.51ms
+        signing_step::sign_produced_cids: 101.00µs
+        verification_step::verify: 3.16ms
+          verify: 2.80ms
+    canon-map-multiple-keys (8.97ms; 54.500 MiB, 54.500 MiB): benchmarking a map insert operation
+      air::runner::execute_air: 8.97ms
+        preparation_step::preparation::parse_data: 423.00µs
+          from_slice: 377.00µs
+        preparation_step::preparation::prepare: 209.00µs
+          air::preparation_step::preparation::make_exec_ctx: 23.00µs
           air_parser::parser::air_parser::parse: 66.00µs
-        runner::execute: 6.02ms
+        runner::execute: 6.04ms
         runner::farewell: 1.63ms
           from_success_result: 1.61ms
             populate_outcome_from_contexts: 1.32ms
         signing_step::sign_produced_cids: 100.00µs
-        verification_step::verify: 403.00µs
-          verify: 40.00µs
-    canon-map-scalar-multiple-keys (4.08ms; 53.125 MiB, 53.125 MiB): benchmarking a map insert operation
-      air::runner::execute_air: 4.08ms
-        preparation_step::preparation::parse_data: 418.00µs
-          from_slice: 370.00µs
-        preparation_step::preparation::prepare: 197.00µs
-          air::preparation_step::preparation::make_exec_ctx: 18.00µs
-          air_parser::parser::air_parser::parse: 62.00µs
-        runner::execute: 2.43ms
-        runner::farewell: 345.00µs
-          from_success_result: 325.00µs
-            populate_outcome_from_contexts: 289.00µs
-        signing_step::sign_produced_cids: 98.00µs
-        verification_step::verify: 405.00µs
-          verify: 40.00µs
-    canon-map-scalar-single-key (3.29ms; 53.000 MiB, 53.000 MiB): benchmarking a map insert operation
-      air::runner::execute_air: 3.29ms
+        verification_step::verify: 401.00µs
+          verify: 35.00µs
+    canon-map-scalar-multiple-keys (4.11ms; 53.125 MiB, 53.125 MiB): benchmarking a map insert operation
+      air::runner::execute_air: 4.11ms
+        preparation_step::preparation::parse_data: 430.00µs
+          from_slice: 385.00µs
+        preparation_step::preparation::prepare: 213.00µs
+          air::preparation_step::preparation::make_exec_ctx: 24.00µs
+          air_parser::parser::air_parser::parse: 69.00µs
+        runner::execute: 2.44ms
+        runner::farewell: 352.00µs
+          from_success_result: 332.00µs
+            populate_outcome_from_contexts: 294.00µs
+        signing_step::sign_produced_cids: 101.00µs
+        verification_step::verify: 404.00µs
+          verify: 34.00µs
+    canon-map-scalar-single-key (3.28ms; 53.000 MiB, 53.000 MiB): benchmarking a map insert operation
+      air::runner::execute_air: 3.28ms
         preparation_step::preparation::parse_data: 427.00µs
-          from_slice: 380.00µs
-        preparation_step::preparation::prepare: 200.00µs
-          air::preparation_step::preparation::make_exec_ctx: 18.00µs
+          from_slice: 379.00µs
+        preparation_step::preparation::prepare: 205.00µs
+          air::preparation_step::preparation::make_exec_ctx: 23.00µs
           air_parser::parser::air_parser::parse: 62.00µs
         runner::execute: 1.58ms
-        runner::farewell: 354.00µs
-          from_success_result: 334.00µs
-            populate_outcome_from_contexts: 282.00µs
+        runner::farewell: 362.00µs
+          from_success_result: 343.00µs
+            populate_outcome_from_contexts: 287.00µs
         signing_step::sign_produced_cids: 101.00µs
-        verification_step::verify: 437.00µs
-          verify: 75.00µs
+        verification_step::verify: 432.00µs
+          verify: 70.00µs
     canon-map-single-key (7.51ms; 55.312 MiB, 55.312 MiB): benchmarking a map insert operation
       air::runner::execute_air: 7.51ms
-        preparation_step::preparation::parse_data: 426.00µs
-          from_slice: 378.00µs
-        preparation_step::preparation::prepare: 196.00µs
-          air::preparation_step::preparation::make_exec_ctx: 18.00µs
-          air_parser::parser::air_parser::parse: 60.00µs
+        preparation_step::preparation::parse_data: 429.00µs
+          from_slice: 383.00µs
+        preparation_step::preparation::prepare: 204.00µs
+          air::preparation_step::preparation::make_exec_ctx: 23.00µs
+          air_parser::parser::air_parser::parse: 62.00µs
         runner::execute: 4.45ms
         runner::farewell: 1.73ms
           from_success_result: 1.71ms
             populate_outcome_from_contexts: 1.46ms
-        signing_step::sign_produced_cids: 99.00µs
-        verification_step::verify: 434.00µs
-          verify: 74.00µs
-    dashboard (5.70ms; 52.625 MiB, 52.625 MiB): big dashboard test
-      air::runner::execute_air: 5.70ms
-        preparation_step::preparation::parse_data: 1.02ms
-          from_slice: 960.00µs
-        preparation_step::preparation::prepare: 320.00µs
-          air::preparation_step::preparation::make_exec_ctx: 34.00µs
-          air_parser::parser::air_parser::parse: 167.00µs
-        runner::execute: 750.00µs
-        runner::farewell: 463.00µs
-          from_success_result: 443.00µs
+        signing_step::sign_produced_cids: 101.00µs
+        verification_step::verify: 430.00µs
+          verify: 69.00µs
+    dashboard (5.73ms; 52.625 MiB, 52.625 MiB): big dashboard test
+      air::runner::execute_air: 5.73ms
+        preparation_step::preparation::parse_data: 1.01ms
+          from_slice: 954.00µs
+        preparation_step::preparation::prepare: 326.00µs
+          air::preparation_step::preparation::make_exec_ctx: 38.00µs
+          air_parser::parser::air_parser::parse: 168.00µs
+        runner::execute: 766.00µs
+        runner::farewell: 468.00µs
+          from_success_result: 446.00µs
             populate_outcome_from_contexts: 402.00µs
-        signing_step::sign_produced_cids: 102.00µs
-        verification_step::verify: 2.87ms
-          verify: 158.00µs
-    long-data (4.96ms; 53.812 MiB, 53.812 MiB): Long data trace
-      air::runner::execute_air: 4.96ms
-        preparation_step::preparation::parse_data: 1.89ms
-          from_slice: 1.84ms
-        preparation_step::preparation::prepare: 183.00µs
-          air::preparation_step::preparation::make_exec_ctx: 35.00µs
-          air_parser::parser::air_parser::parse: 28.00µs
-        runner::execute: 12.00µs
-        runner::farewell: 888.00µs
-          from_success_result: 868.00µs
-            populate_outcome_from_contexts: 836.00µs
-        signing_step::sign_produced_cids: 99.00µs
+        signing_step::sign_produced_cids: 103.00µs
+        verification_step::verify: 2.89ms
+          verify: 151.00µs
+    long-data (4.98ms; 53.812 MiB, 53.812 MiB): Long data trace
+      air::runner::execute_air: 4.98ms
+        preparation_step::preparation::parse_data: 1.91ms
+          from_slice: 1.86ms
+        preparation_step::preparation::prepare: 191.00µs
+          air::preparation_step::preparation::make_exec_ctx: 40.00µs
+          air_parser::parser::air_parser::parse: 31.00µs
+        runner::execute: 8.00µs
+        runner::farewell: 907.00µs
+          from_success_result: 887.00µs
+            populate_outcome_from_contexts: 849.00µs
+        signing_step::sign_produced_cids: 101.00µs
         verification_step::verify: 1.71ms
-          verify: 664.00µs
-    multiple-cids10 (2.54ms; 52.438 MiB, 52.438 MiB): verifying multiple CIDs for single peer
-      air::runner::execute_air: 2.54ms
-        preparation_step::preparation::parse_data: 434.00µs
+          verify: 659.00µs
+    multiple-cids10 (2.53ms; 52.438 MiB, 52.438 MiB): verifying multiple CIDs for single peer
+      air::runner::execute_air: 2.53ms
+        preparation_step::preparation::parse_data: 435.00µs
           from_slice: 381.00µs
-        preparation_step::preparation::prepare: 206.00µs
-          air::preparation_step::preparation::make_exec_ctx: 27.00µs
+        preparation_step::preparation::prepare: 210.00µs
+          air::preparation_step::preparation::make_exec_ctx: 31.00µs
           air_parser::parser::air_parser::parse: 61.00µs
-        runner::execute: 408.00µs
-        runner::farewell: 318.00µs
-          from_success_result: 298.00µs
-            populate_outcome_from_contexts: 251.00µs
-        signing_step::sign_produced_cids: 100.00µs
-        verification_step::verify: 896.00µs
-          verify: 182.00µs
-    multiple-peers8 (9.38ms; 53.375 MiB, 53.375 MiB): verifying many CIDs for many peers
-      air::runner::execute_air: 9.38ms
-        preparation_step::preparation::parse_data: 1.37ms
-          from_slice: 1.31ms
-        preparation_step::preparation::prepare: 257.00µs
-          air::preparation_step::preparation::make_exec_ctx: 72.00µs
-          air_parser::parser::air_parser::parse: 68.00µs
-        runner::execute: 2.64ms
-        runner::farewell: 900.00µs
-          from_success_result: 880.00µs
-            populate_outcome_from_contexts: 783.00µs
-        signing_step::sign_produced_cids: 100.00µs
-        verification_step::verify: 3.94ms
-          verify: 743.00µs
-    multiple-sigs30 (17.44ms; 56.188 MiB, 56.188 MiB): signing multiple CIDs
-      air::runner::execute_air: 17.44ms
-        preparation_step::preparation::parse_data: 3.91ms
-          from_slice: 3.85ms
-        preparation_step::preparation::prepare: 334.00µs
-          air::preparation_step::preparation::make_exec_ctx: 150.00µs
-          air_parser::parser::air_parser::parse: 66.00µs
-        runner::execute: 7.01ms
-        runner::farewell: 2.56ms
-          from_success_result: 2.54ms
+        runner::execute: 414.00µs
+        runner::farewell: 326.00µs
+          from_success_result: 306.00µs
+            populate_outcome_from_contexts: 255.00µs
+        signing_step::sign_produced_cids: 102.00µs
+        verification_step::verify: 882.00µs
+          verify: 176.00µs
+    multiple-peers8 (9.40ms; 53.375 MiB, 53.375 MiB): verifying many CIDs for many peers
+      air::runner::execute_air: 9.40ms
+        preparation_step::preparation::parse_data: 1.38ms
+          from_slice: 1.32ms
+        preparation_step::preparation::prepare: 265.00µs
+          air::preparation_step::preparation::make_exec_ctx: 79.00µs
+          air_parser::parser::air_parser::parse: 67.00µs
+        runner::execute: 2.65ms
+        runner::farewell: 914.00µs
+          from_success_result: 894.00µs
+            populate_outcome_from_contexts: 791.00µs
+        signing_step::sign_produced_cids: 101.00µs
+        verification_step::verify: 3.92ms
+          verify: 734.00µs
+    multiple-sigs30 (17.54ms; 56.188 MiB, 56.188 MiB): signing multiple CIDs
+      air::runner::execute_air: 17.54ms
+        preparation_step::preparation::parse_data: 3.96ms
+          from_slice: 3.90ms
+        preparation_step::preparation::prepare: 344.00µs
+          air::preparation_step::preparation::make_exec_ctx: 156.00µs
+          air_parser::parser::air_parser::parse: 67.00µs
+        runner::execute: 7.06ms
+        runner::farewell: 2.57ms
+          from_success_result: 2.55ms
             populate_outcome_from_contexts: 2.37ms
-        signing_step::sign_produced_cids: 447.00µs
+        signing_step::sign_produced_cids: 445.00µs
         verification_step::verify: 2.98ms
           verify: 1.27ms
-    network-explore (3.08ms; 52.375 MiB, 52.375 MiB): 5 peers of network are discovered
-      air::runner::execute_air: 3.08ms
-        preparation_step::preparation::parse_data: 498.00µs
-          from_slice: 442.00µs
-        preparation_step::preparation::prepare: 220.00µs
-          air::preparation_step::preparation::make_exec_ctx: 21.00µs
+    network-explore (3.07ms; 52.375 MiB, 52.375 MiB): 5 peers of network are discovered
+      air::runner::execute_air: 3.07ms
+        preparation_step::preparation::parse_data: 494.00µs
+          from_slice: 439.00µs
+        preparation_step::preparation::prepare: 228.00µs
+          air::preparation_step::preparation::make_exec_ctx: 26.00µs
           air_parser::parser::air_parser::parse: 81.00µs
-        runner::execute: 139.00µs
-        runner::farewell: 253.00µs
-          from_success_result: 233.00µs
-            populate_outcome_from_contexts: 197.00µs
-        signing_step::sign_produced_cids: 104.00µs
-        verification_step::verify: 1.69ms
-          verify: 64.00µs
-    null (757.00µs; 52.375 MiB, 52.375 MiB): Empty data and null script
-      air::runner::execute_air: 757.00µs
-        preparation_step::preparation::parse_data: 31.00µs
-        preparation_step::preparation::prepare: 193.00µs
-          air::preparation_step::preparation::make_exec_ctx: 21.00µs
-          air_parser::parser::air_parser::parse: 34.00µs
-        runner::execute: 11.00µs
-        runner::farewell: 181.00µs
-          from_success_result: 161.00µs
-            populate_outcome_from_contexts: 125.00µs
-        signing_step::sign_produced_cids: 108.00µs
-        verification_step::verify: 44.00µs
-          verify: 12.00µs
-    parser-10000-100 (23.45ms; 57.688 MiB, 57.688 MiB): long air script with lot of variable assignments
-      air::runner::execute_air: 23.45ms
+        runner::execute: 145.00µs
+        runner::farewell: 257.00µs
+          from_success_result: 238.00µs
+            populate_outcome_from_contexts: 199.00µs
+        signing_step::sign_produced_cids: 103.00µs
+        verification_step::verify: 1.68ms
+          verify: 60.00µs
+    null (741.00µs; 52.375 MiB, 52.375 MiB): Empty data and null script
+      air::runner::execute_air: 741.00µs
         preparation_step::preparation::parse_data: 30.00µs
-        preparation_step::preparation::prepare: 21.84ms
-          air::preparation_step::preparation::make_exec_ctx: 20.00µs
-          air_parser::parser::air_parser::parse: 21.66ms
-        runner::execute: 45.00µs
+        preparation_step::preparation::prepare: 198.00µs
+          air::preparation_step::preparation::make_exec_ctx: 27.00µs
+          air_parser::parser::air_parser::parse: 37.00µs
+        runner::execute: 8.00µs
+        runner::farewell: 183.00µs
+          from_success_result: 164.00µs
+            populate_outcome_from_contexts: 128.00µs
+        signing_step::sign_produced_cids: 104.00µs
+        verification_step::verify: 38.00µs
+          verify: 10.00µs
+    parser-10000-100 (23.04ms; 54.938 MiB, 54.938 MiB): long air script with lot of variable assignments
+      air::runner::execute_air: 23.04ms
+        preparation_step::preparation::parse_data: 29.00µs
+        preparation_step::preparation::prepare: 21.53ms
+          air::preparation_step::preparation::make_exec_ctx: 31.00µs
+          air_parser::parser::air_parser::parse: 21.35ms
+        runner::execute: 46.00µs
         runner::farewell: 188.00µs
           from_success_result: 168.00µs
-            populate_outcome_from_contexts: 128.00µs
-        signing_step::sign_produced_cids: 110.00µs
-        verification_step::verify: 43.00µs
-          verify: 12.00µs
+            populate_outcome_from_contexts: 132.00µs
+        signing_step::sign_produced_cids: 105.00µs
+        verification_step::verify: 40.00µs
+          verify: 9.00µs
     populate-map-multiple-keys (3.44ms; 53.000 MiB, 53.000 MiB): benchmarking a map insert operation
       air::runner::execute_air: 3.44ms
-        preparation_step::preparation::parse_data: 167.00µs
-          from_slice: 120.00µs
-        preparation_step::preparation::prepare: 201.00µs
-          air::preparation_step::preparation::make_exec_ctx: 18.00µs
-          air_parser::parser::air_parser::parse: 65.00µs
-        runner::execute: 2.10ms
-        runner::farewell: 291.00µs
-          from_success_result: 271.00µs
-            populate_outcome_from_contexts: 235.00µs
-        signing_step::sign_produced_cids: 98.00µs
-        verification_step::verify: 394.00µs
-          verify: 41.00µs
+        preparation_step::preparation::parse_data: 168.00µs
+          from_slice: 122.00µs
+        preparation_step::preparation::prepare: 209.00µs
+          air::preparation_step::preparation::make_exec_ctx: 23.00µs
+          air_parser::parser::air_parser::parse: 66.00µs
+        runner::execute: 2.11ms
+        runner::farewell: 295.00µs
+          from_success_result: 275.00µs
+            populate_outcome_from_contexts: 236.00µs
+        signing_step::sign_produced_cids: 100.00µs
+        verification_step::verify: 386.00µs
+          verify: 36.00µs
     populate-map-single-key (2.74ms; 52.938 MiB, 52.938 MiB): benchmarking a map insert operation
       air::runner::execute_air: 2.74ms
         preparation_step::preparation::parse_data: 223.00µs
           from_slice: 176.00µs
-        preparation_step::preparation::prepare: 198.00µs
-          air::preparation_step::preparation::make_exec_ctx: 18.00µs
-          air_parser::parser::air_parser::parse: 63.00µs
+        preparation_step::preparation::prepare: 207.00µs
+          air::preparation_step::preparation::make_exec_ctx: 23.00µs
+          air_parser::parser::air_parser::parse: 65.00µs
         runner::execute: 1.30ms
-        runner::farewell: 311.00µs
-          from_success_result: 290.00µs
-            populate_outcome_from_contexts: 235.00µs
-        signing_step::sign_produced_cids: 99.00µs
-        verification_step::verify: 426.00µs
-          verify: 75.00µs
+        runner::farewell: 317.00µs
+          from_success_result: 297.00µs
+            populate_outcome_from_contexts: 240.00µs
+        signing_step::sign_produced_cids: 100.00µs
+        verification_step::verify: 419.00µs
+          verify: 69.00µs
 Machine e536f8eaae8c978493a773ba566ae3393e2e6240d6ea8e05b5ca1b8f77e9c441:
   Platform: Linux-5.15.0-76-generic-x86_64-with-glibc2.29
-  Timestamp: 2023-11-29 16:59:25.046502+00:00
+  Timestamp: 2023-11-30 15:54:57.248575+00:00
   AquaVM version: 0.54.0
   Benches:
   Features: check_signatures,gen_signatures
@@ -1085,69 +1085,6 @@ Machine e536f8eaae8c978493a773ba566ae3393e2e6240d6ea8e05b5ca1b8f77e9c441:
         signing_step::sign_produced_cids: 159.00µs
         verification_step::verify: 1.34ms
           verify: 230.00µs
-    multiple-cids50 (323.00ms; 59.375 MiB, 59.375 MiB): verifying multiple CIDs for single peer
-      air::runner::execute_air: 323.00ms
-        preparation_step::preparation::parse_data: 6.79ms
-          from_slice: 6.72ms
-        preparation_step::preparation::prepare: 595.00µs
-          air::preparation_step::preparation::make_exec_ctx: 362.00µs
-          air_parser::parser::air_parser::parse: 49.00µs
-        runner::execute: 299.20ms
-          execute: 232.19ms
-            execute: 53.08ms
-              prepare_request_params: 54.00µs
-                to_string(tetraplets): 16.00µs
-            new: 36.44ms
-        runner::farewell: 6.07ms
-          from_success_result: 6.05ms
-            populate_outcome_from_contexts: 6.01ms
-              to_vec(call_results): 16.00µs
-              to_vec(data): 4.77ms
-        signing_step::sign_produced_cids: 180.00µs
-        verification_step::verify: 10.09ms
-          verify: 6.97ms
-    multiple-peers14 (383.60ms; 59.750 MiB, 59.812 MiB): verifying many CIDs for many peers
-      air::runner::execute_air: 383.60ms
-        preparation_step::preparation::parse_data: 7.75ms
-          from_slice: 7.68ms
-        preparation_step::preparation::prepare: 607.00µs
-          air::preparation_step::preparation::make_exec_ctx: 374.00µs
-          air_parser::parser::air_parser::parse: 52.00µs
-        runner::execute: 351.40ms
-          execute: 274.07ms
-            execute: 65.03ms
-              prepare_request_params: 52.00µs
-                to_string(tetraplets): 15.00µs
-            new: 46.23ms
-        runner::farewell: 6.55ms
-          from_success_result: 6.53ms
-            populate_outcome_from_contexts: 6.49ms
-              to_vec(call_results): 16.00µs
-              to_vec(data): 5.13ms
-        signing_step::sign_produced_cids: 170.00µs
-        verification_step::verify: 17.10ms
-          verify: 7.55ms
-    multiple-peers25 (2.15s; 85.750 MiB, 86.562 MiB): verifying many CIDs for many peers
-      air::runner::execute_air: 2.15s
-        preparation_step::preparation::parse_data: 40.88ms
-          from_slice: 40.76ms
-        preparation_step::preparation::prepare: 3.70ms
-          air::preparation_step::preparation::make_exec_ctx: 3.40ms
-          air_parser::parser::air_parser::parse: 58.00µs
-        runner::execute: 2.00s
-          execute: 1.56s
-            execute: 378.34ms
-              prepare_request_params: 73.00µs
-                to_string(tetraplets): 16.00µs
-            new: 259.16ms
-        runner::farewell: 34.76ms
-          from_success_result: 34.72ms
-            populate_outcome_from_contexts: 34.63ms
-              to_vec(call_results): 18.00µs
-              to_vec(data): 27.11ms
-        signing_step::sign_produced_cids: 190.00µs
-        verification_step::verify: 70.22ms
-          verify: 44.09ms
     multiple-peers8 (13.47ms; 53.375 MiB, 53.375 MiB): verifying many CIDs for many peers
       air::runner::execute_air: 13.47ms
         preparation_step::preparation::parse_data: 1.74ms
@@ -1162,26 +1099,6 @@ Machine e536f8eaae8c978493a773ba566ae3393e2e6240d6ea8e05b5ca1b8f77e9c441:
         signing_step::sign_produced_cids: 159.00µs
         verification_step::verify: 6.18ms
           verify: 1.03ms
-    multiple-sigs200 (6.04s; 214.375 MiB, 214.375 MiB): signing multiple CIDs
-      air::runner::execute_air: 6.04s
-        preparation_step::preparation::parse_data: 219.80ms
-          from_slice: 219.70ms
-        preparation_step::preparation::prepare: 25.42ms
-          air::preparation_step::preparation::make_exec_ctx: 25.09ms
-          air_parser::parser::air_parser::parse: 58.00µs
-        runner::execute: 5.30s
-          call::execute: 3.83s
-            execute: 941.01ms
-            new: 604.96ms
-          canon::execute: 308.30ms
-        runner::farewell: 253.30ms
-          from_success_result: 253.30ms
-            populate_outcome_from_contexts: 233.40ms
-              to_vec(call_results): 16.00µs
-              to_vec(data): 145.70ms
-        signing_step::sign_produced_cids: 30.84ms
-        verification_step::verify: 214.00ms
-          verify: 119.20ms
     multiple-sigs30 (24.67ms; 56.188 MiB, 56.188 MiB): signing multiple CIDs
       air::runner::execute_air: 24.67ms
         preparation_step::preparation::parse_data: 4.93ms
@@ -1196,26 +1113,6 @@ Machine e536f8eaae8c978493a773ba566ae3393e2e6240d6ea8e05b5ca1b8f77e9c441:
         signing_step::sign_produced_cids: 668.00µs
         verification_step::verify: 4.30ms
           verify: 1.81ms
-    multiple-sigs50 (369.10ms; 62.562 MiB, 62.562 MiB): signing multiple CIDs
-      air::runner::execute_air: 369.10ms
-        preparation_step::preparation::parse_data: 13.94ms
-          from_slice: 13.87ms
-        preparation_step::preparation::prepare: 914.00µs
-          air::preparation_step::preparation::make_exec_ctx: 678.00µs
-          air_parser::parser::air_parser::parse: 52.00µs
-        runner::execute: 328.70ms
-          call::execute: 238.69ms
-            execute: 56.21ms
-            new: 38.04ms
-          canon::execute: 18.24ms
-        runner::farewell: 11.01ms
-          from_success_result: 11.01ms
-            populate_outcome_from_contexts: 10.57ms
-              to_vec(call_results): 14.00µs
-              to_vec(data): 7.77ms
-        signing_step::sign_produced_cids: 1.77ms
-        verification_step::verify: 12.49ms
-          verify: 6.96ms
     network-explore (4.35ms; 52.375 MiB, 52.375 MiB): 5 peers of network are discovered
       air::runner::execute_air: 4.35ms
         preparation_step::preparation::parse_data: 582.00µs

--- a/benches/PERFORMANCE.txt
+++ b/benches/PERFORMANCE.txt
@@ -643,7 +643,7 @@ Machine c1f3ea5950db0a10b44da931c25774d64ab25084f47d504f72f311e694550ff1:
             new: 38.00µs
 Machine d77ebe8481884bc3b2778c8083f1bf459e548e929edd87041beb14f6b868d35f:
   Platform: macOS-14.1.2-arm64-arm-64bit
-  Timestamp: 2023-12-08 15:19:32.841413+00:00
+  Timestamp: 2023-12-11 13:56:25.495152+00:00
   AquaVM version: 0.54.0
   Benches:
   Features: check_signatures,gen_signatures
@@ -882,6 +882,19 @@ Machine d77ebe8481884bc3b2778c8083f1bf459e548e929edd87041beb14f6b868d35f:
             populate_outcome_from_contexts: 132.00µs
         signing_step::sign_produced_cids: 105.00µs
         verification_step::verify: 40.00µs
+          verify: 9.00µs
+    parser-calls-10000-100 (22.76ms; 54.500 MiB, 54.500 MiB): multiple calls parser benchmark
+      air::runner::execute_air: 22.76ms
+        preparation_step::preparation::parse_data: 28.00µs
+        preparation_step::preparation::prepare: 21.04ms
+          air::preparation_step::preparation::make_exec_ctx: 28.00µs
+          air_parser::parser::air_parser::parse: 20.87ms
+        runner::execute: 47.00µs
+        runner::farewell: 188.00µs
+          from_success_result: 167.00µs
+            populate_outcome_from_contexts: 131.00µs
+        signing_step::sign_produced_cids: 106.00µs
+        verification_step::verify: 39.00µs
           verify: 9.00µs
     populate-map-multiple-keys (3.44ms; 53.000 MiB, 53.000 MiB): benchmarking a map insert operation
       air::runner::execute_air: 3.44ms

--- a/crates/air-lib/air-parser/benches/parser.rs
+++ b/crates/air-lib/air-parser/benches/parser.rs
@@ -14,11 +14,9 @@
  * limitations under the License.
  */
 
-#[macro_use]
-extern crate fstrings;
-
 use std::rc::Rc;
 
+use air_parser::ast::Instruction;
 use criterion::criterion_group;
 use criterion::criterion_main;
 use criterion::Criterion;

--- a/crates/air-lib/air-parser/src/ast/instructions.rs
+++ b/crates/air-lib/air-parser/src/ast/instructions.rs
@@ -44,7 +44,7 @@ pub enum Instruction<'i> {
     FoldStreamMap(Box<FoldStreamMap<'i>>),
     Never(Never),
     New(Box<New<'i>>),
-    Next(Next<'i>),
+    Next(Box<Next<'i>>),
     Null(Null),
     Error,
 }

--- a/crates/air-lib/air-parser/src/ast/instructions.rs
+++ b/crates/air-lib/air-parser/src/ast/instructions.rs
@@ -27,23 +27,23 @@ use std::rc::Rc;
 #[allow(clippy::large_enum_variant)] // for Null and Error variants
 #[derive(Serialize, Debug, PartialEq)]
 pub enum Instruction<'i> {
-    Call(Call<'i>),
-    Ap(Ap<'i>),
-    ApMap(ApMap<'i>),
-    Canon(Canon<'i>),
-    CanonMap(CanonMap<'i>),
-    CanonStreamMapScalar(CanonStreamMapScalar<'i>),
-    Seq(Seq<'i>),
-    Par(Par<'i>),
-    Xor(Xor<'i>),
-    Match(Match<'i>),
-    MisMatch(MisMatch<'i>),
-    Fail(Fail<'i>),
-    FoldScalar(FoldScalar<'i>),
-    FoldStream(FoldStream<'i>),
-    FoldStreamMap(FoldStreamMap<'i>),
+    Call(Box<Call<'i>>),
+    Ap(Box<Ap<'i>>),
+    ApMap(Box<ApMap<'i>>),
+    Canon(Box<Canon<'i>>),
+    CanonMap(Box<CanonMap<'i>>),
+    CanonStreamMapScalar(Box<CanonStreamMapScalar<'i>>),
+    Seq(Box<Seq<'i>>),
+    Par(Box<Par<'i>>),
+    Xor(Box<Xor<'i>>),
+    Match(Box<Match<'i>>),
+    MisMatch(Box<MisMatch<'i>>),
+    Fail(Box<Fail<'i>>),
+    FoldScalar(Box<FoldScalar<'i>>),
+    FoldStream(Box<FoldStream<'i>>),
+    FoldStreamMap(Box<FoldStreamMap<'i>>),
     Never(Never),
-    New(New<'i>),
+    New(Box<New<'i>>),
     Next(Next<'i>),
     Null(Null),
     Error,
@@ -98,22 +98,22 @@ pub struct CanonStreamMapScalar<'i> {
 
 /// (seq instruction instruction)
 #[derive(Serialize, Debug, PartialEq)]
-pub struct Seq<'i>(pub Box<Instruction<'i>>, pub Box<Instruction<'i>>);
+pub struct Seq<'i>(pub Instruction<'i>, pub Instruction<'i>);
 
 /// (par instruction instruction)
 #[derive(Serialize, Debug, PartialEq)]
-pub struct Par<'i>(pub Box<Instruction<'i>>, pub Box<Instruction<'i>>);
+pub struct Par<'i>(pub Instruction<'i>, pub Instruction<'i>);
 
 /// (xor instruction instruction)
 #[derive(Serialize, Debug, PartialEq)]
-pub struct Xor<'i>(pub Box<Instruction<'i>>, pub Box<Instruction<'i>>);
+pub struct Xor<'i>(pub Instruction<'i>, pub Instruction<'i>);
 
 /// (match left_value right_value instruction)
 #[derive(Serialize, Debug, PartialEq)]
 pub struct Match<'i> {
     pub left_value: ImmutableValue<'i>,
     pub right_value: ImmutableValue<'i>,
-    pub instruction: Box<Instruction<'i>>,
+    pub instruction: Instruction<'i>,
 }
 
 /// (mismatch left_value right_value instruction)
@@ -121,7 +121,7 @@ pub struct Match<'i> {
 pub struct MisMatch<'i> {
     pub left_value: ImmutableValue<'i>,
     pub right_value: ImmutableValue<'i>,
-    pub instruction: Box<Instruction<'i>>,
+    pub instruction: Instruction<'i>,
 }
 
 /// (fail 1337 "error message")
@@ -191,7 +191,7 @@ pub struct Never;
 #[derive(Serialize, Debug, PartialEq)]
 pub struct New<'i> {
     pub argument: NewArgument<'i>,
-    pub instruction: Box<Instruction<'i>>,
+    pub instruction: Instruction<'i>,
     pub span: Span,
 }
 

--- a/crates/air-lib/air-parser/src/ast/instructions/impls.rs
+++ b/crates/air-lib/air-parser/src/ast/instructions/impls.rs
@@ -85,28 +85,19 @@ impl<'i> CanonStreamMapScalar<'i> {
 }
 
 impl<'i> Seq<'i> {
-    pub fn new(
-        left_instruction: Box<Instruction<'i>>,
-        right_instruction: Box<Instruction<'i>>,
-    ) -> Self {
+    pub fn new(left_instruction: Instruction<'i>, right_instruction: Instruction<'i>) -> Self {
         Self(left_instruction, right_instruction)
     }
 }
 
 impl<'i> Par<'i> {
-    pub fn new(
-        left_instruction: Box<Instruction<'i>>,
-        right_instruction: Box<Instruction<'i>>,
-    ) -> Self {
+    pub fn new(left_instruction: Instruction<'i>, right_instruction: Instruction<'i>) -> Self {
         Self(left_instruction, right_instruction)
     }
 }
 
 impl<'i> Xor<'i> {
-    pub fn new(
-        left_instruction: Box<Instruction<'i>>,
-        right_instruction: Box<Instruction<'i>>,
-    ) -> Self {
+    pub fn new(left_instruction: Instruction<'i>, right_instruction: Instruction<'i>) -> Self {
         Self(left_instruction, right_instruction)
     }
 }
@@ -115,7 +106,7 @@ impl<'i> Match<'i> {
     pub fn new(
         left_value: ImmutableValue<'i>,
         right_value: ImmutableValue<'i>,
-        instruction: Box<Instruction<'i>>,
+        instruction: Instruction<'i>,
     ) -> Self {
         Self {
             left_value,
@@ -129,7 +120,7 @@ impl<'i> MisMatch<'i> {
     pub fn new(
         left_value: ImmutableValue<'i>,
         right_value: ImmutableValue<'i>,
-        instruction: Box<Instruction<'i>>,
+        instruction: Instruction<'i>,
     ) -> Self {
         Self {
             left_value,
@@ -201,7 +192,7 @@ impl<'i> Next<'i> {
 
 impl<'i> New<'i> {
     #[allow(clippy::self_named_constructors)]
-    pub fn new(argument: NewArgument<'i>, instruction: Box<Instruction<'i>>, span: Span) -> Self {
+    pub fn new(argument: NewArgument<'i>, instruction: Instruction<'i>, span: Span) -> Self {
         Self {
             argument,
             instruction,

--- a/crates/air-lib/air-parser/src/parser/air.lalrpop
+++ b/crates/air-lib/air-parser/src/parser/air.lalrpop
@@ -13,7 +13,7 @@ grammar<'err, 'input, 'v>(input: &'input str, errors: &'err mut Vec<ErrorRecover
 
 pub AIR = Instr;
 
-Instr: Box<Instruction<'input>> = {
+Instr: Instruction<'input> = {
     <left: @L> "(" call <triplet:Triplet> <args:Args> <output:CallOutput?> ")" <right: @R> => {
         let args = Rc::new(args);
         let output = output.unwrap_or(CallOutputValue::None);
@@ -22,7 +22,7 @@ Instr: Box<Instruction<'input>> = {
 
         validator.met_call(&call, span);
 
-        Box::new(Instruction::Call(call))
+        Instruction::Call(call.into())
     },
 
     <left: @L> "(" canon <peer_id:ResolvableToPeerIdVariable> <stream:StreamArgument> <canon_stream:CanonStreamArgument> ")" <right: @R> => {
@@ -31,7 +31,7 @@ Instr: Box<Instruction<'input>> = {
         let span = Span::new(left, right);
         validator.met_canon(&canon, span);
 
-        Box::new(Instruction::Canon(canon))
+        Instruction::Canon(canon.into())
     },
 
     <left: @L> "(" canon <peer_id:ResolvableToPeerIdVariable> <stream_map:StreamMapArgument> <canon_stream_map:CanonStreamMapArgument> ")" <right: @R> => {
@@ -40,7 +40,7 @@ Instr: Box<Instruction<'input>> = {
         let span = Span::new(left, right);
         validator.met_canon_map(&canon_map, span);
 
-        Box::new(Instruction::CanonMap(canon_map))
+        Instruction::CanonMap(canon_map.into())
     },
 
     <left: @L> "(" canon <peer_id:ResolvableToPeerIdVariable> <stream_map:StreamMapArgument> <scalar_pair:Scalar> ")" <right: @R> => {
@@ -50,7 +50,7 @@ Instr: Box<Instruction<'input>> = {
         let span = Span::new(left, right);
         validator.met_canon_map_scalar(&canon, span);
 
-        Box::new(Instruction::CanonStreamMapScalar(canon))
+        Instruction::CanonStreamMapScalar(canon.into())
     },
 
     <left: @L> "(" ap <arg:ApArgument> <result:ApResult> ")" <right: @R> => {
@@ -59,7 +59,7 @@ Instr: Box<Instruction<'input>> = {
         let span = Span::new(left, right);
         validator.met_ap(&apply, span);
 
-        Box::new(Instruction::Ap(apply))
+        Instruction::Ap(apply.into())
     },
 
     <left: @L> "(" ap "(" <key:StreamMapKeyClause> <value:ApArgument> ")" <map:StreamMap> ")" <right: @R> => {
@@ -69,13 +69,13 @@ Instr: Box<Instruction<'input>> = {
         let span = Span::new(left, right);
         validator.met_ap_map(&apply, span);
 
-        Box::new(Instruction::ApMap(apply))
+        Instruction::ApMap(apply.into())
     },
 
-    "(" seq <l:Instr> <r:Instr> ")" => Box::new(Instruction::Seq(Seq::new(l, r))),
-    "(" par <l:Instr> <r:Instr> ")" => Box::new(Instruction::Par(Par::new(l, r))),
-    "(" never ")" => Box::new(Instruction::Never(Never)),
-    "(" null ")" => Box::new(Instruction::Null(Null)),
+    "(" seq <l:Instr> <r:Instr> ")" => Instruction::Seq(Seq::new(l, r).into()),
+    "(" par <l:Instr> <r:Instr> ")" => Instruction::Par(Par::new(l, r).into()),
+    "(" never ")" => Instruction::Never(Never),
+    "(" null ")" => Instruction::Null(Null),
 
     <left: @L> "(" new <argument: NewArgument> <instruction:Instr> ")" <right: @R> => {
         let span = Span::new(left, right);
@@ -83,44 +83,44 @@ Instr: Box<Instruction<'input>> = {
 
         validator.met_new(&new, span);
 
-        Box::new(Instruction::New(new))
+        Instruction::New(new.into())
     },
 
     <left: @L> "(" fail <fail_body: FailBody> ")" <right: @R> => {
         let span = Span::new(left, right);
         validator.met_fail_literal(&fail_body, span);
 
-        Box::new(Instruction::Fail(fail_body))
+        Instruction::Fail(fail_body.into())
     },
 
     <left: @L> "(" fold <iterable:FoldScalarIterable> <iterator:Scalar> <instruction:Instr> <last_instruction:Instr?>")" <right: @R> => {
         let iterator = Scalar::new(iterator.0, iterator.1);
         let span = Span::new(left, right);
-        let fold = FoldScalar::new(iterable, iterator, *instruction, last_instruction.map(|v| *v), span);
+        let fold = FoldScalar::new(iterable, iterator, instruction, last_instruction, span);
 
         validator.met_fold_scalar(&fold, span);
 
-        Box::new(Instruction::FoldScalar(fold))
+        Instruction::FoldScalar(fold.into())
     },
 
     <left: @L> "(" fold <stream:Stream> <iterator:Scalar> <instruction:Instr> <last_instruction:Instr?> ")" <right: @R> => {
         let iterable = Stream::new(stream.0, stream.1);
         let iterator = Scalar::new(iterator.0, iterator.1);
         let span = Span::new(left, right);
-        let fold = FoldStream::new(iterable, iterator, *instruction, last_instruction.map(|v| *v), span);
+        let fold = FoldStream::new(iterable, iterator, instruction, last_instruction, span);
 
         validator.meet_fold_stream(&fold, span);
 
-        Box::new(Instruction::FoldStream(fold))
+        Instruction::FoldStream(fold.into())
     },
 
     <left: @L> "(" fold <stream_map:StreamMap> <iterator:Scalar> <instruction:Instr> <last_instruction:Instr?> ")" <right: @R> => {
         let iterator = Scalar::new(iterator.0, iterator.1);
         let span = Span::new(left, right);
         let iterable = StreamMap::new(stream_map.0, stream_map.1);
-        let fold = FoldStreamMap::new(iterable, iterator, *instruction, last_instruction.map(|v| *v), span);
+        let fold = FoldStreamMap::new(iterable, iterator, instruction, last_instruction, span);
         validator.meet_fold_stream_map(&fold, span);
-        Box::new(Instruction::FoldStreamMap(fold))
+        Instruction::FoldStreamMap(fold.into())
     },
 
     <left: @L> "(" next <iterator:Scalar> ")" <right: @R> => {
@@ -129,17 +129,17 @@ Instr: Box<Instruction<'input>> = {
         let span = Span::new(left, right);
         validator.met_next(&next, span);
 
-        Box::new(Instruction::Next(next))
+        Instruction::Next(next)
     },
 
-    "(" xor <l:Instr> <r:Instr> ")" => Box::new(Instruction::Xor(Xor(l, r))),
+    "(" xor <l:Instr> <r:Instr> ")" => Instruction::Xor(Xor(l, r).into()),
 
     <left: @L> "(" match_ <l:Value> <r:Value> <i:Instr> ")" <right: @R> => {
         let match_ = Match::new(l, r, i);
         let span = Span::new(left, right);
         validator.met_match(&match_, span);
 
-        Box::new(Instruction::Match(match_))
+        Instruction::Match(match_.into())
     },
 
     <left: @L> "(" mismatch <l:Value> <r:Value> <i:Instr> ")" <right: @R> => {
@@ -147,10 +147,10 @@ Instr: Box<Instruction<'input>> = {
         let span = Span::new(left, right);
         validator.met_mismatch(&mismatch, span);
 
-        Box::new(Instruction::MisMatch(mismatch))
+        Instruction::MisMatch(mismatch.into())
      },
 
-    ! => { errors.push(<>); Box::new(Instruction::Error) },
+    ! => { errors.push(<>); Instruction::Error },
 }
 
 Args: Vec<ImmutableValue<'input>> = {

--- a/crates/air-lib/air-parser/src/parser/air.lalrpop
+++ b/crates/air-lib/air-parser/src/parser/air.lalrpop
@@ -129,7 +129,7 @@ Instr: Instruction<'input> = {
         let span = Span::new(left, right);
         validator.met_next(&next, span);
 
-        Instruction::Next(next)
+        Instruction::Next(next.into())
     },
 
     "(" xor <l:Instr> <r:Instr> ")" => Instruction::Xor(Xor(l, r).into()),

--- a/crates/air-lib/air-parser/src/parser/air.rs
+++ b/crates/air-lib/air-parser/src/parser/air.rs
@@ -1,5 +1,5 @@
 // auto-generated: "lalrpop 0.20.0"
-// sha3: 993dbb5ce92c8cefdaa029ad3852c96bafbd0bd1bb6cf24b78fdf40c2189256b
+// sha3: 127100bc464d586a4839740daea718cfbd4c90154fcbc34ebfb7cc898a24b6d7
 use crate::ast::*;
 use crate::parser::ParserError;
 use crate::parser::VariableValidator;
@@ -5789,7 +5789,7 @@ fn __action17<
         let span = Span::new(left, right);
         validator.met_next(&next, span);
 
-        Instruction::Next(next)
+        Instruction::Next(next.into())
     }
 }
 

--- a/crates/air-lib/air-parser/src/parser/air.rs
+++ b/crates/air-lib/air-parser/src/parser/air.rs
@@ -1,5 +1,5 @@
 // auto-generated: "lalrpop 0.20.0"
-// sha3: 3f2a00b4e0b0922c986743c02f1829a8610259b5697c6508b93c823c487de1de
+// sha3: 993dbb5ce92c8cefdaa029ad3852c96bafbd0bd1bb6cf24b78fdf40c2189256b
 use crate::ast::*;
 use crate::parser::ParserError;
 use crate::parser::VariableValidator;
@@ -49,7 +49,7 @@ mod __parse__AIR {
         Variant9(ImmutableValue<'input>),
         Variant10(alloc::vec::Vec<ImmutableValue<'input>>),
         Variant11(AirPos),
-        Variant12(Box<Instruction<'input>>),
+        Variant12(Instruction<'input>),
         Variant13(ApArgument<'input>),
         Variant14(ApResult<'input>),
         Variant15(Vec<ImmutableValue<'input>>),
@@ -60,7 +60,7 @@ mod __parse__AIR {
         Variant20(Fail<'input>),
         Variant21(FoldScalarIterable<'input>),
         Variant22(ResolvableToStringVariable<'input>),
-        Variant23(core::option::Option<Box<Instruction<'input>>>),
+        Variant23(core::option::Option<Instruction<'input>>),
         Variant24(NewArgument<'input>),
         Variant25(Number),
         Variant26(ResolvableToPeerIdVariable<'input>),
@@ -952,7 +952,7 @@ mod __parse__AIR {
         type Token = Token<'input>;
         type TokenIndex = usize;
         type Symbol = __Symbol<'input>;
-        type Success = Box<Instruction<'input>>;
+        type Success = Instruction<'input>;
         type StateIndex = i16;
         type Action = i16;
         type ReduceIndex = i16;
@@ -1889,7 +1889,7 @@ mod __parse__AIR {
             errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
             validator: &'v mut VariableValidator<'input>,
             __tokens0: __TOKENS,
-        ) -> Result<Box<Instruction<'input>>, __lalrpop_util::ParseError<AirPos, Token<'input>, ParserError>>
+        ) -> Result<Instruction<'input>, __lalrpop_util::ParseError<AirPos, Token<'input>, ParserError>>
         {
             let __tokens = __tokens0.into_iter();
             let mut __tokens = __tokens.map(|t| __ToTriple::to_triple(t));
@@ -1955,7 +1955,7 @@ mod __parse__AIR {
         __states: &mut alloc::vec::Vec<i16>,
         __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>,
         _: core::marker::PhantomData<(&'err (), &'input (), &'v ())>,
-    ) -> Option<Result<Box<Instruction<'input>>,__lalrpop_util::ParseError<AirPos, Token<'input>, ParserError>>>
+    ) -> Option<Result<Instruction<'input>,__lalrpop_util::ParseError<AirPos, Token<'input>, ParserError>>>
     {
         let (__pop_states, __nonterminal) = match __action {
             0 => {
@@ -2391,17 +2391,6 @@ mod __parse__AIR {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant12<
-      'input,
-    >(
-        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>
-    ) -> (AirPos, Box<Instruction<'input>>, AirPos)
-     {
-        match __symbols.pop() {
-            Some((__l, __Symbol::Variant12(__v), __r)) => (__l, __v, __r),
-            _ => __symbol_type_mismatch()
-        }
-    }
     fn __pop_Variant16<
       'input,
     >(
@@ -2465,6 +2454,17 @@ mod __parse__AIR {
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant9(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
+    fn __pop_Variant12<
+      'input,
+    >(
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>
+    ) -> (AirPos, Instruction<'input>, AirPos)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant12(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -2622,17 +2622,6 @@ mod __parse__AIR {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant23<
-      'input,
-    >(
-        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>
-    ) -> (AirPos, core::option::Option<Box<Instruction<'input>>>, AirPos)
-     {
-        match __symbols.pop() {
-            Some((__l, __Symbol::Variant23(__v), __r)) => (__l, __v, __r),
-            _ => __symbol_type_mismatch()
-        }
-    }
     fn __pop_Variant17<
       'input,
     >(
@@ -2641,6 +2630,17 @@ mod __parse__AIR {
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant17(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
+    fn __pop_Variant23<
+      'input,
+    >(
+        __symbols: &mut alloc::vec::Vec<(AirPos,__Symbol<'input>,AirPos)>
+    ) -> (AirPos, core::option::Option<Instruction<'input>>, AirPos)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant23(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -5331,8 +5331,8 @@ fn __action0<
     input: &'input str,
     errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (AirPos, Box<Instruction<'input>>, AirPos),
-) -> Box<Instruction<'input>>
+    (_, __0, _): (AirPos, Instruction<'input>, AirPos),
+) -> Instruction<'input>
 {
     __0
 }
@@ -5347,8 +5347,8 @@ fn __action1<
     input: &'input str,
     errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (AirPos, Box<Instruction<'input>>, AirPos),
-) -> Box<Instruction<'input>>
+    (_, __0, _): (AirPos, Instruction<'input>, AirPos),
+) -> Instruction<'input>
 {
     __0
 }
@@ -5371,7 +5371,7 @@ fn __action2<
     (_, output, _): (AirPos, core::option::Option<CallOutputValue<'input>>, AirPos),
     (_, _, _): (AirPos, Token<'input>, AirPos),
     (_, right, _): (AirPos, AirPos, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     {
         let args = Rc::new(args);
@@ -5381,7 +5381,7 @@ fn __action2<
 
         validator.met_call(&call, span);
 
-        Box::new(Instruction::Call(call))
+        Instruction::Call(call.into())
     }
 }
 
@@ -5403,7 +5403,7 @@ fn __action3<
     (_, canon_stream, _): (AirPos, CanonStream<'input>, AirPos),
     (_, _, _): (AirPos, Token<'input>, AirPos),
     (_, right, _): (AirPos, AirPos, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     {
         let canon = Canon::new(peer_id, stream, canon_stream);
@@ -5411,7 +5411,7 @@ fn __action3<
         let span = Span::new(left, right);
         validator.met_canon(&canon, span);
 
-        Box::new(Instruction::Canon(canon))
+        Instruction::Canon(canon.into())
     }
 }
 
@@ -5433,7 +5433,7 @@ fn __action4<
     (_, canon_stream_map, _): (AirPos, CanonStreamMap<'input>, AirPos),
     (_, _, _): (AirPos, Token<'input>, AirPos),
     (_, right, _): (AirPos, AirPos, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     {
         let canon_map = CanonMap::new(peer_id, stream_map, canon_stream_map);
@@ -5441,7 +5441,7 @@ fn __action4<
         let span = Span::new(left, right);
         validator.met_canon_map(&canon_map, span);
 
-        Box::new(Instruction::CanonMap(canon_map))
+        Instruction::CanonMap(canon_map.into())
     }
 }
 
@@ -5463,7 +5463,7 @@ fn __action5<
     (_, scalar_pair, _): (AirPos, (&'input str, AirPos), AirPos),
     (_, _, _): (AirPos, Token<'input>, AirPos),
     (_, right, _): (AirPos, AirPos, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     {
         let scalar = Scalar::new(scalar_pair.0, scalar_pair.1);
@@ -5472,7 +5472,7 @@ fn __action5<
         let span = Span::new(left, right);
         validator.met_canon_map_scalar(&canon, span);
 
-        Box::new(Instruction::CanonStreamMapScalar(canon))
+        Instruction::CanonStreamMapScalar(canon.into())
     }
 }
 
@@ -5493,7 +5493,7 @@ fn __action6<
     (_, result, _): (AirPos, ApResult<'input>, AirPos),
     (_, _, _): (AirPos, Token<'input>, AirPos),
     (_, right, _): (AirPos, AirPos, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     {
         let apply = Ap::new(arg, result);
@@ -5501,7 +5501,7 @@ fn __action6<
         let span = Span::new(left, right);
         validator.met_ap(&apply, span);
 
-        Box::new(Instruction::Ap(apply))
+        Instruction::Ap(apply.into())
     }
 }
 
@@ -5525,7 +5525,7 @@ fn __action7<
     (_, map, _): (AirPos, (&'input str, AirPos), AirPos),
     (_, _, _): (AirPos, Token<'input>, AirPos),
     (_, right, _): (AirPos, AirPos, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     {
         let map = StreamMap::new(map.0, map.1);
@@ -5534,7 +5534,7 @@ fn __action7<
         let span = Span::new(left, right);
         validator.met_ap_map(&apply, span);
 
-        Box::new(Instruction::ApMap(apply))
+        Instruction::ApMap(apply.into())
     }
 }
 
@@ -5550,12 +5550,12 @@ fn __action8<
     validator: &'v mut VariableValidator<'input>,
     (_, _, _): (AirPos, Token<'input>, AirPos),
     (_, _, _): (AirPos, Token<'input>, AirPos),
-    (_, l, _): (AirPos, Box<Instruction<'input>>, AirPos),
-    (_, r, _): (AirPos, Box<Instruction<'input>>, AirPos),
+    (_, l, _): (AirPos, Instruction<'input>, AirPos),
+    (_, r, _): (AirPos, Instruction<'input>, AirPos),
     (_, _, _): (AirPos, Token<'input>, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
-    Box::new(Instruction::Seq(Seq::new(l, r)))
+    Instruction::Seq(Seq::new(l, r).into())
 }
 
 #[allow(unused_variables)]
@@ -5570,12 +5570,12 @@ fn __action9<
     validator: &'v mut VariableValidator<'input>,
     (_, _, _): (AirPos, Token<'input>, AirPos),
     (_, _, _): (AirPos, Token<'input>, AirPos),
-    (_, l, _): (AirPos, Box<Instruction<'input>>, AirPos),
-    (_, r, _): (AirPos, Box<Instruction<'input>>, AirPos),
+    (_, l, _): (AirPos, Instruction<'input>, AirPos),
+    (_, r, _): (AirPos, Instruction<'input>, AirPos),
     (_, _, _): (AirPos, Token<'input>, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
-    Box::new(Instruction::Par(Par::new(l, r)))
+    Instruction::Par(Par::new(l, r).into())
 }
 
 #[allow(unused_variables)]
@@ -5591,9 +5591,9 @@ fn __action10<
     (_, __0, _): (AirPos, Token<'input>, AirPos),
     (_, __1, _): (AirPos, Token<'input>, AirPos),
     (_, __2, _): (AirPos, Token<'input>, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
-    Box::new(Instruction::Never(Never))
+    Instruction::Never(Never)
 }
 
 #[allow(unused_variables)]
@@ -5609,9 +5609,9 @@ fn __action11<
     (_, __0, _): (AirPos, Token<'input>, AirPos),
     (_, __1, _): (AirPos, Token<'input>, AirPos),
     (_, __2, _): (AirPos, Token<'input>, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
-    Box::new(Instruction::Null(Null))
+    Instruction::Null(Null)
 }
 
 #[allow(unused_variables)]
@@ -5628,10 +5628,10 @@ fn __action12<
     (_, _, _): (AirPos, Token<'input>, AirPos),
     (_, _, _): (AirPos, Token<'input>, AirPos),
     (_, argument, _): (AirPos, NewArgument<'input>, AirPos),
-    (_, instruction, _): (AirPos, Box<Instruction<'input>>, AirPos),
+    (_, instruction, _): (AirPos, Instruction<'input>, AirPos),
     (_, _, _): (AirPos, Token<'input>, AirPos),
     (_, right, _): (AirPos, AirPos, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     {
         let span = Span::new(left, right);
@@ -5639,7 +5639,7 @@ fn __action12<
 
         validator.met_new(&new, span);
 
-        Box::new(Instruction::New(new))
+        Instruction::New(new.into())
     }
 }
 
@@ -5659,13 +5659,13 @@ fn __action13<
     (_, fail_body, _): (AirPos, Fail<'input>, AirPos),
     (_, _, _): (AirPos, Token<'input>, AirPos),
     (_, right, _): (AirPos, AirPos, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     {
         let span = Span::new(left, right);
         validator.met_fail_literal(&fail_body, span);
 
-        Box::new(Instruction::Fail(fail_body))
+        Instruction::Fail(fail_body.into())
     }
 }
 
@@ -5684,20 +5684,20 @@ fn __action14<
     (_, _, _): (AirPos, Token<'input>, AirPos),
     (_, iterable, _): (AirPos, FoldScalarIterable<'input>, AirPos),
     (_, iterator, _): (AirPos, (&'input str, AirPos), AirPos),
-    (_, instruction, _): (AirPos, Box<Instruction<'input>>, AirPos),
-    (_, last_instruction, _): (AirPos, core::option::Option<Box<Instruction<'input>>>, AirPos),
+    (_, instruction, _): (AirPos, Instruction<'input>, AirPos),
+    (_, last_instruction, _): (AirPos, core::option::Option<Instruction<'input>>, AirPos),
     (_, _, _): (AirPos, Token<'input>, AirPos),
     (_, right, _): (AirPos, AirPos, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     {
         let iterator = Scalar::new(iterator.0, iterator.1);
         let span = Span::new(left, right);
-        let fold = FoldScalar::new(iterable, iterator, *instruction, last_instruction.map(|v| *v), span);
+        let fold = FoldScalar::new(iterable, iterator, instruction, last_instruction, span);
 
         validator.met_fold_scalar(&fold, span);
 
-        Box::new(Instruction::FoldScalar(fold))
+        Instruction::FoldScalar(fold.into())
     }
 }
 
@@ -5716,21 +5716,21 @@ fn __action15<
     (_, _, _): (AirPos, Token<'input>, AirPos),
     (_, stream, _): (AirPos, (&'input str, AirPos), AirPos),
     (_, iterator, _): (AirPos, (&'input str, AirPos), AirPos),
-    (_, instruction, _): (AirPos, Box<Instruction<'input>>, AirPos),
-    (_, last_instruction, _): (AirPos, core::option::Option<Box<Instruction<'input>>>, AirPos),
+    (_, instruction, _): (AirPos, Instruction<'input>, AirPos),
+    (_, last_instruction, _): (AirPos, core::option::Option<Instruction<'input>>, AirPos),
     (_, _, _): (AirPos, Token<'input>, AirPos),
     (_, right, _): (AirPos, AirPos, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     {
         let iterable = Stream::new(stream.0, stream.1);
         let iterator = Scalar::new(iterator.0, iterator.1);
         let span = Span::new(left, right);
-        let fold = FoldStream::new(iterable, iterator, *instruction, last_instruction.map(|v| *v), span);
+        let fold = FoldStream::new(iterable, iterator, instruction, last_instruction, span);
 
         validator.meet_fold_stream(&fold, span);
 
-        Box::new(Instruction::FoldStream(fold))
+        Instruction::FoldStream(fold.into())
     }
 }
 
@@ -5749,19 +5749,19 @@ fn __action16<
     (_, _, _): (AirPos, Token<'input>, AirPos),
     (_, stream_map, _): (AirPos, (&'input str, AirPos), AirPos),
     (_, iterator, _): (AirPos, (&'input str, AirPos), AirPos),
-    (_, instruction, _): (AirPos, Box<Instruction<'input>>, AirPos),
-    (_, last_instruction, _): (AirPos, core::option::Option<Box<Instruction<'input>>>, AirPos),
+    (_, instruction, _): (AirPos, Instruction<'input>, AirPos),
+    (_, last_instruction, _): (AirPos, core::option::Option<Instruction<'input>>, AirPos),
     (_, _, _): (AirPos, Token<'input>, AirPos),
     (_, right, _): (AirPos, AirPos, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     {
         let iterator = Scalar::new(iterator.0, iterator.1);
         let span = Span::new(left, right);
         let iterable = StreamMap::new(stream_map.0, stream_map.1);
-        let fold = FoldStreamMap::new(iterable, iterator, *instruction, last_instruction.map(|v| *v), span);
+        let fold = FoldStreamMap::new(iterable, iterator, instruction, last_instruction, span);
         validator.meet_fold_stream_map(&fold, span);
-        Box::new(Instruction::FoldStreamMap(fold))
+        Instruction::FoldStreamMap(fold.into())
     }
 }
 
@@ -5781,7 +5781,7 @@ fn __action17<
     (_, iterator, _): (AirPos, (&'input str, AirPos), AirPos),
     (_, _, _): (AirPos, Token<'input>, AirPos),
     (_, right, _): (AirPos, AirPos, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     {
         let iterator = Scalar::new(iterator.0, iterator.1);
@@ -5789,7 +5789,7 @@ fn __action17<
         let span = Span::new(left, right);
         validator.met_next(&next, span);
 
-        Box::new(Instruction::Next(next))
+        Instruction::Next(next)
     }
 }
 
@@ -5805,12 +5805,12 @@ fn __action18<
     validator: &'v mut VariableValidator<'input>,
     (_, _, _): (AirPos, Token<'input>, AirPos),
     (_, _, _): (AirPos, Token<'input>, AirPos),
-    (_, l, _): (AirPos, Box<Instruction<'input>>, AirPos),
-    (_, r, _): (AirPos, Box<Instruction<'input>>, AirPos),
+    (_, l, _): (AirPos, Instruction<'input>, AirPos),
+    (_, r, _): (AirPos, Instruction<'input>, AirPos),
     (_, _, _): (AirPos, Token<'input>, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
-    Box::new(Instruction::Xor(Xor(l, r)))
+    Instruction::Xor(Xor(l, r).into())
 }
 
 #[allow(unused_variables)]
@@ -5828,17 +5828,17 @@ fn __action19<
     (_, _, _): (AirPos, Token<'input>, AirPos),
     (_, l, _): (AirPos, ImmutableValue<'input>, AirPos),
     (_, r, _): (AirPos, ImmutableValue<'input>, AirPos),
-    (_, i, _): (AirPos, Box<Instruction<'input>>, AirPos),
+    (_, i, _): (AirPos, Instruction<'input>, AirPos),
     (_, _, _): (AirPos, Token<'input>, AirPos),
     (_, right, _): (AirPos, AirPos, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     {
         let match_ = Match::new(l, r, i);
         let span = Span::new(left, right);
         validator.met_match(&match_, span);
 
-        Box::new(Instruction::Match(match_))
+        Instruction::Match(match_.into())
     }
 }
 
@@ -5857,17 +5857,17 @@ fn __action20<
     (_, _, _): (AirPos, Token<'input>, AirPos),
     (_, l, _): (AirPos, ImmutableValue<'input>, AirPos),
     (_, r, _): (AirPos, ImmutableValue<'input>, AirPos),
-    (_, i, _): (AirPos, Box<Instruction<'input>>, AirPos),
+    (_, i, _): (AirPos, Instruction<'input>, AirPos),
     (_, _, _): (AirPos, Token<'input>, AirPos),
     (_, right, _): (AirPos, AirPos, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     {
         let mismatch = MisMatch::new(l, r, i);
         let span = Span::new(left, right);
         validator.met_mismatch(&mismatch, span);
 
-        Box::new(Instruction::MisMatch(mismatch))
+        Instruction::MisMatch(mismatch.into())
      }
 }
 
@@ -5882,9 +5882,9 @@ fn __action21<
     errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
     (_, __0, _): (AirPos, __lalrpop_util::ErrorRecovery<AirPos, Token<'input>, ParserError>, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
-    { errors.push(__0); Box::new(Instruction::Error) }
+    { errors.push(__0); Instruction::Error }
 }
 
 #[allow(unused_variables)]
@@ -7283,8 +7283,8 @@ fn __action107<
     input: &'input str,
     errors: &'err mut Vec<ErrorRecovery<AirPos, Token<'input>, ParserError>>,
     validator: &'v mut VariableValidator<'input>,
-    (_, __0, _): (AirPos, Box<Instruction<'input>>, AirPos),
-) -> core::option::Option<Box<Instruction<'input>>>
+    (_, __0, _): (AirPos, Instruction<'input>, AirPos),
+) -> core::option::Option<Instruction<'input>>
 {
     Some(__0)
 }
@@ -7301,7 +7301,7 @@ fn __action108<
     validator: &'v mut VariableValidator<'input>,
     __lookbehind: &AirPos,
     __lookahead: &AirPos,
-) -> core::option::Option<Box<Instruction<'input>>>
+) -> core::option::Option<Instruction<'input>>
 {
     None
 }
@@ -7619,7 +7619,7 @@ fn __action121<
     __4: (AirPos, core::option::Option<CallOutputValue<'input>>, AirPos),
     __5: (AirPos, Token<'input>, AirPos),
     __6: (AirPos, AirPos, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     let __start0 = __0.0;
     let __end0 = __0.0;
@@ -7663,7 +7663,7 @@ fn __action122<
     __4: (AirPos, CanonStream<'input>, AirPos),
     __5: (AirPos, Token<'input>, AirPos),
     __6: (AirPos, AirPos, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     let __start0 = __0.0;
     let __end0 = __0.0;
@@ -7707,7 +7707,7 @@ fn __action123<
     __4: (AirPos, CanonStreamMap<'input>, AirPos),
     __5: (AirPos, Token<'input>, AirPos),
     __6: (AirPos, AirPos, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     let __start0 = __0.0;
     let __end0 = __0.0;
@@ -7751,7 +7751,7 @@ fn __action124<
     __4: (AirPos, (&'input str, AirPos), AirPos),
     __5: (AirPos, Token<'input>, AirPos),
     __6: (AirPos, AirPos, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     let __start0 = __0.0;
     let __end0 = __0.0;
@@ -7794,7 +7794,7 @@ fn __action125<
     __3: (AirPos, ApResult<'input>, AirPos),
     __4: (AirPos, Token<'input>, AirPos),
     __5: (AirPos, AirPos, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     let __start0 = __0.0;
     let __end0 = __0.0;
@@ -7839,7 +7839,7 @@ fn __action126<
     __6: (AirPos, (&'input str, AirPos), AirPos),
     __7: (AirPos, Token<'input>, AirPos),
     __8: (AirPos, AirPos, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     let __start0 = __0.0;
     let __end0 = __0.0;
@@ -7881,10 +7881,10 @@ fn __action127<
     __0: (AirPos, Token<'input>, AirPos),
     __1: (AirPos, Token<'input>, AirPos),
     __2: (AirPos, NewArgument<'input>, AirPos),
-    __3: (AirPos, Box<Instruction<'input>>, AirPos),
+    __3: (AirPos, Instruction<'input>, AirPos),
     __4: (AirPos, Token<'input>, AirPos),
     __5: (AirPos, AirPos, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     let __start0 = __0.0;
     let __end0 = __0.0;
@@ -7925,7 +7925,7 @@ fn __action128<
     __2: (AirPos, Fail<'input>, AirPos),
     __3: (AirPos, Token<'input>, AirPos),
     __4: (AirPos, AirPos, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     let __start0 = __0.0;
     let __end0 = __0.0;
@@ -7964,11 +7964,11 @@ fn __action129<
     __1: (AirPos, Token<'input>, AirPos),
     __2: (AirPos, FoldScalarIterable<'input>, AirPos),
     __3: (AirPos, (&'input str, AirPos), AirPos),
-    __4: (AirPos, Box<Instruction<'input>>, AirPos),
-    __5: (AirPos, core::option::Option<Box<Instruction<'input>>>, AirPos),
+    __4: (AirPos, Instruction<'input>, AirPos),
+    __5: (AirPos, core::option::Option<Instruction<'input>>, AirPos),
     __6: (AirPos, Token<'input>, AirPos),
     __7: (AirPos, AirPos, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     let __start0 = __0.0;
     let __end0 = __0.0;
@@ -8010,11 +8010,11 @@ fn __action130<
     __1: (AirPos, Token<'input>, AirPos),
     __2: (AirPos, (&'input str, AirPos), AirPos),
     __3: (AirPos, (&'input str, AirPos), AirPos),
-    __4: (AirPos, Box<Instruction<'input>>, AirPos),
-    __5: (AirPos, core::option::Option<Box<Instruction<'input>>>, AirPos),
+    __4: (AirPos, Instruction<'input>, AirPos),
+    __5: (AirPos, core::option::Option<Instruction<'input>>, AirPos),
     __6: (AirPos, Token<'input>, AirPos),
     __7: (AirPos, AirPos, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     let __start0 = __0.0;
     let __end0 = __0.0;
@@ -8056,11 +8056,11 @@ fn __action131<
     __1: (AirPos, Token<'input>, AirPos),
     __2: (AirPos, (&'input str, AirPos), AirPos),
     __3: (AirPos, (&'input str, AirPos), AirPos),
-    __4: (AirPos, Box<Instruction<'input>>, AirPos),
-    __5: (AirPos, core::option::Option<Box<Instruction<'input>>>, AirPos),
+    __4: (AirPos, Instruction<'input>, AirPos),
+    __5: (AirPos, core::option::Option<Instruction<'input>>, AirPos),
     __6: (AirPos, Token<'input>, AirPos),
     __7: (AirPos, AirPos, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     let __start0 = __0.0;
     let __end0 = __0.0;
@@ -8103,7 +8103,7 @@ fn __action132<
     __2: (AirPos, (&'input str, AirPos), AirPos),
     __3: (AirPos, Token<'input>, AirPos),
     __4: (AirPos, AirPos, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     let __start0 = __0.0;
     let __end0 = __0.0;
@@ -8142,10 +8142,10 @@ fn __action133<
     __1: (AirPos, Token<'input>, AirPos),
     __2: (AirPos, ImmutableValue<'input>, AirPos),
     __3: (AirPos, ImmutableValue<'input>, AirPos),
-    __4: (AirPos, Box<Instruction<'input>>, AirPos),
+    __4: (AirPos, Instruction<'input>, AirPos),
     __5: (AirPos, Token<'input>, AirPos),
     __6: (AirPos, AirPos, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     let __start0 = __0.0;
     let __end0 = __0.0;
@@ -8186,10 +8186,10 @@ fn __action134<
     __1: (AirPos, Token<'input>, AirPos),
     __2: (AirPos, ImmutableValue<'input>, AirPos),
     __3: (AirPos, ImmutableValue<'input>, AirPos),
-    __4: (AirPos, Box<Instruction<'input>>, AirPos),
+    __4: (AirPos, Instruction<'input>, AirPos),
     __5: (AirPos, Token<'input>, AirPos),
     __6: (AirPos, AirPos, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     let __start0 = __0.0;
     let __end0 = __0.0;
@@ -8296,7 +8296,7 @@ fn __action137<
     __3: (AirPos, Vec<ImmutableValue<'input>>, AirPos),
     __4: (AirPos, core::option::Option<CallOutputValue<'input>>, AirPos),
     __5: (AirPos, Token<'input>, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     let __start0 = __5.2;
     let __end0 = __5.2;
@@ -8338,7 +8338,7 @@ fn __action138<
     __3: (AirPos, Stream<'input>, AirPos),
     __4: (AirPos, CanonStream<'input>, AirPos),
     __5: (AirPos, Token<'input>, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     let __start0 = __5.2;
     let __end0 = __5.2;
@@ -8380,7 +8380,7 @@ fn __action139<
     __3: (AirPos, StreamMap<'input>, AirPos),
     __4: (AirPos, CanonStreamMap<'input>, AirPos),
     __5: (AirPos, Token<'input>, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     let __start0 = __5.2;
     let __end0 = __5.2;
@@ -8422,7 +8422,7 @@ fn __action140<
     __3: (AirPos, StreamMap<'input>, AirPos),
     __4: (AirPos, (&'input str, AirPos), AirPos),
     __5: (AirPos, Token<'input>, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     let __start0 = __5.2;
     let __end0 = __5.2;
@@ -8463,7 +8463,7 @@ fn __action141<
     __2: (AirPos, ApArgument<'input>, AirPos),
     __3: (AirPos, ApResult<'input>, AirPos),
     __4: (AirPos, Token<'input>, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     let __start0 = __4.2;
     let __end0 = __4.2;
@@ -8506,7 +8506,7 @@ fn __action142<
     __5: (AirPos, Token<'input>, AirPos),
     __6: (AirPos, (&'input str, AirPos), AirPos),
     __7: (AirPos, Token<'input>, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     let __start0 = __7.2;
     let __end0 = __7.2;
@@ -8547,9 +8547,9 @@ fn __action143<
     __0: (AirPos, Token<'input>, AirPos),
     __1: (AirPos, Token<'input>, AirPos),
     __2: (AirPos, NewArgument<'input>, AirPos),
-    __3: (AirPos, Box<Instruction<'input>>, AirPos),
+    __3: (AirPos, Instruction<'input>, AirPos),
     __4: (AirPos, Token<'input>, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     let __start0 = __4.2;
     let __end0 = __4.2;
@@ -8588,7 +8588,7 @@ fn __action144<
     __1: (AirPos, Token<'input>, AirPos),
     __2: (AirPos, Fail<'input>, AirPos),
     __3: (AirPos, Token<'input>, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     let __start0 = __3.2;
     let __end0 = __3.2;
@@ -8626,10 +8626,10 @@ fn __action145<
     __1: (AirPos, Token<'input>, AirPos),
     __2: (AirPos, FoldScalarIterable<'input>, AirPos),
     __3: (AirPos, (&'input str, AirPos), AirPos),
-    __4: (AirPos, Box<Instruction<'input>>, AirPos),
-    __5: (AirPos, core::option::Option<Box<Instruction<'input>>>, AirPos),
+    __4: (AirPos, Instruction<'input>, AirPos),
+    __5: (AirPos, core::option::Option<Instruction<'input>>, AirPos),
     __6: (AirPos, Token<'input>, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     let __start0 = __6.2;
     let __end0 = __6.2;
@@ -8670,10 +8670,10 @@ fn __action146<
     __1: (AirPos, Token<'input>, AirPos),
     __2: (AirPos, (&'input str, AirPos), AirPos),
     __3: (AirPos, (&'input str, AirPos), AirPos),
-    __4: (AirPos, Box<Instruction<'input>>, AirPos),
-    __5: (AirPos, core::option::Option<Box<Instruction<'input>>>, AirPos),
+    __4: (AirPos, Instruction<'input>, AirPos),
+    __5: (AirPos, core::option::Option<Instruction<'input>>, AirPos),
     __6: (AirPos, Token<'input>, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     let __start0 = __6.2;
     let __end0 = __6.2;
@@ -8714,10 +8714,10 @@ fn __action147<
     __1: (AirPos, Token<'input>, AirPos),
     __2: (AirPos, (&'input str, AirPos), AirPos),
     __3: (AirPos, (&'input str, AirPos), AirPos),
-    __4: (AirPos, Box<Instruction<'input>>, AirPos),
-    __5: (AirPos, core::option::Option<Box<Instruction<'input>>>, AirPos),
+    __4: (AirPos, Instruction<'input>, AirPos),
+    __5: (AirPos, core::option::Option<Instruction<'input>>, AirPos),
     __6: (AirPos, Token<'input>, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     let __start0 = __6.2;
     let __end0 = __6.2;
@@ -8758,7 +8758,7 @@ fn __action148<
     __1: (AirPos, Token<'input>, AirPos),
     __2: (AirPos, (&'input str, AirPos), AirPos),
     __3: (AirPos, Token<'input>, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     let __start0 = __3.2;
     let __end0 = __3.2;
@@ -8796,9 +8796,9 @@ fn __action149<
     __1: (AirPos, Token<'input>, AirPos),
     __2: (AirPos, ImmutableValue<'input>, AirPos),
     __3: (AirPos, ImmutableValue<'input>, AirPos),
-    __4: (AirPos, Box<Instruction<'input>>, AirPos),
+    __4: (AirPos, Instruction<'input>, AirPos),
     __5: (AirPos, Token<'input>, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     let __start0 = __5.2;
     let __end0 = __5.2;
@@ -8838,9 +8838,9 @@ fn __action150<
     __1: (AirPos, Token<'input>, AirPos),
     __2: (AirPos, ImmutableValue<'input>, AirPos),
     __3: (AirPos, ImmutableValue<'input>, AirPos),
-    __4: (AirPos, Box<Instruction<'input>>, AirPos),
+    __4: (AirPos, Instruction<'input>, AirPos),
     __5: (AirPos, Token<'input>, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     let __start0 = __5.2;
     let __end0 = __5.2;
@@ -8882,7 +8882,7 @@ fn __action151<
     __3: (AirPos, Vec<ImmutableValue<'input>>, AirPos),
     __4: (AirPos, CallOutputValue<'input>, AirPos),
     __5: (AirPos, Token<'input>, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     let __start0 = __4.0;
     let __end0 = __4.2;
@@ -8921,7 +8921,7 @@ fn __action152<
     __2: (AirPos, Triplet<'input>, AirPos),
     __3: (AirPos, Vec<ImmutableValue<'input>>, AirPos),
     __4: (AirPos, Token<'input>, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     let __start0 = __3.2;
     let __end0 = __4.0;
@@ -8960,10 +8960,10 @@ fn __action153<
     __1: (AirPos, Token<'input>, AirPos),
     __2: (AirPos, FoldScalarIterable<'input>, AirPos),
     __3: (AirPos, (&'input str, AirPos), AirPos),
-    __4: (AirPos, Box<Instruction<'input>>, AirPos),
-    __5: (AirPos, Box<Instruction<'input>>, AirPos),
+    __4: (AirPos, Instruction<'input>, AirPos),
+    __5: (AirPos, Instruction<'input>, AirPos),
     __6: (AirPos, Token<'input>, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     let __start0 = __5.0;
     let __end0 = __5.2;
@@ -9002,9 +9002,9 @@ fn __action154<
     __1: (AirPos, Token<'input>, AirPos),
     __2: (AirPos, FoldScalarIterable<'input>, AirPos),
     __3: (AirPos, (&'input str, AirPos), AirPos),
-    __4: (AirPos, Box<Instruction<'input>>, AirPos),
+    __4: (AirPos, Instruction<'input>, AirPos),
     __5: (AirPos, Token<'input>, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     let __start0 = __4.2;
     let __end0 = __5.0;
@@ -9044,10 +9044,10 @@ fn __action155<
     __1: (AirPos, Token<'input>, AirPos),
     __2: (AirPos, (&'input str, AirPos), AirPos),
     __3: (AirPos, (&'input str, AirPos), AirPos),
-    __4: (AirPos, Box<Instruction<'input>>, AirPos),
-    __5: (AirPos, Box<Instruction<'input>>, AirPos),
+    __4: (AirPos, Instruction<'input>, AirPos),
+    __5: (AirPos, Instruction<'input>, AirPos),
     __6: (AirPos, Token<'input>, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     let __start0 = __5.0;
     let __end0 = __5.2;
@@ -9086,9 +9086,9 @@ fn __action156<
     __1: (AirPos, Token<'input>, AirPos),
     __2: (AirPos, (&'input str, AirPos), AirPos),
     __3: (AirPos, (&'input str, AirPos), AirPos),
-    __4: (AirPos, Box<Instruction<'input>>, AirPos),
+    __4: (AirPos, Instruction<'input>, AirPos),
     __5: (AirPos, Token<'input>, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     let __start0 = __4.2;
     let __end0 = __5.0;
@@ -9128,10 +9128,10 @@ fn __action157<
     __1: (AirPos, Token<'input>, AirPos),
     __2: (AirPos, (&'input str, AirPos), AirPos),
     __3: (AirPos, (&'input str, AirPos), AirPos),
-    __4: (AirPos, Box<Instruction<'input>>, AirPos),
-    __5: (AirPos, Box<Instruction<'input>>, AirPos),
+    __4: (AirPos, Instruction<'input>, AirPos),
+    __5: (AirPos, Instruction<'input>, AirPos),
     __6: (AirPos, Token<'input>, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     let __start0 = __5.0;
     let __end0 = __5.2;
@@ -9170,9 +9170,9 @@ fn __action158<
     __1: (AirPos, Token<'input>, AirPos),
     __2: (AirPos, (&'input str, AirPos), AirPos),
     __3: (AirPos, (&'input str, AirPos), AirPos),
-    __4: (AirPos, Box<Instruction<'input>>, AirPos),
+    __4: (AirPos, Instruction<'input>, AirPos),
     __5: (AirPos, Token<'input>, AirPos),
-) -> Box<Instruction<'input>>
+) -> Instruction<'input>
 {
     let __start0 = __4.2;
     let __end0 = __5.0;

--- a/crates/air-lib/air-parser/src/parser/air_parser.rs
+++ b/crates/air-lib/air-parser/src/parser/air_parser.rs
@@ -34,7 +34,7 @@ thread_local!(static PARSER: AIRParser = AIRParser::new());
 
 /// Parse AIR `source_code` to `Box<Instruction>`
 #[tracing::instrument(skip_all)]
-pub fn parse(air_script: &str) -> Result<Box<Instruction<'_>>, String> {
+pub fn parse(air_script: &str) -> Result<Instruction<'_>, String> {
     let mut files = SimpleFiles::new();
     let file_id = files.add("script.air", air_script);
 

--- a/crates/air-lib/air-parser/src/parser/tests/call.rs
+++ b/crates/air-lib/air-parser/src/parser/tests/call.rs
@@ -572,18 +572,21 @@ fn seq_with_empty_and_dash() {
                 CallOutputValue::Scalar(Scalar::new("module", 409.into())),
             ),
             seq(
-                Instruction::Call(Call {
-                    triplet: Triplet {
-                        peer_id: ResolvableToPeerIdVariable::Literal("A"),
-                        service_id: ResolvableToStringVariable::Literal("add_blueprint"),
-                        function_name: ResolvableToStringVariable::Literal(""),
-                    },
-                    args: Rc::new(vec![ImmutableValue::Variable(ImmutableVariable::scalar(
-                        "blueprint",
-                        490.into(),
-                    ))]),
-                    output: CallOutputValue::Scalar(Scalar::new("blueprint_id", 501.into())),
-                }),
+                Instruction::Call(
+                    Call {
+                        triplet: Triplet {
+                            peer_id: ResolvableToPeerIdVariable::Literal("A"),
+                            service_id: ResolvableToStringVariable::Literal("add_blueprint"),
+                            function_name: ResolvableToStringVariable::Literal(""),
+                        },
+                        args: Rc::new(vec![ImmutableValue::Variable(ImmutableVariable::scalar(
+                            "blueprint",
+                            490.into(),
+                        ))]),
+                        output: CallOutputValue::Scalar(Scalar::new("blueprint_id", 501.into())),
+                    }
+                    .into(),
+                ),
                 seq(
                     call(
                         ResolvableToPeerIdVariable::Literal("A"),

--- a/crates/air-lib/air-parser/src/parser/tests/dsl.rs
+++ b/crates/air-lib/air-parser/src/parser/tests/dsl.rs
@@ -30,23 +30,26 @@ pub(super) fn call<'i>(
         function_name,
     };
 
-    Instruction::Call(Call {
-        triplet,
-        args,
-        output,
-    })
+    Instruction::Call(
+        Call {
+            triplet,
+            args,
+            output,
+        }
+        .into(),
+    )
 }
 
 pub(super) fn seq<'i>(l: Instruction<'i>, r: Instruction<'i>) -> Instruction<'i> {
-    Instruction::Seq(Seq(Box::new(l), Box::new(r)))
+    Instruction::Seq(Seq(l, r).into())
 }
 
 pub(super) fn par<'i>(l: Instruction<'i>, r: Instruction<'i>) -> Instruction<'i> {
-    Instruction::Par(Par(Box::new(l), Box::new(r)))
+    Instruction::Par(Par(l, r).into())
 }
 
 pub(super) fn xor<'i>(l: Instruction<'i>, r: Instruction<'i>) -> Instruction<'i> {
-    Instruction::Xor(Xor(Box::new(l), Box::new(r)))
+    Instruction::Xor(Xor(l, r).into())
 }
 
 pub(super) fn seqnn() -> Instruction<'static> {
@@ -58,11 +61,14 @@ pub(super) fn new<'i>(
     instruction: Instruction<'i>,
     span: Span,
 ) -> Instruction<'i> {
-    Instruction::New(New {
-        argument,
-        instruction: Box::new(instruction),
-        span,
-    })
+    Instruction::New(
+        New {
+            argument,
+            instruction,
+            span,
+        }
+        .into(),
+    )
 }
 
 pub(super) fn never() -> Instruction<'static> {
@@ -74,26 +80,29 @@ pub(super) fn null() -> Instruction<'static> {
 }
 
 pub(super) fn fail_scalar(scalar: Scalar) -> Instruction<'_> {
-    Instruction::Fail(Fail::Scalar(scalar))
+    Instruction::Fail(Fail::Scalar(scalar).into())
 }
 
 pub(super) fn fail_scalar_wl(scalar: ScalarWithLambda) -> Instruction<'_> {
-    Instruction::Fail(Fail::ScalarWithLambda(scalar))
+    Instruction::Fail(Fail::ScalarWithLambda(scalar).into())
 }
 
 pub(super) fn fail_literals(ret_code: i64, error_message: &str) -> Instruction<'_> {
-    Instruction::Fail(Fail::Literal {
-        ret_code,
-        error_message,
-    })
+    Instruction::Fail(
+        Fail::Literal {
+            ret_code,
+            error_message,
+        }
+        .into(),
+    )
 }
 
 pub(super) fn fail_last_error() -> Instruction<'static> {
-    Instruction::Fail(Fail::LastError)
+    Instruction::Fail(Fail::LastError.into())
 }
 
 pub(super) fn fail_error() -> Instruction<'static> {
-    Instruction::Fail(Fail::Error)
+    Instruction::Fail(Fail::Error.into())
 }
 
 pub(super) fn fold_scalar_variable<'i>(
@@ -103,13 +112,16 @@ pub(super) fn fold_scalar_variable<'i>(
     last_instruction: Option<Instruction<'i>>,
     span: Span,
 ) -> Instruction<'i> {
-    Instruction::FoldScalar(FoldScalar {
-        iterable: FoldScalarIterable::Scalar(scalar),
-        iterator,
-        instruction: Rc::new(instruction),
-        last_instruction: last_instruction.map(Rc::new),
-        span,
-    })
+    Instruction::FoldScalar(
+        FoldScalar {
+            iterable: FoldScalarIterable::Scalar(scalar),
+            iterator,
+            instruction: Rc::new(instruction),
+            last_instruction: last_instruction.map(Rc::new),
+            span,
+        }
+        .into(),
+    )
 }
 
 pub(super) fn fold_scalar_variable_wl<'i>(
@@ -119,13 +131,16 @@ pub(super) fn fold_scalar_variable_wl<'i>(
     last_instruction: Option<Instruction<'i>>,
     span: Span,
 ) -> Instruction<'i> {
-    Instruction::FoldScalar(FoldScalar {
-        iterable: FoldScalarIterable::ScalarWithLambda(scalar),
-        iterator,
-        instruction: Rc::new(instruction),
-        last_instruction: last_instruction.map(Rc::new),
-        span,
-    })
+    Instruction::FoldScalar(
+        FoldScalar {
+            iterable: FoldScalarIterable::ScalarWithLambda(scalar),
+            iterator,
+            instruction: Rc::new(instruction),
+            last_instruction: last_instruction.map(Rc::new),
+            span,
+        }
+        .into(),
+    )
 }
 
 pub(super) fn fold_scalar_canon_stream<'i>(
@@ -135,13 +150,16 @@ pub(super) fn fold_scalar_canon_stream<'i>(
     last_instruction: Option<Instruction<'i>>,
     span: Span,
 ) -> Instruction<'i> {
-    Instruction::FoldScalar(FoldScalar {
-        iterable: FoldScalarIterable::CanonStream(canon_stream),
-        iterator,
-        instruction: Rc::new(instruction),
-        last_instruction: last_instruction.map(Rc::new),
-        span,
-    })
+    Instruction::FoldScalar(
+        FoldScalar {
+            iterable: FoldScalarIterable::CanonStream(canon_stream),
+            iterator,
+            instruction: Rc::new(instruction),
+            last_instruction: last_instruction.map(Rc::new),
+            span,
+        }
+        .into(),
+    )
 }
 
 pub(super) fn fold_scalar_canon_stream_map<'i>(
@@ -151,13 +169,16 @@ pub(super) fn fold_scalar_canon_stream_map<'i>(
     last_instruction: Option<Instruction<'i>>,
     span: Span,
 ) -> Instruction<'i> {
-    Instruction::FoldScalar(FoldScalar {
-        iterable: FoldScalarIterable::CanonStreamMap(canon_stream_map),
-        iterator,
-        instruction: Rc::new(instruction),
-        last_instruction: last_instruction.map(Rc::new),
-        span,
-    })
+    Instruction::FoldScalar(
+        FoldScalar {
+            iterable: FoldScalarIterable::CanonStreamMap(canon_stream_map),
+            iterator,
+            instruction: Rc::new(instruction),
+            last_instruction: last_instruction.map(Rc::new),
+            span,
+        }
+        .into(),
+    )
 }
 
 pub(super) fn fold_scalar_empty_array<'i>(
@@ -166,13 +187,16 @@ pub(super) fn fold_scalar_empty_array<'i>(
     last_instruction: Option<Instruction<'i>>,
     span: Span,
 ) -> Instruction<'i> {
-    Instruction::FoldScalar(FoldScalar {
-        iterable: FoldScalarIterable::EmptyArray,
-        iterator,
-        instruction: Rc::new(instruction),
-        last_instruction: last_instruction.map(Rc::new),
-        span,
-    })
+    Instruction::FoldScalar(
+        FoldScalar {
+            iterable: FoldScalarIterable::EmptyArray,
+            iterator,
+            instruction: Rc::new(instruction),
+            last_instruction: last_instruction.map(Rc::new),
+            span,
+        }
+        .into(),
+    )
 }
 
 pub(super) fn fold_stream<'i>(
@@ -182,13 +206,16 @@ pub(super) fn fold_stream<'i>(
     last_instruction: Option<Instruction<'i>>,
     span: Span,
 ) -> Instruction<'i> {
-    Instruction::FoldStream(FoldStream {
-        iterable,
-        iterator,
-        instruction: Rc::new(instruction),
-        last_instruction: last_instruction.map(Rc::new),
-        span,
-    })
+    Instruction::FoldStream(
+        FoldStream {
+            iterable,
+            iterator,
+            instruction: Rc::new(instruction),
+            last_instruction: last_instruction.map(Rc::new),
+            span,
+        }
+        .into(),
+    )
 }
 
 pub(super) fn match_<'i>(
@@ -196,11 +223,14 @@ pub(super) fn match_<'i>(
     right_value: ImmutableValue<'i>,
     instruction: Instruction<'i>,
 ) -> Instruction<'i> {
-    Instruction::Match(Match {
-        left_value,
-        right_value,
-        instruction: Box::new(instruction),
-    })
+    Instruction::Match(
+        Match {
+            left_value,
+            right_value,
+            instruction,
+        }
+        .into(),
+    )
 }
 
 pub(super) fn mismatch<'i>(
@@ -208,15 +238,18 @@ pub(super) fn mismatch<'i>(
     right_value: ImmutableValue<'i>,
     instruction: Instruction<'i>,
 ) -> Instruction<'i> {
-    Instruction::MisMatch(MisMatch {
-        left_value,
-        right_value,
-        instruction: Box::new(instruction),
-    })
+    Instruction::MisMatch(
+        MisMatch {
+            left_value,
+            right_value,
+            instruction,
+        }
+        .into(),
+    )
 }
 
 pub(super) fn ap<'i>(argument: ApArgument<'i>, result: ApResult<'i>) -> Instruction<'i> {
-    Instruction::Ap(Ap { argument, result })
+    Instruction::Ap(Ap { argument, result }.into())
 }
 
 pub(super) fn ap_with_map<'i>(
@@ -224,11 +257,14 @@ pub(super) fn ap_with_map<'i>(
     argument: ApArgument<'i>,
     result: StreamMap<'i>,
 ) -> Instruction<'i> {
-    Instruction::ApMap(ApMap {
-        key: key,
-        value: argument,
-        map: result,
-    })
+    Instruction::ApMap(
+        ApMap {
+            key,
+            value: argument,
+            map: result,
+        }
+        .into(),
+    )
 }
 
 pub(super) fn canon<'i>(
@@ -236,11 +272,14 @@ pub(super) fn canon<'i>(
     stream: Stream<'i>,
     canon_stream: CanonStream<'i>,
 ) -> Instruction<'i> {
-    Instruction::Canon(Canon {
-        peer_id: peer_pk,
-        stream,
-        canon_stream,
-    })
+    Instruction::Canon(
+        Canon {
+            peer_id: peer_pk,
+            stream,
+            canon_stream,
+        }
+        .into(),
+    )
 }
 
 pub(super) fn canon_stream_map_scalar<'i>(
@@ -248,11 +287,14 @@ pub(super) fn canon_stream_map_scalar<'i>(
     stream_map: StreamMap<'i>,
     scalar: Scalar<'i>,
 ) -> Instruction<'i> {
-    Instruction::CanonStreamMapScalar(CanonStreamMapScalar {
-        peer_id: peer_pk,
-        stream_map,
-        scalar,
-    })
+    Instruction::CanonStreamMapScalar(
+        CanonStreamMapScalar {
+            peer_id: peer_pk,
+            stream_map,
+            scalar,
+        }
+        .into(),
+    )
 }
 
 pub(super) fn canon_stream_map_canon_map<'i>(
@@ -260,11 +302,14 @@ pub(super) fn canon_stream_map_canon_map<'i>(
     stream_map: StreamMap<'i>,
     canon_stream_map: CanonStreamMap<'i>,
 ) -> Instruction<'i> {
-    Instruction::CanonMap(CanonMap {
-        peer_id: peer_pk,
-        stream_map,
-        canon_stream_map,
-    })
+    Instruction::CanonMap(
+        CanonMap {
+            peer_id: peer_pk,
+            stream_map,
+            canon_stream_map,
+        }
+        .into(),
+    )
 }
 
 pub(super) fn binary_instruction<'i, 'b>(

--- a/crates/air-lib/air-parser/src/parser/tests/mod.rs
+++ b/crates/air-lib/air-parser/src/parser/tests/mod.rs
@@ -33,7 +33,7 @@ use crate::parser::AIRParser;
 thread_local!(static TEST_PARSER: AIRParser = AIRParser::new());
 
 fn parse(source_code: &str) -> Instruction {
-    *TEST_PARSER.with(|parser| {
+    TEST_PARSER.with(|parser| {
         let mut errors = Vec::new();
         let lexer = crate::parser::AIRLexer::new(source_code);
         let mut validator = crate::parser::VariableValidator::new();

--- a/crates/beautifier/src/beautifier.rs
+++ b/crates/beautifier/src/beautifier.rs
@@ -109,15 +109,12 @@ impl<W: io::Write> Beautifier<W> {
     /// Emit beautified code for the `air_script`.
     pub fn beautify(&mut self, air_script: &str) -> Result<(), BeautifyError> {
         let tree = air_parser::parse(air_script).map_err(BeautifyError::Parse)?;
-        self.beautify_ast(tree)
+        self.beautify_ast(&tree)
     }
 
     /// Emit beautified code for the `ast`.
-    pub fn beautify_ast<'i>(
-        &mut self,
-        ast: impl AsRef<ast::Instruction<'i>>,
-    ) -> Result<(), BeautifyError> {
-        Ok(self.beautify_walker(ast.as_ref(), 0)?)
+    pub fn beautify_ast(&mut self, ast: &ast::Instruction<'_>) -> Result<(), BeautifyError> {
+        Ok(self.beautify_walker(ast, 0)?)
     }
 
     fn beautify_walker(&mut self, node: &ast::Instruction<'_>, indent: usize) -> io::Result<()> {

--- a/junk/gen-bench-data/gen_benchmark_data.sh
+++ b/junk/gen-bench-data/gen_benchmark_data.sh
@@ -25,6 +25,7 @@ for bench in multiple-cids10 \
             call-requests500 \
             call-results500 \
             parser-10000-100 \
+            parser-calls-10000-100 \
             null \
             ;
 do

--- a/junk/gen-bench-data/src/main.rs
+++ b/junk/gen-bench-data/src/main.rs
@@ -53,8 +53,10 @@ enum Bench {
     BigValuesData,
     CallRequests500,
     CallResults500,
-    #[command(name="parser-10000-100")]
+    #[command(name = "parser-10000-100")]
     Parser10000_100,
+    #[command(name = "parser-calls-10000-100")]
+    ParserCalls10000_100,
     Null,
 }
 
@@ -85,6 +87,7 @@ fn main() {
         Bench::CallRequests500 => calls::call_requests(500),
         Bench::CallResults500 => calls::call_results(500),
         Bench::Parser10000_100 => parser_10000_100(),
+        Bench::ParserCalls10000_100 => parser_calls(10000, 100),
         Bench::Null => null(),
     };
 
@@ -705,6 +708,55 @@ fn parser_10000_100() -> Data {
         keypair: bs58::encode(keypair.as_inner().to_vec()).into_string(),
         params_json: hashmap! {
             "comment".to_owned() => "long air script with lot of variable assignments".to_owned(),
+            "particle-id".to_owned() => particle_id.to_owned(),
+            "current-peer-id".to_owned() => peer_id.clone(),
+            "init-peer-id".to_owned() => peer_id,
+        },
+    }
+}
+
+fn parser_calls(calls: usize, vars: usize) -> Data {
+    let (keypair, peer_id) = derive_dummy_keypair("init_peer_id");
+    let particle_id = "particle_id";
+
+    let vars = (0..vars).map(|n| format!("var{}", n)).collect_vec();
+    let init_var = vars[0].clone();
+    let statements = vars
+        .iter()
+        .cycle()
+        .take(calls)
+        .tuple_windows()
+        .map(|(a, b)| format!(r#"(call {a} ("serv" "func") [] {b})"#))
+        .collect_vec();
+
+    fn build_tree(statements: &[String]) -> String {
+        assert!(!statements.is_empty());
+        if statements.len() == 1 {
+            statements[0].clone()
+        } else {
+            let mid = statements.len() / 2;
+            format!(
+                "(seq {} {})",
+                build_tree(&statements[..mid]),
+                build_tree(&statements[mid..])
+            )
+        }
+    }
+
+    let tree = build_tree(&statements);
+    let air = format!(
+        r#"(seq (call "peer" ("serv" "func") [] {}) {})"#,
+        init_var, tree
+    );
+
+    Data {
+        air,
+        prev_data: vec![],
+        cur_data: vec![],
+        call_results: None,
+        keypair: bs58::encode(keypair.as_inner().to_vec()).into_string(),
+        params_json: hashmap! {
+            "comment".to_owned() => "multiple calls parser benchmark".to_owned(),
             "particle-id".to_owned() => particle_id.to_owned(),
             "current-peer-id".to_owned() => peer_id.clone(),
             "init-peer-id".to_owned() => peer_id,


### PR DESCRIPTION
Instead of being boxed for each node, the `Instruction` type contains a boxed variable-size elements.  Thus `Instruction` is quite lean, and the allocator deals with variable-sized elements.

Total number of allocations is more or less same, but less space is wasted for unused memory: previously the Instruction's size was 112 bytes in WASM, now it is 16.

It reduces memory consumption on large AIR scripts (heap size decreased from 7.7MiB to 4.625MiB in parser-10000-100, and for the new parser-calls-10000-100 benchmark, it decreased from 5.115MiB to 4.375MiB).

This is a breaking change as the API changes (though the code that navigates the parsed tree generally should work as is).