### PR TITLE
chore: Rust channel update dedicated to ENIAC Day

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,9 +81,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a824f2aa7e75a0c98c5a504fceb80649e9c35265d44525b5f94de4771a395cd"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
  "getrandom 0.2.11",
  "once_cell",
@@ -2759,7 +2759,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
- "ahash 0.7.7",
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -2768,7 +2768,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash 0.7.7",
+ "ahash 0.7.8",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "d713b3834d76b85304d4d525563c1276e2e30dc97cc67bfb4585a4a29fc2c89f"
 dependencies = [
  "cfg-if 1.0.0",
  "once_cell",
@@ -2777,7 +2777,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.6",
+ "ahash 0.8.9",
 ]
 
 [[package]]
@@ -2786,7 +2786,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
- "ahash 0.8.6",
+ "ahash 0.8.9",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1887,9 +1887,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.1"
+version = "4.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
+checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
@@ -2193,7 +2193,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f628eaec48bfd21b865dc2950cfa014450c01d2fa2b69a86c2fd5844ec523c0"
 dependencies = [
- "curve25519-dalek 4.1.1",
+ "curve25519-dalek 4.1.2",
  "ed25519 2.2.3",
  "rand_core 0.6.4",
  "serde",

--- a/air/src/execution_step/instructions/call/resolved_call.rs
+++ b/air/src/execution_step/instructions/call/resolved_call.rs
@@ -58,7 +58,7 @@ struct ResolvedArguments {
 #[derive(Debug)]
 enum CheckArgsResult<T> {
     Ok(T),
-    Joinable(ExecutionError),
+    Joinable(#[allow(dead_code)] ExecutionError),
 }
 
 impl<T> CheckArgsResult<T> {

--- a/air/tests/test_module/features/tetraplets/security_tetraplets/auth_module/Cargo.lock
+++ b/air/tests/test_module/features/tetraplets/security_tetraplets/auth_module/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "ahash"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a824f2aa7e75a0c98c5a504fceb80649e9c35265d44525b5f94de4771a395cd"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
  "getrandom",
  "once_cell",
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "air-execution-info-collector"
-version = "0.7.12"
+version = "0.7.14"
 dependencies = [
  "aquavm-air-parser",
 ]
@@ -33,9 +33,9 @@ dependencies = [
 name = "air-interpreter-cid"
 version = "0.9.0"
 dependencies = [
- "blake3",
  "cid",
  "digest 0.10.7",
+ "fluence-blake3",
  "multihash 0.19.1",
  "multihash-codetable",
  "rkyv",
@@ -47,11 +47,12 @@ dependencies = [
 
 [[package]]
 name = "air-interpreter-data"
-version = "0.17.0"
+version = "0.17.2"
 dependencies = [
  "air-interpreter-cid",
  "air-interpreter-sede",
  "air-interpreter-signatures",
+ "air-interpreter-value",
  "air-utils",
  "aquavm-air-parser",
  "fluence-keypair",
@@ -71,9 +72,10 @@ dependencies = [
 
 [[package]]
 name = "air-interpreter-interface"
-version = "0.17.1"
+version = "0.19.0"
 dependencies = [
  "air-interpreter-sede",
+ "air-interpreter-value",
  "marine-call-parameters",
  "serde",
  "serde_bytes",
@@ -107,6 +109,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "air-interpreter-value"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "air-lambda-ast"
 version = "0.1.0"
 dependencies = [
@@ -134,7 +144,7 @@ version = "0.1.0"
 
 [[package]]
 name = "air-trace-handler"
-version = "0.5.10"
+version = "0.5.12"
 dependencies = [
  "air-interpreter-cid",
  "air-interpreter-data",
@@ -151,7 +161,7 @@ dependencies = [
 
 [[package]]
 name = "air-utils"
-version = "0.2.0"
+version = "0.3.0"
 
 [[package]]
 name = "android-tzdata"
@@ -170,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "aquavm-air"
-version = "0.58.0"
+version = "0.61.0"
 dependencies = [
  "air-execution-info-collector",
  "air-interpreter-cid",
@@ -178,6 +188,7 @@ dependencies = [
  "air-interpreter-interface",
  "air-interpreter-sede",
  "air-interpreter-signatures",
+ "air-interpreter-value",
  "air-lambda-ast",
  "air-lambda-parser",
  "air-log-targets",
@@ -204,8 +215,9 @@ dependencies = [
 
 [[package]]
 name = "aquavm-air-parser"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
+ "air-interpreter-value",
  "air-lambda-ast",
  "air-lambda-parser",
  "codespan",
@@ -371,7 +383,6 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq 0.3.0",
- "digest 0.10.7",
 ]
 
 [[package]]
@@ -550,7 +561,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f76990911f2267d837d9d0ad060aa63aaad170af40904b29461734c339030d4d"
 dependencies = [
  "quote",
- "syn 2.0.40",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -623,9 +634,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.0.0"
+version = "4.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f711ade317dd348950a9910f81c5947e3d8907ebd2b83f76203ff1807e6a2bc2"
+checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -646,7 +657,7 @@ checksum = "83fdaf97f4804dcebfa5862639bc9ce4121e82140bec2a987ac5140294865b5b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -811,15 +822,29 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.1.20"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77"
+checksum = "1676f435fc1dadde4d03e43f5d62b259e1ce5f40bd4ffb21db2b42ebe59c1382"
 
 [[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "fluence-blake3"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a3c704928408e9b8f7c9d5b24a4f205dd5cb89d378aa31a01140df810093bf5"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq 0.3.0",
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "fluence-keypair"
@@ -1156,9 +1181,9 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "marine-call-parameters"
-version = "0.10.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef9a7c6ed5fa9052474c1cd76d3b3e67dbc4c455c76263c2c043214e12cce6bd"
+checksum = "05495180730abae04abe209386ce367309a82110edb65fcdb1f3080f819bc1a0"
 dependencies = [
  "marine-macro",
  "marine-rs-sdk-main",
@@ -1168,9 +1193,9 @@ dependencies = [
 
 [[package]]
 name = "marine-macro"
-version = "0.10.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdaa50f8239afa104ef8a99d4219288f68169e29c913485bbd094a35fe79113"
+checksum = "f502185316f584a9373cceb6ff24a11d260dfd39505c817056bc127cd1a96a08"
 dependencies = [
  "marine-macro-impl",
  "marine-rs-sdk-main",
@@ -1178,9 +1203,9 @@ dependencies = [
 
 [[package]]
 name = "marine-macro-impl"
-version = "0.10.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460ef42c1bf6dbb88976a00514f8e1b97a7ccb60e3e6009cbb563b0d163166c7"
+checksum = "e50fbc0e70ee4cde7802f0748acfb197d7770c7feffb980ce8c29bddd007519e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1191,9 +1216,9 @@ dependencies = [
 
 [[package]]
 name = "marine-rs-sdk"
-version = "0.10.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034cab8adf708e87db08f093e0c7b8ea49359cc875ed2a778c1bf245b5d9d9f8"
+checksum = "f93d2bd852fea1fea8097c195044430347eda98fd6a3752119b549192d5ac4ba"
 dependencies = [
  "marine-call-parameters",
  "marine-macro",
@@ -1204,9 +1229,9 @@ dependencies = [
 
 [[package]]
 name = "marine-rs-sdk-main"
-version = "0.10.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031eeea016dab58c1ccb0c65b798cb5e47d214b05115c8c06198717d18275756"
+checksum = "0b79c165fc21438b069babeec5ae36ba0eade5e08fb1d92dabbe6b41014ce841"
 dependencies = [
  "log",
  "serde",
@@ -1214,9 +1239,9 @@ dependencies = [
 
 [[package]]
 name = "marine-timestamp-macro"
-version = "0.10.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f812a03cb13b79ab75e38053a77ecc4b4738a1b485b650d971dec3dbbcb2561"
+checksum = "d03f267ac0a29f543ef12a1a519ff8d98e74ac66e1c580f2930d41ce2c50507d"
 dependencies = [
  "chrono",
  "quote",
@@ -1433,7 +1458,7 @@ checksum = "e3d7ddaed09e0eb771a79ab0fd64609ba0afb0a8366421957936ad14cbd13630"
 
 [[package]]
 name = "polyplets"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "marine-call-parameters",
  "serde",
@@ -1496,9 +1521,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.70"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
@@ -1534,9 +1559,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -1782,9 +1807,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.193"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
@@ -1800,13 +1825,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.193"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -1962,9 +1987,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.40"
+version = "2.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13fa70a4ee923979ffb522cacce59d34421ebdea5625e1073c4326ef9d2dd42e"
+checksum = "74f1bdc9872430ce9b75da68329d1c1746faf50ffac5f19e02b71e37ff881ffb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2026,7 +2051,7 @@ checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -2098,7 +2123,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -2197,7 +2222,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.50",
  "wasm-bindgen-shared",
 ]
 
@@ -2219,7 +2244,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.50",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2447,5 +2472,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.50",
 ]

--- a/air/tests/test_module/features/tetraplets/security_tetraplets/log_storage/Cargo.lock
+++ b/air/tests/test_module/features/tetraplets/security_tetraplets/log_storage/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "ahash"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a824f2aa7e75a0c98c5a504fceb80649e9c35265d44525b5f94de4771a395cd"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
  "getrandom",
  "once_cell",
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "air-execution-info-collector"
-version = "0.7.12"
+version = "0.7.14"
 dependencies = [
  "aquavm-air-parser",
 ]
@@ -33,9 +33,9 @@ dependencies = [
 name = "air-interpreter-cid"
 version = "0.9.0"
 dependencies = [
- "blake3",
  "cid",
  "digest 0.10.7",
+ "fluence-blake3",
  "multihash 0.19.1",
  "multihash-codetable",
  "rkyv",
@@ -47,11 +47,12 @@ dependencies = [
 
 [[package]]
 name = "air-interpreter-data"
-version = "0.17.0"
+version = "0.17.2"
 dependencies = [
  "air-interpreter-cid",
  "air-interpreter-sede",
  "air-interpreter-signatures",
+ "air-interpreter-value",
  "air-utils",
  "aquavm-air-parser",
  "fluence-keypair",
@@ -71,9 +72,10 @@ dependencies = [
 
 [[package]]
 name = "air-interpreter-interface"
-version = "0.17.1"
+version = "0.19.0"
 dependencies = [
  "air-interpreter-sede",
+ "air-interpreter-value",
  "marine-call-parameters",
  "serde",
  "serde_bytes",
@@ -107,6 +109,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "air-interpreter-value"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "air-lambda-ast"
 version = "0.1.0"
 dependencies = [
@@ -134,7 +144,7 @@ version = "0.1.0"
 
 [[package]]
 name = "air-trace-handler"
-version = "0.5.10"
+version = "0.5.12"
 dependencies = [
  "air-interpreter-cid",
  "air-interpreter-data",
@@ -151,7 +161,7 @@ dependencies = [
 
 [[package]]
 name = "air-utils"
-version = "0.2.0"
+version = "0.3.0"
 
 [[package]]
 name = "android-tzdata"
@@ -170,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "aquavm-air"
-version = "0.58.0"
+version = "0.61.0"
 dependencies = [
  "air-execution-info-collector",
  "air-interpreter-cid",
@@ -178,6 +188,7 @@ dependencies = [
  "air-interpreter-interface",
  "air-interpreter-sede",
  "air-interpreter-signatures",
+ "air-interpreter-value",
  "air-lambda-ast",
  "air-lambda-parser",
  "air-log-targets",
@@ -204,8 +215,9 @@ dependencies = [
 
 [[package]]
 name = "aquavm-air-parser"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
+ "air-interpreter-value",
  "air-lambda-ast",
  "air-lambda-parser",
  "codespan",
@@ -363,7 +375,6 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq 0.3.0",
- "digest 0.10.7",
 ]
 
 [[package]]
@@ -542,7 +553,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f76990911f2267d837d9d0ad060aa63aaad170af40904b29461734c339030d4d"
 dependencies = [
  "quote",
- "syn 2.0.40",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -615,9 +626,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.0.0"
+version = "4.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f711ade317dd348950a9910f81c5947e3d8907ebd2b83f76203ff1807e6a2bc2"
+checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -638,7 +649,7 @@ checksum = "83fdaf97f4804dcebfa5862639bc9ce4121e82140bec2a987ac5140294865b5b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -803,15 +814,29 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.1.20"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77"
+checksum = "1676f435fc1dadde4d03e43f5d62b259e1ce5f40bd4ffb21db2b42ebe59c1382"
 
 [[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "fluence-blake3"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a3c704928408e9b8f7c9d5b24a4f205dd5cb89d378aa31a01140df810093bf5"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq 0.3.0",
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "fluence-keypair"
@@ -1156,9 +1181,9 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "marine-call-parameters"
-version = "0.10.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef9a7c6ed5fa9052474c1cd76d3b3e67dbc4c455c76263c2c043214e12cce6bd"
+checksum = "05495180730abae04abe209386ce367309a82110edb65fcdb1f3080f819bc1a0"
 dependencies = [
  "marine-macro",
  "marine-rs-sdk-main",
@@ -1168,9 +1193,9 @@ dependencies = [
 
 [[package]]
 name = "marine-macro"
-version = "0.10.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdaa50f8239afa104ef8a99d4219288f68169e29c913485bbd094a35fe79113"
+checksum = "f502185316f584a9373cceb6ff24a11d260dfd39505c817056bc127cd1a96a08"
 dependencies = [
  "marine-macro-impl",
  "marine-rs-sdk-main",
@@ -1178,9 +1203,9 @@ dependencies = [
 
 [[package]]
 name = "marine-macro-impl"
-version = "0.10.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460ef42c1bf6dbb88976a00514f8e1b97a7ccb60e3e6009cbb563b0d163166c7"
+checksum = "e50fbc0e70ee4cde7802f0748acfb197d7770c7feffb980ce8c29bddd007519e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1191,9 +1216,9 @@ dependencies = [
 
 [[package]]
 name = "marine-rs-sdk"
-version = "0.10.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034cab8adf708e87db08f093e0c7b8ea49359cc875ed2a778c1bf245b5d9d9f8"
+checksum = "f93d2bd852fea1fea8097c195044430347eda98fd6a3752119b549192d5ac4ba"
 dependencies = [
  "marine-call-parameters",
  "marine-macro",
@@ -1204,9 +1229,9 @@ dependencies = [
 
 [[package]]
 name = "marine-rs-sdk-main"
-version = "0.10.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031eeea016dab58c1ccb0c65b798cb5e47d214b05115c8c06198717d18275756"
+checksum = "0b79c165fc21438b069babeec5ae36ba0eade5e08fb1d92dabbe6b41014ce841"
 dependencies = [
  "log",
  "serde",
@@ -1214,9 +1239,9 @@ dependencies = [
 
 [[package]]
 name = "marine-timestamp-macro"
-version = "0.10.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f812a03cb13b79ab75e38053a77ecc4b4738a1b485b650d971dec3dbbcb2561"
+checksum = "d03f267ac0a29f543ef12a1a519ff8d98e74ac66e1c580f2930d41ce2c50507d"
 dependencies = [
  "chrono",
  "quote",
@@ -1433,7 +1458,7 @@ checksum = "e3d7ddaed09e0eb771a79ab0fd64609ba0afb0a8366421957936ad14cbd13630"
 
 [[package]]
 name = "polyplets"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "marine-call-parameters",
  "serde",
@@ -1496,9 +1521,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.70"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
@@ -1534,9 +1559,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -1782,9 +1807,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.193"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
@@ -1800,13 +1825,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.193"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -1962,9 +1987,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.40"
+version = "2.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13fa70a4ee923979ffb522cacce59d34421ebdea5625e1073c4326ef9d2dd42e"
+checksum = "74f1bdc9872430ce9b75da68329d1c1746faf50ffac5f19e02b71e37ff881ffb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2026,7 +2051,7 @@ checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -2098,7 +2123,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -2197,7 +2222,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.50",
  "wasm-bindgen-shared",
 ]
 
@@ -2219,7 +2244,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.50",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2447,5 +2472,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.50",
 ]

--- a/crates/air-lib/interpreter-sede/src/format.rs
+++ b/crates/air-lib/interpreter-sede/src/format.rs
@@ -35,9 +35,11 @@ pub trait Format<Value> {
 }
 
 pub trait BorrowFormat<'data, Value: 'data>: Format<Value> {
+    #[allow(dead_code)]
     fn borrow_from_slice(&self, slice: &'data [u8]) -> Result<Value, Self::DeserializationError>;
 }
 
+#[allow(dead_code)]
 pub trait ArchivedFormat<Value>: Format<Value> {
     type Archived;
     type ValidationError;

--- a/crates/air-lib/interpreter-value/src/value/mod.rs
+++ b/crates/air-lib/interpreter-value/src/value/mod.rs
@@ -37,7 +37,6 @@ use std::rc::Rc;
 pub use self::index::Index;
 use crate::JsonString;
 pub use crate::Map;
-pub use serde::ser::Serializer;
 pub use serde_json::Number;
 
 /// Represents any valid JSON value with a cheap to clone Rc-based representation.

--- a/junk/gen-bench-data/Cargo.lock
+++ b/junk/gen-bench-data/Cargo.lock
@@ -30,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.7"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
+checksum = "d713b3834d76b85304d4d525563c1276e2e30dc97cc67bfb4585a4a29fc2c89f"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1707,7 +1707,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.7",
+ "ahash 0.8.9",
 ]
 
 [[package]]
@@ -1716,7 +1716,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
- "ahash 0.8.7",
+ "ahash 0.8.9",
 ]
 
 [[package]]

--- a/junk/gen-bench-data/Cargo.lock
+++ b/junk/gen-bench-data/Cargo.lock
@@ -51,7 +51,7 @@ dependencies = [
 
 [[package]]
 name = "air-execution-info-collector"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "aquavm-air-parser",
 ]
@@ -74,7 +74,7 @@ dependencies = [
 
 [[package]]
 name = "air-interpreter-data"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "air-interpreter-cid",
  "air-interpreter-sede",
@@ -99,7 +99,7 @@ dependencies = [
 
 [[package]]
 name = "air-interpreter-interface"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "air-interpreter-sede",
  "air-interpreter-value",
@@ -174,7 +174,7 @@ version = "0.1.0"
 
 [[package]]
 name = "air-test-utils"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "air-interpreter-cid",
  "air-interpreter-data",
@@ -199,7 +199,7 @@ dependencies = [
 
 [[package]]
 name = "air-testing-framework"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "air-interpreter-signatures",
  "air-test-utils",
@@ -215,7 +215,7 @@ dependencies = [
 
 [[package]]
 name = "air-trace-handler"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "air-interpreter-cid",
  "air-interpreter-data",
@@ -311,7 +311,7 @@ checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 
 [[package]]
 name = "aquavm-air"
-version = "0.60.0"
+version = "0.61.0"
 dependencies = [
  "air-execution-info-collector",
  "air-interpreter-cid",
@@ -346,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "aquavm-air-parser"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "air-interpreter-value",
  "air-lambda-ast",
@@ -435,7 +435,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "avm-data-store"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "avm-interface",
  "serde",
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "avm-interface"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "air-interpreter-interface",
  "air-interpreter-sede",
@@ -460,7 +460,7 @@ dependencies = [
 
 [[package]]
 name = "avm-server"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "air-interpreter-interface",
  "air-interpreter-sede",
@@ -1146,9 +1146,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.1"
+version = "4.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
+checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2954,7 +2954,7 @@ checksum = "626dec3cac7cc0e1577a2ec3fc496277ec2baa084bebad95bb6fdbfae235f84c"
 
 [[package]]
 name = "polyplets"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "marine-call-parameters 0.14.0",
  "serde",

--- a/junk/gen-bench-data/Cargo.lock
+++ b/junk/gen-bench-data/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a824f2aa7e75a0c98c5a504fceb80649e9c35265d44525b5f94de4771a395cd"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
  "getrandom",
  "once_cell",
@@ -1698,7 +1698,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash 0.7.7",
+ "ahash 0.7.8",
 ]
 
 [[package]]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # AquaVM can be built with "stable", "nightly" required only to build Marine tests
-channel = "nightly-2023-09-13"
+channel = "nightly-2024-02-15"
 components = [ "rustfmt", "clippy", "rust-src", "llvm-tools-preview" ]
 targets = [ "x86_64-unknown-linux-gnu", "x86_64-apple-darwin", "wasm32-wasi", "wasm32-unknown-unknown" ]
 profile = "minimal"


### PR DESCRIPTION
It requires updating minor version of curve25519-dalek crate in the Cargo.lock.  If you need to use older version of nightly rustc, use curve25519-dalek-4.1.1.  It affects Cargo.lock only.