### PR TITLE
fix(avm-client)!: this fixes the last argument type for WASM module 'invoke' function

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -122,7 +122,7 @@ jobs:
       - avm
       - nox-snapshot
 
-    uses: fluencelabs/js-client/.github/workflows/tests.yml@master
+    uses: fluencelabs/js-client/.github/workflows/tests.yml@main
     with:
       avm-version: "${{ needs.avm.outputs.version }}"
       nox-image: "${{ needs.nox-snapshot.outputs.nox-image }}"
@@ -131,7 +131,7 @@ jobs:
     needs:
       - avm
 
-    uses: fluencelabs/js-client/.github/workflows/snapshot.yml@master
+    uses: fluencelabs/js-client/.github/workflows/snapshot.yml@main
     with:
       avm-version: "${{ needs.avm.outputs.version }}"
 

--- a/avm/client/src/avmHelpers.ts
+++ b/avm/client/src/avmHelpers.ts
@@ -27,6 +27,7 @@ const tetrapletRepr = new MsgPackRepr();
 const callResultsRepr = new MulticodecRepr(new MsgPackRepr());
 //
 const defaultAquaVMRuntimeMemoryLimit = Number("4294967296");
+const aquaVMRuntimeHardLimitsAreDisabled = Boolean(false);
 
 /**
  * Encodes arguments into JSON array suitable for marine-js
@@ -66,7 +67,7 @@ export function serializeAvmArgs(
         air_size_limit: defaultAquaVMRuntimeMemoryLimit,
         particle_size_limit: defaultAquaVMRuntimeMemoryLimit,
         call_result_size_limit: defaultAquaVMRuntimeMemoryLimit,
-        hard_limit_enabled: defaultAquaVMRuntimeMemoryLimit,
+        hard_limit_enabled: aquaVMRuntimeHardLimitsAreDisabled,
     };
 
     return [air, Array.from(prevData), Array.from(data), runParamsSnakeCase, Array.from(encodedCallResults)];

--- a/avm/client/src/avmHelpers.ts
+++ b/avm/client/src/avmHelpers.ts
@@ -26,8 +26,7 @@ const tetrapletRepr = new MsgPackRepr();
 // Have to match the air-interpreter-interface.
 const callResultsRepr = new MulticodecRepr(new MsgPackRepr());
 //
-const defaultAquaVMRuntimeMemoryLimit = Number("4294967296");
-const aquaVMRuntimeHardLimitsAreDisabled = Boolean(false);
+const defaultAquaVMRuntimeMemoryLimit = 4294967296;
 
 /**
  * Encodes arguments into JSON array suitable for marine-js
@@ -67,7 +66,7 @@ export function serializeAvmArgs(
         air_size_limit: defaultAquaVMRuntimeMemoryLimit,
         particle_size_limit: defaultAquaVMRuntimeMemoryLimit,
         call_result_size_limit: defaultAquaVMRuntimeMemoryLimit,
-        hard_limit_enabled: aquaVMRuntimeHardLimitsAreDisabled,
+        hard_limit_enabled: false,
     };
 
     return [air, Array.from(prevData), Array.from(data), runParamsSnakeCase, Array.from(encodedCallResults)];


### PR DESCRIPTION
This fixes the 'invoke' call incorrect argument type issue for js-client. 