### PR TITLE
feat(avm-client): implement pluggable formats in JS

### DIFF
--- a/avm/client/package-lock.json
+++ b/avm/client/package-lock.json
@@ -8,8 +8,139 @@
             "name": "@fluencelabs/avm",
             "version": "0.55.0",
             "license": "Apache 2.0",
+            "dependencies": {
+                "msgpackr": "^1.10.0",
+                "multicodec": "^3.2.1"
+            },
             "devDependencies": {
                 "typescript": "5.2.2"
+            }
+        },
+        "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.2.tgz",
+            "integrity": "sha512-9bfjwDxIDWmmOKusUcqdS4Rw+SETlp9Dy39Xui9BEGEk19dDwH0jhipwFzEff/pFg95NKymc6TOTbRKcWeRqyQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.2.tgz",
+            "integrity": "sha512-lwriRAHm1Yg4iDf23Oxm9n/t5Zpw1lVnxYU3HnJPTi2lJRkKTrps1KVgvL6m7WvmhYVt/FIsssWay+k45QHeuw==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.2.tgz",
+            "integrity": "sha512-MOI9Dlfrpi2Cuc7i5dXdxPbFIgbDBGgKR5F2yWEa6FVEtSWncfVNKW5AKjImAQ6CZlBK9tympdsZJ2xThBiWWA==",
+            "cpu": [
+                "arm"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.2.tgz",
+            "integrity": "sha512-FU20Bo66/f7He9Fp9sP2zaJ1Q8L9uLPZQDub/WlUip78JlPeMbVL8546HbZfcW9LNciEXc8d+tThSJjSC+tmsg==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.2.tgz",
+            "integrity": "sha512-gsWNDCklNy7Ajk0vBBf9jEx04RUxuDQfBse918Ww+Qb9HCPoGzS+XJTLe96iN3BVK7grnLiYghP/M4L8VsaHeA==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.2.tgz",
+            "integrity": "sha512-O+6Gs8UeDbyFpbSh2CPEz/UOrrdWPTBYNblZK5CxxLisYt4kGX3Sc+czffFonyjiGSq3jWLwJS/CCJc7tBr4sQ==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/msgpackr": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.10.0.tgz",
+            "integrity": "sha512-rVQ5YAQDoZKZLX+h8tNq7FiHrPJoeGHViz3U4wIcykhAEpwF/nH2Vbk8dQxmpX5JavkI8C7pt4bnkJ02ZmRoUw==",
+            "optionalDependencies": {
+                "msgpackr-extract": "^3.0.2"
+            }
+        },
+        "node_modules/msgpackr-extract": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.2.tgz",
+            "integrity": "sha512-SdzXp4kD/Qf8agZ9+iTu6eql0m3kWm1A2y1hkpTeVNENutaB0BwHlSvAIaMxwntmRUAUjon2V4L8Z/njd0Ct8A==",
+            "hasInstallScript": true,
+            "optional": true,
+            "dependencies": {
+                "node-gyp-build-optional-packages": "5.0.7"
+            },
+            "bin": {
+                "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+            },
+            "optionalDependencies": {
+                "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.2",
+                "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.2",
+                "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.2",
+                "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.2",
+                "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.2",
+                "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.2"
+            }
+        },
+        "node_modules/multicodec": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-3.2.1.tgz",
+            "integrity": "sha512-+expTPftro8VAW8kfvcuNNNBgb9gPeNYV9dn+z1kJRWF2vih+/S79f2RVeIwmrJBUJ6NT9IUPWnZDQvegEh5pw==",
+            "deprecated": "This module has been superseded by the multiformats module",
+            "dependencies": {
+                "uint8arrays": "^3.0.0",
+                "varint": "^6.0.0"
+            }
+        },
+        "node_modules/multiformats": {
+            "version": "9.9.0",
+            "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+            "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+        },
+        "node_modules/node-gyp-build-optional-packages": {
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.7.tgz",
+            "integrity": "sha512-YlCCc6Wffkx0kHkmam79GKvDQ6x+QZkMjFGrIMxgFNILFvGSbCp2fCBC55pGTT9gVaz8Na5CLmxt/urtzRv36w==",
+            "optional": true,
+            "bin": {
+                "node-gyp-build-optional-packages": "bin.js",
+                "node-gyp-build-optional-packages-optional": "optional.js",
+                "node-gyp-build-optional-packages-test": "build-test.js"
             }
         },
         "node_modules/typescript": {
@@ -24,14 +155,119 @@
             "engines": {
                 "node": ">=14.17"
             }
+        },
+        "node_modules/uint8arrays": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+            "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+            "dependencies": {
+                "multiformats": "^9.4.2"
+            }
+        },
+        "node_modules/varint": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+            "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
         }
     },
     "dependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.2.tgz",
