### PR TITLE
feat(avm-server): add a convenience method to hide implementation from nox

### DIFF
--- a/crates/air-lib/interpreter-interface/src/interpreter_outcome.rs
+++ b/crates/air-lib/interpreter-interface/src/interpreter_outcome.rs
@@ -117,14 +117,15 @@ impl InterpreterOutcome {
             ));
         }
 
-        let air_size_limit_exceeded =
-            try_as_boolean(record_values.pop().unwrap(), "air_size_limit_exceeded")?;
-        let particle_size_limit_exceeded =
-            try_as_boolean(record_values.pop().unwrap(), "particle_size_limit_exceeded")?;
         let call_result_size_limit_exceeded = try_as_boolean(
             record_values.pop().unwrap(),
             "call_result_size_limit_exceeded",
         )?;
+        let particle_size_limit_exceeded =
+            try_as_boolean(record_values.pop().unwrap(), "particle_size_limit_exceeded")?;
+        let air_size_limit_exceeded =
+            try_as_boolean(record_values.pop().unwrap(), "air_size_limit_exceeded")?;
+
         let call_requests = try_as_byte_vec(record_values.pop().unwrap(), "call_requests")?;
         let next_peer_pks = try_as_string_vec(record_values.pop().unwrap(), "next_peer_pks")?;
         let data = try_as_byte_vec(record_values.pop().unwrap(), "data")?;

--- a/crates/air-lib/interpreter-interface/src/interpreter_outcome.rs
+++ b/crates/air-lib/interpreter-interface/src/interpreter_outcome.rs
@@ -74,6 +74,12 @@ impl SoftLimitsTriggering {
             call_result_size_limit_exceeded,
         }
     }
+
+    pub fn is_triggered(&self) -> bool {
+        self.air_size_limit_exceeded
+            || self.particle_size_limit_exceeded
+            || self.call_result_size_limit_exceeded
+    }
 }
 
 impl InterpreterOutcome {

--- a/crates/air-lib/interpreter-interface/src/interpreter_outcome.rs
+++ b/crates/air-lib/interpreter-interface/src/interpreter_outcome.rs
@@ -75,7 +75,7 @@ impl SoftLimitsTriggering {
         }
     }
 
-    pub fn is_triggered(&self) -> bool {
+    pub fn are_limits_exceeded(&self) -> bool {
         self.air_size_limit_exceeded
             || self.particle_size_limit_exceeded
             || self.call_result_size_limit_exceeded


### PR DESCRIPTION
This convenience method hides internal repr from nox