### PR TITLE
fix(performance): data printout removal some preparation step errors increases data consumption printout data out

### DIFF
--- a/air/src/preparation_step/errors.rs
+++ b/air/src/preparation_step/errors.rs
@@ -37,8 +37,7 @@ pub enum PreparationError {
     /// Errors occurred on executed trace deserialization.
     #[error(
         "an error occurred while data deserialization: {error:?}.\n\
-        AquaVM version is {} and it expect data of {} version,\
-        it's failed to get version of AquaVM produced this data.",
+        AquaVM version is {} and it expects {} version.",
         super::interpreter_version(),
         data_version()
     )]
@@ -47,8 +46,7 @@ pub enum PreparationError {
     /// Errors occurred on executed trace deserialization.
     #[error(
         "an error occurred while envelope deserialization: {error:?}.\n\
-        AquaVM version is {} and it expect data of {} version,\
-        it's failed to get version of AquaVM produced this data.",
+        AquaVM version is {} and it expects {} version.",
         super::interpreter_version(),
         data_version()
     )]

--- a/air/src/preparation_step/errors.rs
+++ b/air/src/preparation_step/errors.rs
@@ -21,7 +21,6 @@ use air_interpreter_data::CidStoreVerificationError;
 use air_interpreter_data::DataDeserializationError;
 use air_interpreter_data::Versions;
 use air_interpreter_interface::CallResultsDeserializeError;
-use air_interpreter_interface::SerializedCallResults;
 use strum::IntoEnumIterator;
 use strum_macros::EnumDiscriminants;
 use strum_macros::EnumIter;
@@ -39,57 +38,41 @@ pub enum PreparationError {
     #[error(
         "an error occurred while data deserialization: {error:?}.\n\
         AquaVM version is {} and it expect data of {} version,\
-        it's failed to get version of AquaVM produced this data.\n\
-        Data: {raw_data:?}",
+        it's failed to get version of AquaVM produced this data.",
         super::interpreter_version(),
         data_version()
     )]
-    DataDeFailed {
-        raw_data: Vec<u8>,
-        error: DataDeserializationError,
-    },
+    DataDeFailed { error: DataDeserializationError },
 
     /// Errors occurred on executed trace deserialization.
     #[error(
         "an error occurred while envelope deserialization: {error:?}.\n\
         AquaVM version is {} and it expect data of {} version,\
-        it's failed to get version of AquaVM produced this data.\n\
-        Envelope data: {env_raw_data:?}",
+        it's failed to get version of AquaVM produced this data.",
         super::interpreter_version(),
         data_version()
     )]
-    EnvelopeDeFailed {
-        env_raw_data: Vec<u8>,
-        error: DataDeserializationError,
-    },
+    EnvelopeDeFailed { error: DataDeserializationError },
 
     /// Errors occurred on executed trace deserialization
     /// when it was possible to recover versions.
     #[error(
         "an error occurred while data deserialization: {error:?}.\n\
         AquaVM's version is {} and it expects data of {} version.\n\
-        Supplied data version is {}, it's produced by AquaVM of {} version.\n\
-        Envelope data: {env_raw_data:?}",
+        Supplied data version is {}, it's produced by AquaVM of {} version.",
         super::interpreter_version(),
         data_version(),
         versions.data_version,
         versions.interpreter_version,
     )]
     EnvelopeDeFailedWithVersions {
-        env_raw_data: Vec<u8>,
         error: DataDeserializationError,
         versions: Versions,
     },
 
     /// Error occurred on call results deserialization.
-    #[error(
-        "error occurred while deserialize call results: {error:?}.\n\
-    Call results: {call_results:?}"
-    )]
-    CallResultsDeFailed {
-        call_results: SerializedCallResults,
-        error: CallResultsDeserializeError,
-    },
+    #[error("error occurred while deserialize call results: {error:?}.")]
+    CallResultsDeFailed { error: CallResultsDeserializeError },
 
     /// Error occurred when a version of interpreter produced supplied data is less then minimal.
     #[error("supplied data was produced by `{actual_version}` version of interpreter, but minimum `{required_version}` version is required")]