+            "integrity": "sha512-9bfjwDxIDWmmOKusUcqdS4Rw+SETlp9Dy39Xui9BEGEk19dDwH0jhipwFzEff/pFg95NKymc6TOTbRKcWeRqyQ==",
+            "optional": true
+        },
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.2.tgz",
+            "integrity": "sha512-lwriRAHm1Yg4iDf23Oxm9n/t5Zpw1lVnxYU3HnJPTi2lJRkKTrps1KVgvL6m7WvmhYVt/FIsssWay+k45QHeuw==",
+            "optional": true
+        },
+        "@msgpackr-extract/msgpackr-extract-linux-arm": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.2.tgz",
+            "integrity": "sha512-MOI9Dlfrpi2Cuc7i5dXdxPbFIgbDBGgKR5F2yWEa6FVEtSWncfVNKW5AKjImAQ6CZlBK9tympdsZJ2xThBiWWA==",
+            "optional": true
+        },
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.2.tgz",
+            "integrity": "sha512-FU20Bo66/f7He9Fp9sP2zaJ1Q8L9uLPZQDub/WlUip78JlPeMbVL8546HbZfcW9LNciEXc8d+tThSJjSC+tmsg==",
+            "optional": true
+        },
+        "@msgpackr-extract/msgpackr-extract-linux-x64": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.2.tgz",
+            "integrity": "sha512-gsWNDCklNy7Ajk0vBBf9jEx04RUxuDQfBse918Ww+Qb9HCPoGzS+XJTLe96iN3BVK7grnLiYghP/M4L8VsaHeA==",
+            "optional": true
+        },
+        "@msgpackr-extract/msgpackr-extract-win32-x64": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.2.tgz",
+            "integrity": "sha512-O+6Gs8UeDbyFpbSh2CPEz/UOrrdWPTBYNblZK5CxxLisYt4kGX3Sc+czffFonyjiGSq3jWLwJS/CCJc7tBr4sQ==",
+            "optional": true
+        },
+        "msgpackr": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.10.0.tgz",
+            "integrity": "sha512-rVQ5YAQDoZKZLX+h8tNq7FiHrPJoeGHViz3U4wIcykhAEpwF/nH2Vbk8dQxmpX5JavkI8C7pt4bnkJ02ZmRoUw==",
+            "requires": {
+                "msgpackr-extract": "^3.0.2"
+            }
+        },
+        "msgpackr-extract": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.2.tgz",
+            "integrity": "sha512-SdzXp4kD/Qf8agZ9+iTu6eql0m3kWm1A2y1hkpTeVNENutaB0BwHlSvAIaMxwntmRUAUjon2V4L8Z/njd0Ct8A==",
+            "optional": true,
+            "requires": {
+                "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.2",
+                "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.2",
+                "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.2",
+                "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.2",
+                "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.2",
+                "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.2",
+                "node-gyp-build-optional-packages": "5.0.7"
+            }
+        },
+        "multicodec": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-3.2.1.tgz",
+            "integrity": "sha512-+expTPftro8VAW8kfvcuNNNBgb9gPeNYV9dn+z1kJRWF2vih+/S79f2RVeIwmrJBUJ6NT9IUPWnZDQvegEh5pw==",
+            "requires": {
+                "uint8arrays": "^3.0.0",
+                "varint": "^6.0.0"
+            }
+        },
+        "multiformats": {
+            "version": "9.9.0",
+            "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+            "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+        },
+        "node-gyp-build-optional-packages": {
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.7.tgz",
+            "integrity": "sha512-YlCCc6Wffkx0kHkmam79GKvDQ6x+QZkMjFGrIMxgFNILFvGSbCp2fCBC55pGTT9gVaz8Na5CLmxt/urtzRv36w==",
+            "optional": true
+        },
         "typescript": {
             "version": "5.2.2",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
             "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
             "dev": true
+        },
+        "uint8arrays": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+            "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+            "requires": {
+                "multiformats": "^9.4.2"
+            }
+        },
+        "varint": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+            "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
         }
     }
 }

