### PR TITLE
feat(preparation):  AquaVM preparation step now checks input arguments sizes [fixes VM-425]

### DIFF
--- a/air/src/lib.rs
+++ b/air/src/lib.rs
@@ -62,6 +62,10 @@ pub use polyplets::SecurityTetraplet;
 pub use preparation_step::interpreter_version;
 pub use preparation_step::min_supported_version;
 pub use preparation_step::PreparationError;
+pub use preparation_step::MAX_AIR_SIZE;
+pub use preparation_step::MAX_CALL_RESULTS_SIZE;
+pub use preparation_step::MAX_PARTICLE_SIZE;
+
 pub use utils::ToErrorCode;
 
 pub use crate::human_readable_data::to_human_readable_data;

--- a/air/src/preparation_step/errors.rs
+++ b/air/src/preparation_step/errors.rs
@@ -109,6 +109,18 @@ pub enum PreparationError {
     /// Failed to check peers' signatures.
     #[error(transparent)]
     DataSignatureCheckError(#[from] DataVerifierError),
+
+    /// AIR script size is bigger than the allowed limit.
+    #[error("air size: {0} bytes is bigger than a limit allowed: {1} bytes")]
+    AIRSizeLimitReached(usize, usize),
+
+    /// Current_data particle size is bigger than the allowed limit.
+    #[error("Current_data particle size: {0} bytes is bigger than a limit allowed: {1} bytes")]
+    ParticleSizeLimitReached(usize, usize),
+
+    /// CallResults cummulative size is bigger than the allowed limit.
+    #[error("Call results cummulative size: {0} bytes is bigger than a limit allowed: {1} bytes")]
+    CallResultsSizeLimitReached(usize, usize),
 }
 
 impl ToErrorCode for PreparationError {
@@ -148,5 +160,17 @@ impl PreparationError {
             actual_version,
             required_version,
         }
+    }
+
+    pub fn air_size_limit(actual_size: usize, limit: usize) -> Self {
+        Self::AIRSizeLimitReached(actual_size, limit)
+    }
+
+    pub fn particle_size_limit(actual_size: usize, limit: usize) -> Self {
+        Self::ParticleSizeLimitReached(actual_size, limit)
+    }
+
+    pub fn call_results_size_limit(actual_size: usize, limit: usize) -> Self {
+        Self::CallResultsSizeLimitReached(actual_size, limit)
     }
 }

--- a/air/src/preparation_step/mod.rs
+++ b/air/src/preparation_step/mod.rs
@@ -17,13 +17,18 @@
 mod errors;
 mod interpreter_versions;
 mod preparation;
+mod sizes_limits_check;
 
 pub use errors::PreparationError;
 pub use interpreter_versions::interpreter_version;
 pub use interpreter_versions::min_supported_version;
+pub use sizes_limits_check::MAX_AIR_SIZE;
+pub use sizes_limits_check::MAX_CALL_RESULTS_SIZE;
+pub use sizes_limits_check::MAX_PARTICLE_SIZE;
 
 pub(crate) use preparation::check_version_compatibility;
 pub(crate) use preparation::parse_data;
 pub(crate) use preparation::prepare;
 pub(crate) use preparation::ParsedDataPair;
 pub(crate) use preparation::PreparationDescriptor;
+pub(crate) use sizes_limits_check::check_against_size_limits;

--- a/air/src/preparation_step/preparation.rs
+++ b/air/src/preparation_step/preparation.rs
@@ -34,7 +34,7 @@ use air_parser::ast::Instruction;
 use air_utils::measure;
 use fluence_keypair::KeyFormat;
 
-type PreparationResult<T> = Result<T, PreparationError>;
+pub(crate) type PreparationResult<T> = Result<T, PreparationError>;
 
 /// Represents result of the preparation_step step.
 pub(crate) struct PreparationDescriptor<'ctx, 'i> {

--- a/air/src/preparation_step/sizes_limits_check.rs
+++ b/air/src/preparation_step/sizes_limits_check.rs
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 Fluence Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use air_interpreter_interface::SerializedCallResults;
+
+use super::preparation::PreparationResult;
+use crate::PreparationError;
+
+const MB: usize = 1024 * 1024;
+pub const MAX_AIR_SIZE: usize = 16 * MB;
+pub const MAX_PARTICLE_SIZE: usize = 64 * MB;
+pub const MAX_CALL_RESULTS_SIZE: usize = 32 * MB;
+
+pub(crate) fn check_against_size_limits(
+    air: &str,
+    raw_current_data: &[u8],
+    call_results: &SerializedCallResults,
+) -> PreparationResult<()> {
+    if air.len() > MAX_AIR_SIZE {
+        return Err(PreparationError::air_size_limit(air.len(), MAX_AIR_SIZE));
+    }
+
+    if raw_current_data.len() > MAX_PARTICLE_SIZE {
+        return Err(PreparationError::particle_size_limit(
+            raw_current_data.len(),
+            MAX_PARTICLE_SIZE,
+        ));
+    }
+
+    if call_results.len() > MAX_CALL_RESULTS_SIZE {
+        return Err(PreparationError::call_results_size_limit(
+            call_results.len(),
+            MAX_CALL_RESULTS_SIZE,
+        ));
+    }
+
+    Ok(())
+}

--- a/air/src/runner.rs
+++ b/air/src/runner.rs
@@ -61,6 +61,13 @@ fn execute_air_impl(
     params: RunParameters,
     call_results: SerializedCallResults,
 ) -> Result<InterpreterOutcome, InterpreterOutcome> {
+    use crate::preparation_step::check_against_size_limits;
+
+    farewell_if_fail!(
+        check_against_size_limits(&air, &raw_current_data, &call_results),
+        raw_prev_data
+    );
+
     let ParsedDataPair {
         prev_data,
         current_data,


### PR DESCRIPTION
This adds some hardening checks that forces AquaVM to quit if its arguments are too big.