@@ -119,28 +102,20 @@ impl ToErrorCode for PreparationError {
 }
 
 impl PreparationError {
-    pub fn data_de_failed(raw_data: Vec<u8>, error: DataDeserializationError) -> Self {
-        Self::DataDeFailed { raw_data, error }
+    pub fn data_de_failed(error: DataDeserializationError) -> Self {
+        Self::DataDeFailed { error }
     }
 
-    pub fn envelope_de_failed(env_raw_data: Vec<u8>, error: DataDeserializationError) -> Self {
-        Self::EnvelopeDeFailed { env_raw_data, error }
+    pub fn envelope_de_failed(error: DataDeserializationError) -> Self {
+        Self::EnvelopeDeFailed { error }
     }
 
-    pub fn env_de_failed_with_versions(
-        env_raw_data: Vec<u8>,
-        error: DataDeserializationError,
-        versions: Versions,
-    ) -> Self {
-        Self::EnvelopeDeFailedWithVersions {
-            env_raw_data,
-            error,
-            versions,
-        }
+    pub fn env_de_failed_with_versions(error: DataDeserializationError, versions: Versions) -> Self {
+        Self::EnvelopeDeFailedWithVersions { error, versions }
     }
 
-    pub fn call_results_de_failed(call_results: SerializedCallResults, error: CallResultsDeserializeError) -> Self {
-        Self::CallResultsDeFailed { call_results, error }
+    pub fn call_results_de_failed(error: CallResultsDeserializeError) -> Self {
+        Self::CallResultsDeFailed { error }
     }
 
     pub fn unsupported_interpreter_version(actual_version: semver::Version, required_version: semver::Version) -> Self {

--- a/air/src/preparation_step/preparation.rs
+++ b/air/src/preparation_step/preparation.rs
@@ -122,18 +122,18 @@ pub(crate) fn try_to_envelope(raw_env_data: &[u8]) -> PreparationResult<Interpre
 }
 
 pub(crate) fn try_to_data(raw_data: &[u8]) -> PreparationResult<InterpreterData> {
-    InterpreterData::try_from_slice(raw_data).map_err(|de_error| to_data_de_error(raw_data.to_vec(), de_error))
+    InterpreterData::try_from_slice(raw_data).map_err(to_data_de_error)
 }
 
 fn to_envelope_de_error(env_raw_data: Vec<u8>, de_error: DataDeserializationError) -> PreparationError {
     match InterpreterDataEnvelope::try_get_versions(&env_raw_data) {
-        Ok(versions) => PreparationError::env_de_failed_with_versions(env_raw_data, de_error, versions),
-        Err(_) => PreparationError::envelope_de_failed(env_raw_data, de_error),
+        Ok(versions) => PreparationError::env_de_failed_with_versions(de_error, versions),
+        Err(_) => PreparationError::envelope_de_failed(de_error),
     }
 }
 
-fn to_data_de_error(env_raw_data: Vec<u8>, de_error: DataDeserializationError) -> PreparationError {
-    PreparationError::data_de_failed(env_raw_data, de_error)
+fn to_data_de_error(de_error: DataDeserializationError) -> PreparationError {
+    PreparationError::data_de_failed(de_error)
 }
 
 #[tracing::instrument(skip_all)]
@@ -147,7 +147,7 @@ fn make_exec_ctx(
     let call_results = measure!(
         CallResultsRepr
             .deserialize(call_results)
-            .map_err(|e| PreparationError::call_results_de_failed(call_results.clone(), e))?,
+            .map_err(PreparationError::call_results_de_failed)?,
         tracing::Level::INFO,
         "CallResultsRepr.deserialize",
     );

--- a/air/tests/test_module/negative_tests/preparation_step.rs
+++ b/air/tests/test_module/negative_tests/preparation_step.rs
@@ -46,7 +46,6 @@ fn invalid_data_without_versions() {
 
     let expected_serde_error = InterpreterDataEnvelope::try_from_slice(&invalid_data).unwrap_err();
     let expected_error = PreparationError::EnvelopeDeFailed {
-        env_raw_data: invalid_data,
         error: expected_serde_error,
     };
     assert!(check_error(&result, expected_error));
@@ -79,7 +78,6 @@ fn invalid_data_with_versions() {
 
     let expected_serde_error = InterpreterDataEnvelope::try_from_slice(&invalid_data).unwrap_err();
     let expected_error = PreparationError::EnvelopeDeFailedWithVersions {
-        env_raw_data: invalid_data,
         error: expected_serde_error,
         versions,
     };
@@ -114,7 +112,6 @@ fn invalid_callresults() {
     let expected_serde_error = CallResultsRepr.deserialize(&wrong_call_results).unwrap_err();
     let expected_error = PreparationError::CallResultsDeFailed {
         error: expected_serde_error,
-        call_results: wrong_call_results.into(),
     };
 
     assert!(check_error(&result, expected_error));


### PR DESCRIPTION
Some preparation step errors increases data consumption printout data out. This patch removes data from preparation step errors to save some RAM bytes.