--- a/avm/client/package-lock.json
+++ b/avm/client/package-lock.json
@@ -9,112 +9,59 @@
             "version": "0.55.0",
             "license": "Apache 2.0",
             "dependencies": {
-                "msgpackr": "^1.10.0",
+                "msgpack-lite": "^0.1.26",
                 "multicodec": "^3.2.1"
             },
             "devDependencies": {
                 "typescript": "5.2.2"
             }
         },
-        "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.2.tgz",
-            "integrity": "sha512-9bfjwDxIDWmmOKusUcqdS4Rw+SETlp9Dy39Xui9BEGEk19dDwH0jhipwFzEff/pFg95NKymc6TOTbRKcWeRqyQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "optional": true,
-            "os": [
-                "darwin"
+        "node_modules/event-lite": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/event-lite/-/event-lite-0.1.3.tgz",
+            "integrity": "sha512-8qz9nOz5VeD2z96elrEKD2U433+L3DWdUdDkOINLGOJvx1GsMBbMn0aCeu28y8/e85A6mCigBiFlYMnTBEGlSw=="
+        },
+        "node_modules/ieee754": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
             ]
         },
-        "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.2.tgz",
-            "integrity": "sha512-lwriRAHm1Yg4iDf23Oxm9n/t5Zpw1lVnxYU3HnJPTi2lJRkKTrps1KVgvL6m7WvmhYVt/FIsssWay+k45QHeuw==",
-            "cpu": [
-                "x64"
-            ],
-            "optional": true,
-            "os": [
-                "darwin"
-            ]
+        "node_modules/int64-buffer": {
+            "version": "0.1.10",
+            "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-0.1.10.tgz",
+            "integrity": "sha512-v7cSY1J8ydZ0GyjUHqF+1bshJ6cnEVLo9EnjB8p+4HDRPZc9N5jjmvUV7NvEsqQOKyH0pmIBFWXVQbiS0+OBbA=="
         },
-        "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.2.tgz",
-            "integrity": "sha512-MOI9Dlfrpi2Cuc7i5dXdxPbFIgbDBGgKR5F2yWEa6FVEtSWncfVNKW5AKjImAQ6CZlBK9tympdsZJ2xThBiWWA==",
-            "cpu": [
-                "arm"
-            ],
-            "optional": true,
-            "os": [
-                "linux"
-            ]
+        "node_modules/isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
         },
-        "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.2.tgz",
-            "integrity": "sha512-FU20Bo66/f7He9Fp9sP2zaJ1Q8L9uLPZQDub/WlUip78JlPeMbVL8546HbZfcW9LNciEXc8d+tThSJjSC+tmsg==",
-            "cpu": [
-                "arm64"
-            ],
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.2.tgz",
-            "integrity": "sha512-gsWNDCklNy7Ajk0vBBf9jEx04RUxuDQfBse918Ww+Qb9HCPoGzS+XJTLe96iN3BVK7grnLiYghP/M4L8VsaHeA==",
-            "cpu": [
-                "x64"
-            ],
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.2.tgz",
-            "integrity": "sha512-O+6Gs8UeDbyFpbSh2CPEz/UOrrdWPTBYNblZK5CxxLisYt4kGX3Sc+czffFonyjiGSq3jWLwJS/CCJc7tBr4sQ==",
-            "cpu": [
-                "x64"
-            ],
-            "optional": true,
-            "os": [
-                "win32"
-            ]
-        },
-        "node_modules/msgpackr": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.10.0.tgz",
-            "integrity": "sha512-rVQ5YAQDoZKZLX+h8tNq7FiHrPJoeGHViz3U4wIcykhAEpwF/nH2Vbk8dQxmpX5JavkI8C7pt4bnkJ02ZmRoUw==",
-            "optionalDependencies": {
-                "msgpackr-extract": "^3.0.2"
-            }
-        },
-        "node_modules/msgpackr-extract": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.2.tgz",
-            "integrity": "sha512-SdzXp4kD/Qf8agZ9+iTu6eql0m3kWm1A2y1hkpTeVNENutaB0BwHlSvAIaMxwntmRUAUjon2V4L8Z/njd0Ct8A==",
-            "hasInstallScript": true,
-            "optional": true,
+        "node_modules/msgpack-lite": {
+            "version": "0.1.26",
+            "resolved": "https://registry.npmjs.org/msgpack-lite/-/msgpack-lite-0.1.26.tgz",
+            "integrity": "sha512-SZ2IxeqZ1oRFGo0xFGbvBJWMp3yLIY9rlIJyxy8CGrwZn1f0ZK4r6jV/AM1r0FZMDUkWkglOk/eeKIL9g77Nxw==",
             "dependencies": {
-                "node-gyp-build-optional-packages": "5.0.7"
+                "event-lite": "^0.1.1",
+                "ieee754": "^1.1.8",
+                "int64-buffer": "^0.1.9",
+                "isarray": "^1.0.0"
             },
             "bin": {
-                "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
-            },
-            "optionalDependencies": {
-                "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.2",
-                "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.2",
-                "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.2",
-                "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.2",
-                "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.2",
-                "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.2"
+                "msgpack": "bin/msgpack"
             }
         },
         "node_modules/multicodec": {
@@ -131,17 +78,6 @@
             "version": "9.9.0",
             "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
             "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
-        },
-        "node_modules/node-gyp-build-optional-packages": {
-            "version": "5.0.7",
-            "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.7.tgz",
-            "integrity": "sha512-YlCCc6Wffkx0kHkmam79GKvDQ6x+QZkMjFGrIMxgFNILFvGSbCp2fCBC55pGTT9gVaz8Na5CLmxt/urtzRv36w==",
-            "optional": true,
-            "bin": {
-                "node-gyp-build-optional-packages": "bin.js",
-                "node-gyp-build-optional-packages-optional": "optional.js",
-                "node-gyp-build-optional-packages-test": "build-test.js"
-            }
         },
         "node_modules/typescript": {
             "version": "5.2.2",
@@ -171,63 +107,35 @@
         }
     },
     "dependencies": {
-        "@msgpackr-extract/msgpackr-extract-darwin-arm64": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.2.tgz",
-            "integrity": "sha512-9bfjwDxIDWmmOKusUcqdS4Rw+SETlp9Dy39Xui9BEGEk19dDwH0jhipwFzEff/pFg95NKymc6TOTbRKcWeRqyQ==",
-            "optional": true
+        "event-lite": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/event-lite/-/event-lite-0.1.3.tgz",
+            "integrity": "sha512-8qz9nOz5VeD2z96elrEKD2U433+L3DWdUdDkOINLGOJvx1GsMBbMn0aCeu28y8/e85A6mCigBiFlYMnTBEGlSw=="
         },
-        "@msgpackr-extract/msgpackr-extract-darwin-x64": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.2.tgz",
-            "integrity": "sha512-lwriRAHm1Yg4iDf23Oxm9n/t5Zpw1lVnxYU3HnJPTi2lJRkKTrps1KVgvL6m7WvmhYVt/FIsssWay+k45QHeuw==",
-            "optional": true
+        "ieee754": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
         },
-        "@msgpackr-extract/msgpackr-extract-linux-arm": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.2.tgz",
-            "integrity": "sha512-MOI9Dlfrpi2Cuc7i5dXdxPbFIgbDBGgKR5F2yWEa6FVEtSWncfVNKW5AKjImAQ6CZlBK9tympdsZJ2xThBiWWA==",
-            "optional": true
+        "int64-buffer": {
+            "version": "0.1.10",
+            "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-0.1.10.tgz",
+            "integrity": "sha512-v7cSY1J8ydZ0GyjUHqF+1bshJ6cnEVLo9EnjB8p+4HDRPZc9N5jjmvUV7NvEsqQOKyH0pmIBFWXVQbiS0+OBbA=="
         },
-        "@msgpackr-extract/msgpackr-extract-linux-arm64": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.2.tgz",
-            "integrity": "sha512-FU20Bo66/f7He9Fp9sP2zaJ1Q8L9uLPZQDub/WlUip78JlPeMbVL8546HbZfcW9LNciEXc8d+tThSJjSC+tmsg==",
-            "optional": true
+        "isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
         },
-        "@msgpackr-extract/msgpackr-extract-linux-x64": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.2.tgz",
-            "integrity": "sha512-gsWNDCklNy7Ajk0vBBf9jEx04RUxuDQfBse918Ww+Qb9HCPoGzS+XJTLe96iN3BVK7grnLiYghP/M4L8VsaHeA==",
-            "optional": true
-        },
-        "@msgpackr-extract/msgpackr-extract-win32-x64": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.2.tgz",
-            "integrity": "sha512-O+6Gs8UeDbyFpbSh2CPEz/UOrrdWPTBYNblZK5CxxLisYt4kGX3Sc+czffFonyjiGSq3jWLwJS/CCJc7tBr4sQ==",
-            "optional": true
-        },
-        "msgpackr": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.10.0.tgz",
-            "integrity": "sha512-rVQ5YAQDoZKZLX+h8tNq7FiHrPJoeGHViz3U4wIcykhAEpwF/nH2Vbk8dQxmpX5JavkI8C7pt4bnkJ02ZmRoUw==",
+        "msgpack-lite": {
+            "version": "0.1.26",
+            "resolved": "https://registry.npmjs.org/msgpack-lite/-/msgpack-lite-0.1.26.tgz",
+            "integrity": "sha512-SZ2IxeqZ1oRFGo0xFGbvBJWMp3yLIY9rlIJyxy8CGrwZn1f0ZK4r6jV/AM1r0FZMDUkWkglOk/eeKIL9g77Nxw==",
             "requires": {
-                "msgpackr-extract": "^3.0.2"
-            }
-        },
-        "msgpackr-extract": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.2.tgz",
-            "integrity": "sha512-SdzXp4kD/Qf8agZ9+iTu6eql0m3kWm1A2y1hkpTeVNENutaB0BwHlSvAIaMxwntmRUAUjon2V4L8Z/njd0Ct8A==",
-            "optional": true,
-            "requires": {
-                "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.2",
-                "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.2",
-                "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.2",
-                "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.2",
-                "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.2",
-                "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.2",
-                "node-gyp-build-optional-packages": "5.0.7"
+                "event-lite": "^0.1.1",
+                "ieee754": "^1.1.8",
+                "int64-buffer": "^0.1.9",
+                "isarray": "^1.0.0"
             }
         },
         "multicodec": {
@@ -243,12 +151,6 @@
             "version": "9.9.0",
             "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
             "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
-        },
-        "node-gyp-build-optional-packages": {
-            "version": "5.0.7",
-            "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.7.tgz",
-            "integrity": "sha512-YlCCc6Wffkx0kHkmam79GKvDQ6x+QZkMjFGrIMxgFNILFvGSbCp2fCBC55pGTT9gVaz8Na5CLmxt/urtzRv36w==",
-            "optional": true
         },
         "typescript": {
             "version": "5.2.2",

--- a/avm/client/package.json
+++ b/avm/client/package.json
@@ -13,7 +13,10 @@
         "build": "tsc && ./build_wasm.sh"
     },
     "private": false,
-    "dependencies": {},
+    "dependencies": {
+        "msgpackr": "^1.10.0",
+        "multicodec": "^3.2.1"
+    },
     "devDependencies": {
         "typescript": "5.2.2"
     }

--- a/avm/client/package.json
+++ b/avm/client/package.json
@@ -14,7 +14,7 @@
     },
     "private": false,
     "dependencies": {
-        "msgpackr": "^1.10.0",
+        "msgpack-lite": "^0.1.26",
         "multicodec": "^3.2.1"
     },
     "devDependencies": {

--- a/avm/client/src/avmHelpers.ts
+++ b/avm/client/src/avmHelpers.ts
@@ -90,13 +90,15 @@ export function deserializeAvmResult(result: any): InterpreterResult {
         let arguments_;
         let tetraplets;
         try {
-            arguments_ = argumentRepr.fromBinary(callRequest.arguments)
+            let argumentsBuf = new Uint8Array(callRequest.arguments);
+            arguments_ = argumentRepr.fromBinary(argumentsBuf);
         } catch (e) {
             throw "Couldn't parse arguments: " + e + '. Original data is: ' + callRequest.arguments;
         }
 
         try {
-            tetraplets = tetrapletRepr.fromBinary(callRequest.tetraplets)
+            let tetrapletBuf = new Uint8Array(callRequest.tetraplets);
+            tetraplets = tetrapletRepr.fromBinary(tetrapletBuf);
         } catch (e) {
             throw "Couldn't parse tetraplets: " + e + '. Original data is: ' + callRequest.tetraplets;
         }

--- a/avm/client/src/avmHelpers.ts
+++ b/avm/client/src/avmHelpers.ts
@@ -17,9 +17,6 @@
 import { CallResultsArray, InterpreterResult, CallRequest, RunParameters, JSONArray, JSONObject } from './types';
 import { JsonRepr } from './formats'
 
-const decoder = new TextDecoder();
-const encoder = new TextEncoder();
-
 // Have to match the air-interpreter-interface.
 const callRequestsRepr = new JsonRepr();
 // Have to match the air-interpreter-interface.

--- a/avm/client/src/avmHelpers.ts
+++ b/avm/client/src/avmHelpers.ts
@@ -26,7 +26,7 @@ const callRequestsRepr = new JsonRepr();
 const argumentRepr = new JsonRepr();
 // Have to match the air-interpreter-interface.
 const tetrapletRepr = new JsonRepr();
-
+// Have to match the air-interpreter-interface.
 const callResultsRepr = new JsonRepr();
 
 /**
@@ -74,13 +74,13 @@ export function serializeAvmArgs(
  * @returns structured InterpreterResult
  */
 export function deserializeAvmResult(result: any): InterpreterResult {
-    const callRequestsStr = decoder.decode(new Uint8Array(result.call_requests));
+    const callRequestsBuf = new Uint8Array(result.call_requests);
     let parsedCallRequests: object;
     try {
-        if (callRequestsStr.length === 0) {
+        if (callRequestsBuf.length === 0) {
             parsedCallRequests = {};
         } else {
-            parsedCallRequests = callRequestsRepr.fromBinary(new Uint8Array(result.call_requests));
+            parsedCallRequests = callRequestsRepr.fromBinary(callRequestsBuf);
         }
     } catch (e) {
         throw "Couldn't parse call requests: " + e + '. Original data is: ' + result.call_requests;

--- a/avm/client/src/formats.ts
+++ b/avm/client/src/formats.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import msgpackr from "msgpackr"
+import msgpack from "msgpack-lite"
 import multicodec from "multicodec"
 
 const decoder = new TextDecoder();
@@ -52,11 +52,11 @@ export class JsonRepr implements Representation, Multiformatable {
  */
 export class MsgPackRepr implements Representation, Multiformatable {
     fromBinary(data: Uint8Array): object {
-        return msgpackr.unpack(data)
+        return msgpack.decode(data)
     }
 
     toBinary(obj: object): Uint8Array {
-        return msgpackr.pack(obj)
+        return msgpack.encode(obj)
     }
 
     get_code(): multicodec.CodecCode {

--- a/avm/client/src/formats.ts
+++ b/avm/client/src/formats.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2023 Fluence Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as msgpackr from "msgpackr"
+import * as multicodec from "multicodec"
+
+const decoder = new TextDecoder();
+const encoder = new TextEncoder();
+
+interface Representation {
+    fromBinary(data: Uint8Array): object
+    toBinary(obj: object): Uint8Array
+}
+
+interface Multiformatable {
+    get_code(): multicodec.CodecCode
+}
+
+/**
+ * Simple JSON representation.
+ */
+export class JsonRepr implements Representation, Multiformatable {
+    fromBinary(data: Uint8Array): object {
+        let dataStr = decoder.decode(data)
+        return JSON.parse(dataStr);
+    }
+
+    toBinary(obj: object): Uint8Array {
+        return encoder.encode(JSON.stringify(obj))
+    }
+
+    get_code(): multicodec.CodecCode {
+        return multicodec.JSON
+    }
+}
+
+/**
+ * Simple MessagePack representation.
+ */
+export class MsgPackRepr implements Representation, Multiformatable {
+    fromBinary(data: Uint8Array): object {
+        return msgpackr.unpack(data)
+    }
+
+    toBinary(obj: object): Uint8Array {
+        return msgpackr.pack(obj)
+    }
+
+    get_code(): multicodec.CodecCode {
+        return multicodec.MESSAGEPACK
+    }
+}
+
+/**
+ * Multicodec representation that supports both JSON and MsgPack, but uses only specific representation for encoding.
+ */
+export class MulticodecRepr implements Representation {
+    serializer: Representation & Multiformatable
+
+    constructor(serializer: Representation & Multiformatable) {
+        this.serializer = serializer
+    }
+
+    fromBinary(data: Uint8Array): object {
+        let code = multicodec.getCodeFromData(data)
+        var repr = null;
+
+        if (code == multicodec.JSON) {
+            repr = new JsonRepr()
+        } else if (code == multicodec.MESSAGEPACK) {
+            repr = new MsgPackRepr()
+        }
+
+        if (repr === null) {
+            throw "Unknown code " + code + "in multiformat data " + data
+        } else {
+            return repr.fromBinary(multicodec.rmPrefix(data))
+        }
+    }
+
+    toBinary(obj: object): Uint8Array {
+        let bareData = this.serializer.toBinary(obj);
+        let varintCode = multicodec.getVarintFromCode(this.serializer.get_code());
+        return multicodec.addPrefix(varintCode, bareData)
+    }
+}

--- a/avm/client/src/formats.ts
+++ b/avm/client/src/formats.ts
@@ -76,7 +76,7 @@ export class MulticodecRepr implements Representation {
 
     fromBinary(data: Uint8Array): object {
         let code = multicodec.getCodeFromData(data)
-        var repr = null;
+        let repr: Representation | null = null;
 
         if (code == multicodec.JSON) {
             repr = new JsonRepr()

--- a/avm/client/src/formats.ts
+++ b/avm/client/src/formats.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as msgpackr from "msgpackr"
-import * as multicodec from "multicodec"
+import msgpackr from "msgpackr"
+import multicodec from "multicodec"
 
 const decoder = new TextDecoder();
 const encoder = new TextEncoder();

--- a/avm/client/src/formats.ts
+++ b/avm/client/src/formats.ts
@@ -86,9 +86,9 @@ export class MulticodecRepr implements Representation {
 
         if (repr === null) {
             throw "Unknown code " + code + "in multiformat data " + data
-        } else {
-            return repr.fromBinary(multicodec.rmPrefix(data))
         }
+        
+        return repr.fromBinary(multicodec.rmPrefix(data))
     }
 
     toBinary(obj: object): Uint8Array {

--- a/avm/client/src/index.ts
+++ b/avm/client/src/index.ts
@@ -16,3 +16,4 @@
 
 export * from './types';
 export * from './avmHelpers';
+export * from './formats';


### PR DESCRIPTION
For parsing and producing call requests and call results in AquaVM-compatible way with JSON and MessagePack.

Multicodec representation is also supported, both JSON and MessagePack can be used as input.